### PR TITLE
fix(ios): use tiered source fallback in createCalendar

### DIFF
--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/CalendarService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/CalendarService.swift
@@ -65,18 +65,24 @@ class CalendarService {
       return
     }
     
-    // Find the local source - this is the only writable source for local calendars
-    guard let localSource = eventStore.sources.first(where: { $0.sourceType == .local }) else {
+    // Use the best available writable source:
+    // 1. Default calendar's source (usually iCloud on most devices)
+    // 2. First CalDAV source (iCloud, Google, etc.)
+    // 3. Local source (simulator or devices with no cloud accounts)
+    guard let source = eventStore.defaultCalendarForNewEvents?.source
+        ?? eventStore.sources.first(where: { $0.sourceType == .calDAV })
+        ?? eventStore.sources.first(where: { $0.sourceType == .local })
+    else {
       completion(.failure(CalendarError(
         code: PlatformExceptionCodes.calendarUnavailable,
-        message: "Could not find local calendar source"
+        message: "Could not find a writable calendar source"
       )))
       return
     }
-    
+
     // Create a new calendar
     let calendar = EKCalendar(for: .event, eventStore: eventStore)
-    calendar.source = localSource
+    calendar.source = source
     calendar.title = name
     
     // Set color if provided


### PR DESCRIPTION
## Summary

`createCalendar` fails with `CALENDAR_UNAVAILABLE` on most real iPhones because the Swift code hardcodes `sourceType == .local`. Most iOS devices use iCloud (`.calDAV`) as their primary calendar source, so no `.local` source exists.

This replaces the hardcoded `.local` lookup with a tiered fallback:

1. **Default calendar's source** — usually iCloud on most devices
2. **First CalDAV source** — iCloud, Google, Exchange, etc.
3. **Local source** — simulator or devices with no cloud accounts

This matches how iOS Calendar app selects sources and fixes calendar creation on iCloud-only devices.

## Changes

- `packages/device_calendar_plus_ios/.../CalendarService.swift` — replaced single `.local` source guard with tiered `defaultCalendarForNewEvents?.source ?? .calDAV ?? .local` fallback

## Testing

Tested on a real iPhone with iCloud as the only calendar source:
- `createCalendar(name: "Test", colorHex: "#6C63FF")` now succeeds
- Calendar appears under iCloud in the iOS Calendar app
- Still works on simulator (falls back to `.local`)