### PR TITLE
feat: return notDetermined permission status on Android

### DIFF
--- a/packages/device_calendar_plus/lib/src/calendar_permission_status.dart
+++ b/packages/device_calendar_plus/lib/src/calendar_permission_status.dart
@@ -3,7 +3,13 @@ enum CalendarPermissionStatus {
   /// Full read and write access to calendars.
   granted,
 
-  /// Permission has been denied by the user.
+  /// Permission has been permanently denied by the user.
+  ///
+  /// On Android, this means the user selected "Don't ask again" and the
+  /// permission dialog can no longer be shown. Use [DeviceCalendar.openAppSettings]
+  /// to direct the user to the system settings page.
+  ///
+  /// On iOS, this maps to `EKAuthorizationStatus.denied`.
   denied,
 
   /// Write-only access to calendars (iOS 17+ only).
@@ -23,10 +29,17 @@ enum CalendarPermissionStatus {
   /// This status is never returned on Android.
   restricted,
 
-  /// Permission has not been requested yet (iOS only).
+  /// Permission has not been granted yet, but can still be requested.
   ///
-  /// This is the initial state before the app has requested calendar permissions.
+  /// Calling [DeviceCalendar.requestPermissions] while in this state will show
+  /// the system permission dialog.
   ///
-  /// This status is never returned on Android.
+  /// On iOS, this maps directly to the `EKAuthorizationStatus.notDetermined` state.
+  ///
+  /// On Android, this covers both "never asked" and "denied once but can still
+  /// ask again". Android's `checkSelfPermission()` returns `PERMISSION_DENIED`
+  /// in both cases, so a `SharedPreferences` flag combined with
+  /// `shouldShowRequestPermissionRationale()` is used to detect when the
+  /// permission has been permanently denied (which returns [denied] instead).
   notDetermined,
 }

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/PermissionService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/PermissionService.kt
@@ -2,6 +2,7 @@ package to.bullet.device_calendar_plus_android
 
 import android.Manifest
 import android.app.Activity
+import android.content.Context
 import android.content.pm.PackageManager
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -14,6 +15,10 @@ class PermissionService(private val activity: Activity) {
         // Permission status values matching CalendarPermissionStatus enum
         const val STATUS_GRANTED = "granted"
         const val STATUS_DENIED = "denied"
+        const val STATUS_NOT_DETERMINED = "notDetermined"
+
+        private const val PREFS_PERMISSION_WAS_DENIED_BEFORE =
+            "device_calendar_plus_permission_was_denied_before"
     }
     
     private var pendingCallback: ((Result<String>) -> Unit)? = null
@@ -40,7 +45,32 @@ class PermissionService(private val activity: Activity) {
         
         return null
     }
-    
+
+    /**
+     * Determines the current calendar permission status, distinguishing between
+     * "never asked" ([STATUS_NOT_DETERMINED]) and "denied" ([STATUS_DENIED]).
+     *
+     * Android's [ContextCompat.checkSelfPermission] returns [PackageManager.PERMISSION_DENIED]
+     * both when the user has never been asked and when they actively denied. To distinguish
+     * these cases, we combine [ActivityCompat.shouldShowRequestPermissionRationale] with a
+     * [android.content.SharedPreferences] flag that records whether a denial has occurred.
+     *
+     * The OS behavior (experimentally verified) follows this scenario table:
+     *
+     * | Previous state     | Action  | shouldShowRationale | SharedPrefs flag |
+     * |--------------------|---------|---------------------|------------------|
+     * | Not asked          | —       | false               | false            |
+     * | Denied once        | Denied  | true                | true             |
+     * | Denied once        | Dismiss | true                | true             |
+     * | Permanently denied | Denied | false              | true             |
+     *
+     * Decision logic when [PackageManager.PERMISSION_DENIED]:
+     * - `shouldShowRationale == false` AND SharedPrefs flag set --> [STATUS_DENIED] (permanently denied, must use app settings)
+     * - everything else --> [STATUS_NOT_DETERMINED] (permission dialog can still be shown)
+     *
+     * Based on the approach from Baseflow's flutter-permission-handler:
+     * https://github.com/Baseflow/flutter-permission-handler/blob/39fba431428e5d82d35f4999663461468fe3a728/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java#L400-L536
+     */
     private fun getCurrentPermissionStatus(): String {
         val readPermission = Manifest.permission.READ_CALENDAR
         val writePermission = Manifest.permission.WRITE_CALENDAR
@@ -55,7 +85,30 @@ class PermissionService(private val activity: Activity) {
             writePermission
         ) == PackageManager.PERMISSION_GRANTED
         
-        return if (readGranted && writeGranted) STATUS_GRANTED else STATUS_DENIED
+        if (readGranted && writeGranted) return STATUS_GRANTED
+
+        val deniedPermissions = mutableListOf<String>()
+        if (!readGranted) deniedPermissions.add(readPermission)
+        if (!writeGranted) deniedPermissions.add(writePermission)
+
+        val permanentlyDenied = deniedPermissions.any { wasPermissionDeniedBefore(it) } &&
+            deniedPermissions.none {
+                ActivityCompat.shouldShowRequestPermissionRationale(activity, it)
+            }
+
+        if (permanentlyDenied) return STATUS_DENIED
+
+        return STATUS_NOT_DETERMINED
+    }
+
+    private fun wasPermissionDeniedBefore(permissionName: String): Boolean {
+        val prefs = activity.getSharedPreferences(permissionName, Context.MODE_PRIVATE)
+        return prefs.getBoolean(PREFS_PERMISSION_WAS_DENIED_BEFORE, false)
+    }
+
+    private fun setPermissionDenied(permissionName: String) {
+        val prefs = activity.getSharedPreferences(permissionName, Context.MODE_PRIVATE)
+        prefs.edit().putBoolean(PREFS_PERMISSION_WAS_DENIED_BEFORE, true).apply()
     }
     
     fun hasPermissions(): Result<String> {
@@ -108,6 +161,14 @@ class PermissionService(private val activity: Activity) {
         // Check if both permissions were granted
         val allGranted = grantResults.isNotEmpty() && 
             grantResults.all { it == PackageManager.PERMISSION_GRANTED }
+
+        if (!allGranted) {
+            permissions.forEachIndexed { index, permission ->
+                if (grantResults.getOrNull(index) != PackageManager.PERMISSION_GRANTED) {
+                    setPermissionDenied(permission)
+                }
+            }
+        }
         
         callback(Result.success(if (allGranted) STATUS_GRANTED else STATUS_DENIED))
         return true


### PR DESCRIPTION
Resolves #11.

## Summary

- Android: `hasPermissions()` now correctly returns `CalendarPermissionStatus.notDetermined` when the permission dialog can still be shown (never asked, or denied once but not permanently), instead of always returning `denied`
- Only returns `denied` when the user has permanently denied the permission ("Don't ask again"), meaning `openAppSettings()` is the only recourse
- Uses `shouldShowRequestPermissionRationale()` combined with a `SharedPreferences` flag to detect permanent denial - approach based on [Baseflow's flutter-permission-handler](https://github.com/Baseflow/flutter-permission-handler/blob/39fba431428e5d82d35f4999663461468fe3a728/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java#L400-L536)
- Updated dartdocs for `CalendarPermissionStatus.denied` and `.notDetermined` to reflect cross-platform semantics

## Details

Android's `ContextCompat.checkSelfPermission()` returns `PERMISSION_DENIED` both when
the user has never been asked and when they actively denied. To distinguish these cases,
we now track whether a denial has occurred via `SharedPreferences`, following the same
pattern used by the widely-adopted `permission_handler` package.

The new semantics:
- `notDetermined` = permission dialog can still be shown (call `requestPermissions()`)
- `denied` = permanently denied, dialog will not appear (direct user to `openAppSettings()`)

This changes the return value of `hasPermissions()` on Android in a way that is additive
but may affect existing conditional logic (code that only checked for `granted` vs `denied`
should now also handle `notDetermined`).

Implemented with the help of [Cursor](https://cursor.com), but reviewed manually. :)