### PR TITLE
feat: add listSources() API and cloud calendar sync support

### DIFF
--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -539,9 +539,10 @@ class DeviceCalendar {
   /// [isAllDay] indicates if this is an all-day event (default: false).
   /// [description] is optional event notes/description.
   /// [location] is optional event location.
+  /// [url] is optional URL associated with the event. Can be used to link to
+  ///   app content or identify app-created events (e.g., `myapp://event/123`).
   /// [timeZone] is optional timezone identifier (null for all-day events).
   ///   The platform will validate the timezone string.
-  /// [url] is optional event URL (supported on both platforms).
   /// [availability] is the availability status (default: EventAvailability.busy).
   ///
   /// Returns the system-generated event ID.
@@ -567,6 +568,7 @@ class DeviceCalendar {
   ///   endDate: DateTime(2024, 3, 15, 15, 0),
   ///   description: 'Q1 project review meeting',
   ///   location: 'Conference Room A',
+  ///   url: 'myapp://event/project-review',
   ///   timeZone: 'America/New_York',
   ///   availability: EventAvailability.busy,
   /// );
@@ -579,6 +581,7 @@ class DeviceCalendar {
     bool isAllDay = false,
     String? description,
     String? location,
+    String? url,
     String? timeZone,
     EventAvailability availability = EventAvailability.busy,
   }) async {
@@ -623,6 +626,7 @@ class DeviceCalendar {
             isAllDay,
             description,
             location,
+            url,
             timeZone,
             availability.name,
           );

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -3,18 +3,22 @@ import 'package:flutter/services.dart';
 
 import 'src/calendar.dart';
 import 'src/calendar_permission_status.dart';
+import 'src/calendar_source.dart';
 import 'src/event.dart';
 import 'src/event_availability.dart';
 import 'src/platform_exception_converter.dart';
 
+// Platform-specific options
 export 'package:device_calendar_plus_android/device_calendar_plus_android.dart'
     show CreateCalendarOptionsAndroid;
-// Platform-specific options
+export 'package:device_calendar_plus_ios/device_calendar_plus_ios.dart'
+    show CreateCalendarOptionsIos;
 export 'package:device_calendar_plus_platform_interface/device_calendar_plus_platform_interface.dart'
     show CreateCalendarPlatformOptions, InstanceIdParser, ParsedInstanceId;
 
 export 'src/calendar.dart';
 export 'src/calendar_permission_status.dart';
+export 'src/calendar_source.dart';
 export 'src/device_calendar_error.dart';
 export 'src/event.dart';
 export 'src/event_availability.dart';
@@ -163,6 +167,51 @@ class DeviceCalendar {
     }
   }
 
+  /// Lists all calendar sources/accounts available on the device.
+  ///
+  /// Returns a list of [CalendarSource] objects representing each source.
+  /// Use this to discover available accounts before creating calendars that
+  /// sync to cloud services.
+  ///
+  /// On iOS, sources include iCloud, local, subscribed calendars, etc.
+  /// On Android, sources are account name + account type combinations.
+  ///
+  /// Example:
+  /// ```dart
+  /// final plugin = DeviceCalendar.instance;
+  /// final sources = await plugin.listSources();
+  /// for (final source in sources) {
+  ///   print('${source.title} (${source.type})');
+  ///   print('  Can create calendars: ${source.allowsCalendarCreation}');
+  /// }
+  ///
+  /// // Find iCloud source on iOS
+  /// final icloud = sources.firstWhere(
+  ///   (s) => s.title == 'iCloud',
+  ///   orElse: () => sources.first,
+  /// );
+  ///
+  /// // Create a calendar in that source
+  /// await plugin.createCalendar(
+  ///   name: 'My Calendar',
+  ///   platformOptions: CreateCalendarOptionsIos(sourceId: icloud.id),
+  /// );
+  /// ```
+  Future<List<CalendarSource>> listSources() async {
+    try {
+      final List<Map<String, dynamic>> rawSources =
+          await DeviceCalendarPlusPlatform.instance.listSources();
+      return rawSources.map((map) => CalendarSource.fromMap(map)).toList();
+    } on PlatformException catch (e, stackTrace) {
+      final convertedException =
+          PlatformExceptionConverter.convertPlatformException(e);
+      if (convertedException != null) {
+        Error.throwWithStackTrace(convertedException, stackTrace);
+      }
+      rethrow;
+    }
+  }
+
   /// Lists all calendars available on the device.
   ///
   /// Returns a list of [Calendar] objects representing each calendar.
@@ -229,11 +278,7 @@ class DeviceCalendar {
     CreateCalendarPlatformOptions? platformOptions,
   }) async {
     if (name.trim().isEmpty) {
-      throw ArgumentError.value(
-        name,
-        'name',
-        'Calendar name cannot be empty',
-      );
+      throw ArgumentError.value(name, 'name', 'Calendar name cannot be empty');
     }
 
     try {
@@ -283,23 +328,20 @@ class DeviceCalendar {
   }) async {
     // Validate that at least one parameter is provided
     if (name == null && colorHex == null) {
-      throw ArgumentError(
-        'At least one of name or colorHex must be provided',
-      );
+      throw ArgumentError('At least one of name or colorHex must be provided');
     }
 
     // Validate name if provided
     if (name != null && name.trim().isEmpty) {
-      throw ArgumentError.value(
-        name,
-        'name',
-        'Calendar name cannot be empty',
-      );
+      throw ArgumentError.value(name, 'name', 'Calendar name cannot be empty');
     }
 
     try {
-      await DeviceCalendarPlusPlatform.instance
-          .updateCalendar(calendarId, name, colorHex);
+      await DeviceCalendarPlusPlatform.instance.updateCalendar(
+        calendarId,
+        name,
+        colorHex,
+      );
     } on PlatformException catch (e, stackTrace) {
       final convertedException =
           PlatformExceptionConverter.convertPlatformException(e);
@@ -389,10 +431,10 @@ class DeviceCalendar {
     try {
       final List<Map<String, dynamic>> rawEvents =
           await DeviceCalendarPlusPlatform.instance.listEvents(
-        startDate,
-        endDate,
-        calendarIds,
-      );
+            startDate,
+            endDate,
+            calendarIds,
+          );
       return rawEvents.map((map) => Event.fromMap(map)).toList();
     } on PlatformException catch (e, stackTrace) {
       final convertedException =
@@ -427,11 +469,9 @@ class DeviceCalendar {
       // Parse the ID to extract eventId and optional timestamp
       final parsed = InstanceIdParser.parse(id);
 
-      final Map<String, dynamic>? rawEvent =
-          await DeviceCalendarPlusPlatform.instance.getEvent(
-        parsed.eventId,
-        parsed.timestamp,
-      );
+      final Map<String, dynamic>? rawEvent = await DeviceCalendarPlusPlatform
+          .instance
+          .getEvent(parsed.eventId, parsed.timestamp);
 
       if (rawEvent == null) {
         return null;
@@ -552,17 +592,11 @@ class DeviceCalendar {
     }
 
     if (title.trim().isEmpty) {
-      throw ArgumentError.value(
-        title,
-        'title',
-        'Event title cannot be empty',
-      );
+      throw ArgumentError.value(title, 'title', 'Event title cannot be empty');
     }
 
     if (endDate.isBefore(startDate)) {
-      throw ArgumentError(
-        'End date must be after start date',
-      );
+      throw ArgumentError('End date must be after start date');
     }
 
     // Normalize dates for all-day events
@@ -576,26 +610,22 @@ class DeviceCalendar {
         startDate.month,
         startDate.day,
       );
-      normalizedEndDate = DateTime(
-        endDate.year,
-        endDate.month,
-        endDate.day,
-      );
+      normalizedEndDate = DateTime(endDate.year, endDate.month, endDate.day);
     }
 
     try {
-      final String eventId =
-          await DeviceCalendarPlusPlatform.instance.createEvent(
-        calendarId,
-        title,
-        normalizedStartDate,
-        normalizedEndDate,
-        isAllDay,
-        description,
-        location,
-        timeZone,
-        availability.name,
-      );
+      final String eventId = await DeviceCalendarPlusPlatform.instance
+          .createEvent(
+            calendarId,
+            title,
+            normalizedStartDate,
+            normalizedEndDate,
+            isAllDay,
+            description,
+            location,
+            timeZone,
+            availability.name,
+          );
       return eventId;
     } on PlatformException catch (e, stackTrace) {
       final convertedException =
@@ -632,11 +662,7 @@ class DeviceCalendar {
   /// ```
   Future<void> deleteEvent({required String eventId}) async {
     if (eventId.trim().isEmpty) {
-      throw ArgumentError.value(
-        eventId,
-        'eventId',
-        'Event ID cannot be empty',
-      );
+      throw ArgumentError.value(eventId, 'eventId', 'Event ID cannot be empty');
     }
 
     try {
@@ -717,11 +743,7 @@ class DeviceCalendar {
   }) async {
     // Validate eventId
     if (eventId.trim().isEmpty) {
-      throw ArgumentError.value(
-        eventId,
-        'eventId',
-        'Event ID cannot be empty',
-      );
+      throw ArgumentError.value(eventId, 'eventId', 'Event ID cannot be empty');
     }
 
     // Validate at least one field is provided
@@ -732,16 +754,12 @@ class DeviceCalendar {
         location == null &&
         isAllDay == null &&
         timeZone == null) {
-      throw ArgumentError(
-        'At least one field must be provided to update',
-      );
+      throw ArgumentError('At least one field must be provided to update');
     }
 
     // Validate dates if both are provided
     if (startDate != null && endDate != null && endDate.isBefore(startDate)) {
-      throw ArgumentError(
-        'End date must be after start date',
-      );
+      throw ArgumentError('End date must be after start date');
     }
 
     // Normalize dates for all-day events
@@ -761,11 +779,7 @@ class DeviceCalendar {
         );
       }
       if (endDate != null) {
-        normalizedEndDate = DateTime(
-          endDate.year,
-          endDate.month,
-          endDate.day,
-        );
+        normalizedEndDate = DateTime(endDate.year, endDate.month, endDate.day);
       }
     }
 

--- a/packages/device_calendar_plus/lib/src/calendar_source.dart
+++ b/packages/device_calendar_plus/lib/src/calendar_source.dart
@@ -1,0 +1,74 @@
+/// Represents a calendar source/account on the device.
+///
+/// Calendar sources are containers that group calendars together.
+/// On iOS, these correspond to `EKSource` (iCloud, local, subscribed, etc.).
+/// On Android, these correspond to account name + account type combinations
+/// from the Calendar Provider.
+///
+/// Use [DeviceCalendar.listSources] to retrieve available sources, then pass
+/// the source information to platform-specific options when creating calendars.
+class CalendarSource {
+  /// Unique identifier for the source.
+  ///
+  /// On iOS, this is the `EKSource.sourceIdentifier`.
+  /// On Android, this is a composite key of `accountName:accountType`.
+  final String id;
+
+  /// User-facing title of the source.
+  ///
+  /// Examples: "iCloud", "user@gmail.com", "Local"
+  final String title;
+
+  /// The type of the source.
+  ///
+  /// Common values:
+  /// - iOS: "local", "caldav", "exchange", "subscribed", "birthdays"
+  /// - Android: "com.google", "com.microsoft.exchange", "LOCAL"
+  final String type;
+
+  /// Whether calendars can be created in this source.
+  ///
+  /// Some sources (like subscribed calendars or birthdays) don't allow
+  /// creating new calendars.
+  final bool allowsCalendarCreation;
+
+  /// Creates an immutable calendar source description.
+  const CalendarSource({
+    required this.id,
+    required this.title,
+    required this.type,
+    required this.allowsCalendarCreation,
+  });
+
+  /// Builds a calendar source object from a platform channel payload.
+  factory CalendarSource.fromMap(Map<String, dynamic> map) {
+    return CalendarSource(
+      id: map['id'] as String,
+      title: map['title'] as String,
+      type: map['type'] as String,
+      allowsCalendarCreation: map['allowsCalendarCreation'] as bool? ?? false,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is CalendarSource &&
+        other.id == id &&
+        other.title == title &&
+        other.type == type &&
+        other.allowsCalendarCreation == allowsCalendarCreation;
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(id, title, type, allowsCalendarCreation);
+  }
+
+  @override
+  String toString() {
+    return 'CalendarSource(id: $id, title: $title, type: $type, '
+        'allowsCalendarCreation: $allowsCalendarCreation)';
+  }
+}

--- a/packages/device_calendar_plus/lib/src/event.dart
+++ b/packages/device_calendar_plus/lib/src/event.dart
@@ -78,6 +78,10 @@ class Event {
   /// True for recurring events, false for one-time events.
   final bool isRecurring;
 
+  /// URL associated with this event.
+  /// Can be used to link to app content or identify app-created events.
+  final String? url;
+
   Event({
     required this.eventId,
     required this.instanceId,
@@ -92,6 +96,7 @@ class Event {
     required this.status,
     this.timeZone,
     required this.isRecurring,
+    this.url,
   });
 
   /// Creates an Event from a map returned by the platform.
@@ -110,6 +115,7 @@ class Event {
       status: EventStatus.fromName(map['status'] as String),
       timeZone: map['timeZone'] as String?,
       isRecurring: map['isRecurring'] as bool? ?? false,
+      url: map['url'] as String?,
     );
   }
 
@@ -131,6 +137,7 @@ class Event {
     if (description != null) map['description'] = description;
     if (location != null) map['location'] = location;
     if (timeZone != null) map['timeZone'] = timeZone;
+    if (url != null) map['url'] = url;
 
     return map;
   }
@@ -138,7 +145,7 @@ class Event {
   @override
   String toString() {
     return 'Event(eventId: $eventId, instanceId: $instanceId, calendarId: $calendarId, title: $title, '
-        'startDate: $startDate, endDate: $endDate, isAllDay: $isAllDay)';
+        'startDate: $startDate, endDate: $endDate, isAllDay: $isAllDay, url: $url)';
   }
 
   @override
@@ -158,7 +165,8 @@ class Event {
         other.availability == availability &&
         other.status == status &&
         other.timeZone == timeZone &&
-        other.isRecurring == isRecurring;
+        other.isRecurring == isRecurring &&
+        other.url == url;
   }
 
   @override
@@ -177,6 +185,7 @@ class Event {
       status,
       timeZone,
       isRecurring,
+      url,
     );
   }
 }

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -22,6 +22,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     bool isAllDay,
     String? description,
     String? location,
+    String? url,
     String? timeZone,
     String availability,
   )?
@@ -74,6 +75,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
       bool isAllDay,
       String? description,
       String? location,
+      String? url,
       String? timeZone,
       String availability,
     )
@@ -206,6 +208,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     bool isAllDay,
     String? description,
     String? location,
+    String? url,
     String? timeZone,
     String availability,
   ) async {
@@ -223,6 +226,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
         isAllDay,
         description,
         location,
+        url,
         timeZone,
         availability,
       );
@@ -1012,6 +1016,7 @@ void main() {
             isAllDay,
             description,
             location,
+            url,
             timeZone,
             availability,
           ) {
@@ -1068,6 +1073,7 @@ void main() {
           isAllDay,
           description,
           location,
+          url,
           timeZone,
           availability,
         ) {

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -24,7 +24,8 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     String? location,
     String? timeZone,
     String availability,
-  )? _createEventCallback;
+  )?
+  _createEventCallback;
 
   // Callback to capture updateEvent arguments
   Future<void> Function(
@@ -37,7 +38,8 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     bool? isAllDay,
     String? timeZone,
     String? availability,
-  })? _updateEventCallback;
+  })?
+  _updateEventCallback;
 
   void setPermissionStatus(CalendarPermissionStatus status) {
     _permissionStatusCode = status.name;
@@ -74,7 +76,8 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
       String? location,
       String? timeZone,
       String availability,
-    ) callback,
+    )
+    callback,
   ) {
     _createEventCallback = callback;
   }
@@ -90,7 +93,8 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
       bool? isAllDay,
       String? timeZone,
       String? availability,
-    }) callback,
+    })
+    callback,
   ) {
     _updateEventCallback = callback;
   }
@@ -120,6 +124,14 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
   }
 
   @override
+  Future<List<Map<String, dynamic>>> listSources() async {
+    if (_exceptionToThrow != null) {
+      throw _exceptionToThrow!;
+    }
+    return [];
+  }
+
+  @override
   Future<List<Map<String, dynamic>>> listCalendars() async {
     if (_exceptionToThrow != null) {
       throw _exceptionToThrow!;
@@ -141,7 +153,10 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
 
   @override
   Future<void> updateCalendar(
-      String calendarId, String? name, String? colorHex) async {
+    String calendarId,
+    String? name,
+    String? colorHex,
+  ) async {
     if (_exceptionToThrow != null) {
       throw _exceptionToThrow!;
     }
@@ -279,26 +294,28 @@ void main() {
       });
 
       group('error handling', () {
-        test('throws DeviceCalendarException when permissions not declared',
-            () async {
-          mockPlatform.throwException(
-            PlatformException(
-              code: 'PERMISSIONS_NOT_DECLARED',
-              message: 'Calendar permissions must be declared',
-            ),
-          );
-
-          expect(
-            () => DeviceCalendar.instance.requestPermissions(),
-            throwsA(
-              isA<DeviceCalendarException>().having(
-                (e) => e.errorCode,
-                'errorCode',
-                DeviceCalendarError.permissionsNotDeclared,
+        test(
+          'throws DeviceCalendarException when permissions not declared',
+          () async {
+            mockPlatform.throwException(
+              PlatformException(
+                code: 'PERMISSIONS_NOT_DECLARED',
+                message: 'Calendar permissions must be declared',
               ),
-            ),
-          );
-        });
+            );
+
+            expect(
+              () => DeviceCalendar.instance.requestPermissions(),
+              throwsA(
+                isA<DeviceCalendarException>().having(
+                  (e) => e.errorCode,
+                  'errorCode',
+                  DeviceCalendarError.permissionsNotDeclared,
+                ),
+              ),
+            );
+          },
+        );
 
         test('rethrows other PlatformExceptions unchanged', () async {
           mockPlatform.throwException(
@@ -340,26 +357,28 @@ void main() {
       });
 
       group('error handling', () {
-        test('throws DeviceCalendarException when permissions not declared',
-            () async {
-          mockPlatform.throwException(
-            PlatformException(
-              code: 'PERMISSIONS_NOT_DECLARED',
-              message: 'Calendar permissions must be declared',
-            ),
-          );
-
-          expect(
-            () => DeviceCalendar.instance.hasPermissions(),
-            throwsA(
-              isA<DeviceCalendarException>().having(
-                (e) => e.errorCode,
-                'errorCode',
-                DeviceCalendarError.permissionsNotDeclared,
+        test(
+          'throws DeviceCalendarException when permissions not declared',
+          () async {
+            mockPlatform.throwException(
+              PlatformException(
+                code: 'PERMISSIONS_NOT_DECLARED',
+                message: 'Calendar permissions must be declared',
               ),
-            ),
-          );
-        });
+            );
+
+            expect(
+              () => DeviceCalendar.instance.hasPermissions(),
+              throwsA(
+                isA<DeviceCalendarException>().having(
+                  (e) => e.errorCode,
+                  'errorCode',
+                  DeviceCalendarError.permissionsNotDeclared,
+                ),
+              ),
+            );
+          },
+        );
 
         test('rethrows other PlatformExceptions unchanged', () async {
           mockPlatform.throwException(
@@ -391,26 +410,28 @@ void main() {
       });
 
       group('error handling', () {
-        test('throws DeviceCalendarException when permissions not declared',
-            () async {
-          mockPlatform.throwException(
-            PlatformException(
-              code: 'PERMISSIONS_NOT_DECLARED',
-              message: 'Calendar permissions must be declared',
-            ),
-          );
-
-          expect(
-            () => DeviceCalendar.instance.openAppSettings(),
-            throwsA(
-              isA<DeviceCalendarException>().having(
-                (e) => e.errorCode,
-                'errorCode',
-                DeviceCalendarError.permissionsNotDeclared,
+        test(
+          'throws DeviceCalendarException when permissions not declared',
+          () async {
+            mockPlatform.throwException(
+              PlatformException(
+                code: 'PERMISSIONS_NOT_DECLARED',
+                message: 'Calendar permissions must be declared',
               ),
-            ),
-          );
-        });
+            );
+
+            expect(
+              () => DeviceCalendar.instance.openAppSettings(),
+              throwsA(
+                isA<DeviceCalendarException>().having(
+                  (e) => e.errorCode,
+                  'errorCode',
+                  DeviceCalendarError.permissionsNotDeclared,
+                ),
+              ),
+            );
+          },
+        );
 
         test('rethrows other PlatformExceptions unchanged', () async {
           mockPlatform.throwException(
@@ -501,8 +522,9 @@ void main() {
 
     group('createCalendar', () {
       test('returns calendar ID when created successfully', () async {
-        final calendarId =
-            await DeviceCalendar.instance.createCalendar(name: 'Test Calendar');
+        final calendarId = await DeviceCalendar.instance.createCalendar(
+          name: 'Test Calendar',
+        );
 
         expect(calendarId, isNotEmpty);
         expect(calendarId, isA<String>());
@@ -510,8 +532,9 @@ void main() {
       });
 
       test('creates calendar with name only', () async {
-        final calendarId =
-            await DeviceCalendar.instance.createCalendar(name: 'Work Calendar');
+        final calendarId = await DeviceCalendar.instance.createCalendar(
+          name: 'Work Calendar',
+        );
 
         expect(calendarId, isNotEmpty);
       });
@@ -647,8 +670,10 @@ void main() {
 
       test('throws ArgumentError when name is whitespace only', () async {
         expect(
-          () => DeviceCalendar.instance
-              .updateCalendar('calendar-123', name: '   '),
+          () => DeviceCalendar.instance.updateCalendar(
+            'calendar-123',
+            name: '   ',
+          ),
           throwsA(
             isA<ArgumentError>().having(
               (e) => e.message,
@@ -662,12 +687,16 @@ void main() {
       test('converts permissionDenied PlatformException', () async {
         mockPlatform.throwException(
           PlatformException(
-              code: 'PERMISSION_DENIED', message: 'Permission denied'),
+            code: 'PERMISSION_DENIED',
+            message: 'Permission denied',
+          ),
         );
 
         expect(
-          () => DeviceCalendar.instance
-              .updateCalendar('calendar-123', name: 'New Name'),
+          () => DeviceCalendar.instance.updateCalendar(
+            'calendar-123',
+            name: 'New Name',
+          ),
           throwsA(
             isA<DeviceCalendarException>().having(
               (e) => e.errorCode,
@@ -686,8 +715,10 @@ void main() {
         );
 
         expect(
-          () => DeviceCalendar.instance
-              .updateCalendar('calendar-123', name: 'New Name'),
+          () => DeviceCalendar.instance.updateCalendar(
+            'calendar-123',
+            name: 'New Name',
+          ),
           throwsA(
             isA<PlatformException>().having(
               (e) => e.code,
@@ -840,7 +871,9 @@ void main() {
         expect(event, isNotNull);
         expect(event!.eventId, 'event1');
         expect(
-            event.instanceId, 'event1'); // Non-recurring: instanceId == eventId
+          event.instanceId,
+          'event1',
+        ); // Non-recurring: instanceId == eventId
         expect(event.title, 'Team Meeting');
         expect(event.description, 'Weekly sync');
       });
@@ -855,8 +888,9 @@ void main() {
           'calendarId': 'cal1',
           'title': 'Daily Standup',
           'startDate': eventStart.millisecondsSinceEpoch,
-          'endDate':
-              eventStart.add(Duration(minutes: 30)).millisecondsSinceEpoch,
+          'endDate': eventStart
+              .add(Duration(minutes: 30))
+              .millisecondsSinceEpoch,
           'isAllDay': false,
           'availability': 'busy',
           'status': 'confirmed',
@@ -958,63 +992,65 @@ void main() {
         expect(eventId, isNotEmpty);
       });
 
-      test('normalizes dates for all-day events (strips time components)',
-          () async {
-        // Create an all-day event with time components
-        final startWithTime = DateTime(2024, 3, 15, 14, 30, 45);
-        final endWithTime = DateTime(2024, 3, 16, 18, 15, 30);
+      test(
+        'normalizes dates for all-day events (strips time components)',
+        () async {
+          // Create an all-day event with time components
+          final startWithTime = DateTime(2024, 3, 15, 14, 30, 45);
+          final endWithTime = DateTime(2024, 3, 16, 18, 15, 30);
 
-        // Mock to capture what was actually passed to the platform
-        DateTime? capturedStart;
-        DateTime? capturedEnd;
+          // Mock to capture what was actually passed to the platform
+          DateTime? capturedStart;
+          DateTime? capturedEnd;
 
-        final mock = MockDeviceCalendarPlusPlatform();
-        mock.setCreateEventCallback((
-          calendarId,
-          title,
-          startDate,
-          endDate,
-          isAllDay,
-          description,
-          location,
-          timeZone,
-          availability,
-        ) {
-          capturedStart = startDate;
-          capturedEnd = endDate;
-          return Future.value('event-id');
-        });
+          final mock = MockDeviceCalendarPlusPlatform();
+          mock.setCreateEventCallback((
+            calendarId,
+            title,
+            startDate,
+            endDate,
+            isAllDay,
+            description,
+            location,
+            timeZone,
+            availability,
+          ) {
+            capturedStart = startDate;
+            capturedEnd = endDate;
+            return Future.value('event-id');
+          });
 
-        DeviceCalendarPlusPlatform.instance = mock;
+          DeviceCalendarPlusPlatform.instance = mock;
 
-        await DeviceCalendar.instance.createEvent(
-          calendarId: 'cal-123',
-          title: 'All Day Event',
-          startDate: startWithTime,
-          endDate: endWithTime,
-          isAllDay: true,
-        );
+          await DeviceCalendar.instance.createEvent(
+            calendarId: 'cal-123',
+            title: 'All Day Event',
+            startDate: startWithTime,
+            endDate: endWithTime,
+            isAllDay: true,
+          );
 
-        // Verify dates were normalized to midnight
-        expect(capturedStart, isNotNull);
-        expect(capturedEnd, isNotNull);
-        expect(capturedStart!.hour, 0);
-        expect(capturedStart!.minute, 0);
-        expect(capturedStart!.second, 0);
-        expect(capturedStart!.millisecond, 0);
-        expect(capturedEnd!.hour, 0);
-        expect(capturedEnd!.minute, 0);
-        expect(capturedEnd!.second, 0);
-        expect(capturedEnd!.millisecond, 0);
+          // Verify dates were normalized to midnight
+          expect(capturedStart, isNotNull);
+          expect(capturedEnd, isNotNull);
+          expect(capturedStart!.hour, 0);
+          expect(capturedStart!.minute, 0);
+          expect(capturedStart!.second, 0);
+          expect(capturedStart!.millisecond, 0);
+          expect(capturedEnd!.hour, 0);
+          expect(capturedEnd!.minute, 0);
+          expect(capturedEnd!.second, 0);
+          expect(capturedEnd!.millisecond, 0);
 
-        // Verify dates preserved the day
-        expect(capturedStart!.year, 2024);
-        expect(capturedStart!.month, 3);
-        expect(capturedStart!.day, 15);
-        expect(capturedEnd!.year, 2024);
-        expect(capturedEnd!.month, 3);
-        expect(capturedEnd!.day, 16);
-      });
+          // Verify dates preserved the day
+          expect(capturedStart!.year, 2024);
+          expect(capturedStart!.month, 3);
+          expect(capturedStart!.day, 15);
+          expect(capturedEnd!.year, 2024);
+          expect(capturedEnd!.month, 3);
+          expect(capturedEnd!.day, 16);
+        },
+      );
 
       test('preserves exact time for non-all-day events', () async {
         final startWithTime = DateTime(2024, 3, 15, 14, 30, 45);
@@ -1307,9 +1343,7 @@ void main() {
 
       test('throws ArgumentError when no fields provided', () async {
         expect(
-          () => DeviceCalendar.instance.updateEvent(
-            eventId: 'event-123',
-          ),
+          () => DeviceCalendar.instance.updateEvent(eventId: 'event-123'),
           throwsArgumentError,
         );
       });

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
@@ -7,7 +7,78 @@ import android.provider.CalendarContract
 import androidx.core.content.ContextCompat
 
 class CalendarService(private val activity: Activity) {
-    
+
+    fun listSources(): Result<List<Map<String, Any>>> {
+        val sources = mutableListOf<Map<String, Any>>()
+
+        val projection = arrayOf(
+            CalendarContract.Calendars.ACCOUNT_NAME,
+            CalendarContract.Calendars.ACCOUNT_TYPE,
+            CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL
+        )
+
+        try {
+            // Map to track unique accounts and their max access level
+            val accountMap = mutableMapOf<String, MutableMap<String, Any>>()
+
+            activity.contentResolver.query(
+                CalendarContract.Calendars.CONTENT_URI,
+                projection,
+                null,
+                null,
+                null
+            )?.use { cursor ->
+                val accountNameIndex = cursor.getColumnIndex(CalendarContract.Calendars.ACCOUNT_NAME)
+                val accountTypeIndex = cursor.getColumnIndex(CalendarContract.Calendars.ACCOUNT_TYPE)
+                val accessLevelIndex = cursor.getColumnIndex(CalendarContract.Calendars.CALENDAR_ACCESS_LEVEL)
+
+                while (cursor.moveToNext()) {
+                    val accountName = cursor.getString(accountNameIndex) ?: continue
+                    val accountType = cursor.getString(accountTypeIndex) ?: continue
+                    val accessLevel = cursor.getInt(accessLevelIndex)
+
+                    // Create a unique key for each account
+                    val key = "$accountName:$accountType"
+
+                    // Check if this account allows calendar creation (at least contributor level)
+                    val allowsCreation = accessLevel >= CalendarContract.Calendars.CAL_ACCESS_CONTRIBUTOR
+
+                    // Update the account map, keeping track of whether any calendar allows creation
+                    if (accountMap.containsKey(key)) {
+                        val existing = accountMap[key]!!
+                        val existingAllows = existing["allowsCalendarCreation"] as Boolean
+                        existing["allowsCalendarCreation"] = existingAllows || allowsCreation
+                    } else {
+                        accountMap[key] = mutableMapOf(
+                            "id" to key,
+                            "title" to accountName,
+                            "type" to accountType,
+                            "allowsCalendarCreation" to allowsCreation
+                        )
+                    }
+                }
+            }
+
+            sources.addAll(accountMap.values)
+        } catch (e: SecurityException) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.PERMISSION_DENIED,
+                    "Calendar permission denied: ${e.message}"
+                )
+            )
+        } catch (e: Exception) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.UNKNOWN_ERROR,
+                    "Failed to query calendar sources: ${e.message}"
+                )
+            )
+        }
+
+        return Result.success(sources)
+    }
+
     fun listCalendars(): Result<List<Map<String, Any>>> {
         val calendars = mutableListOf<Map<String, Any>>()
         
@@ -89,9 +160,9 @@ class CalendarService(private val activity: Activity) {
         return Result.success(calendars)
     }
     
-    fun createCalendar(name: String, colorHex: String?, accountNameParam: String?): Result<String> {
+    fun createCalendar(name: String, colorHex: String?, accountNameParam: String?, accountTypeParam: String?): Result<String> {
         // Check for write calendar permission
-        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.WRITE_CALENDAR) 
+        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.WRITE_CALENDAR)
             != PackageManager.PERMISSION_GRANTED) {
             return Result.failure(
                 CalendarException(
@@ -100,9 +171,9 @@ class CalendarService(private val activity: Activity) {
                 )
             )
         }
-        
+
         val accountName = accountNameParam ?: "local"
-        val accountType = CalendarContract.ACCOUNT_TYPE_LOCAL
+        val accountType = accountTypeParam ?: CalendarContract.ACCOUNT_TYPE_LOCAL
         
         // Android automatically creates the account when inserting the first calendar
         try {

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
@@ -39,6 +39,7 @@ class DeviceCalendarPlusAndroidPlugin :
             "requestPermissions" -> handleRequestPermissions(result)
             "hasPermissions" -> handleHasPermissions(result)
             "openAppSettings" -> handleOpenAppSettings(result)
+            "listSources" -> handleListSources(result)
             "listCalendars" -> handleListCalendars(result)
             "createCalendar" -> handleCreateCalendar(call, result)
             "updateCalendar" -> handleUpdateCalendar(call, result)
@@ -114,9 +115,25 @@ class DeviceCalendarPlusAndroidPlugin :
         }
     }
     
+    private fun handleListSources(result: Result) {
+        val service = calendarService!!
+
+        val serviceResult = service.listSources()
+        serviceResult.fold(
+            onSuccess = { sources -> result.success(sources) },
+            onFailure = { error ->
+                if (error is CalendarException) {
+                    result.error(error.code, error.message, null)
+                } else {
+                    result.error(PlatformExceptionCodes.UNKNOWN_ERROR, error.message, null)
+                }
+            }
+        )
+    }
+
     private fun handleListCalendars(result: Result) {
         val service = calendarService!!
-        
+
         val serviceResult = service.listCalendars()
         serviceResult.fold(
             onSuccess = { calendars -> result.success(calendars) },
@@ -129,15 +146,16 @@ class DeviceCalendarPlusAndroidPlugin :
             }
         )
     }
-    
+
     private fun handleCreateCalendar(call: MethodCall, result: Result) {
         val service = calendarService ?: error("CalendarService not initialized - plugin lifecycle error")
-        
+
         // Parse arguments
         val name = call.argument<String>("name")
         val colorHex = call.argument<String>("colorHex")
         val accountName = call.argument<String>("accountName")
-        
+        val accountType = call.argument<String>("accountType")
+
         if (name == null) {
             result.error(
                 PlatformExceptionCodes.INVALID_ARGUMENTS,
@@ -146,8 +164,8 @@ class DeviceCalendarPlusAndroidPlugin :
             )
             return
         }
-        
-        val serviceResult = service.createCalendar(name, colorHex, accountName)
+
+        val serviceResult = service.createCalendar(name, colorHex, accountName, accountType)
         serviceResult.fold(
             onSuccess = { calendarId -> result.success(calendarId) },
             onFailure = { error ->

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
@@ -335,7 +335,7 @@ class DeviceCalendarPlusAndroidPlugin :
     
     private fun handleCreateEvent(call: MethodCall, result: Result) {
         val service = eventsService ?: error("EventsService not initialized - plugin lifecycle error")
-        
+
         // Parse arguments
         val calendarId = call.argument<String>("calendarId")
         val title = call.argument<String>("title")
@@ -344,11 +344,12 @@ class DeviceCalendarPlusAndroidPlugin :
         val isAllDay = call.argument<Boolean>("isAllDay")
         val description = call.argument<String>("description")
         val location = call.argument<String>("location")
+        val url = call.argument<String>("url")
         val timeZone = call.argument<String>("timeZone")
         val availability = call.argument<String>("availability")
-        
+
         // Validate required arguments
-        if (calendarId == null || title == null || startDateMillis == null || 
+        if (calendarId == null || title == null || startDateMillis == null ||
             endDateMillis == null || isAllDay == null || availability == null) {
             result.error(
                 PlatformExceptionCodes.INVALID_ARGUMENTS,
@@ -357,10 +358,10 @@ class DeviceCalendarPlusAndroidPlugin :
             )
             return
         }
-        
+
         val startDate = java.util.Date(startDateMillis)
         val endDate = java.util.Date(endDateMillis)
-        
+
         val serviceResult = service.createEvent(
             calendarId,
             title,
@@ -369,6 +370,7 @@ class DeviceCalendarPlusAndroidPlugin :
             isAllDay,
             description,
             location,
+            url,
             timeZone,
             availability
         )

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -38,7 +38,8 @@ class EventsService(private val activity: Activity) {
             CalendarContract.Instances.AVAILABILITY,
             CalendarContract.Instances.STATUS,
             CalendarContract.Instances.EVENT_TIMEZONE,
-            CalendarContract.Instances.RRULE
+            CalendarContract.Instances.RRULE,
+            CalendarContract.Instances.CUSTOM_APP_URI
         )
         
         // Build selection clause for calendar and event filtering
@@ -81,7 +82,8 @@ class EventsService(private val activity: Activity) {
                         CalendarContract.Instances.AVAILABILITY,
                         CalendarContract.Instances.STATUS,
                         CalendarContract.Instances.EVENT_TIMEZONE,
-                        CalendarContract.Instances.RRULE
+                        CalendarContract.Instances.RRULE,
+                        urlColumn = CalendarContract.Instances.CUSTOM_APP_URI
                     )
                     events.add(eventMap)
                 }
@@ -138,7 +140,8 @@ class EventsService(private val activity: Activity) {
         timeZoneColumn: String,
         recurrenceRuleColumn: String,
         createdColumn: String? = null,
-        lastModifiedColumn: String? = null
+        lastModifiedColumn: String? = null,
+        urlColumn: String? = null
     ): Map<String, Any> {
         val eventIdIndex = cursor.getColumnIndex(eventIdColumn)
         val calendarIdIndex = cursor.getColumnIndex(calendarIdColumn)
@@ -154,6 +157,7 @@ class EventsService(private val activity: Activity) {
         val recurrenceRuleIndex = cursor.getColumnIndex(recurrenceRuleColumn)
         val createdIndex = if (createdColumn != null) cursor.getColumnIndex(createdColumn) else -1
         val lastModifiedIndex = if (lastModifiedColumn != null) cursor.getColumnIndex(lastModifiedColumn) else -1
+        val urlIndex = if (urlColumn != null) cursor.getColumnIndex(urlColumn) else -1
         
         val eventId = cursor.getString(eventIdIndex)
         val calendarId = cursor.getString(calendarIdIndex)
@@ -169,6 +173,7 @@ class EventsService(private val activity: Activity) {
         val recurrenceRule = if (!cursor.isNull(recurrenceRuleIndex)) cursor.getString(recurrenceRuleIndex) else null
         val createdDate = if (createdIndex >= 0 && !cursor.isNull(createdIndex)) cursor.getLong(createdIndex) else null
         val lastModifiedDate = if (lastModifiedIndex >= 0 && !cursor.isNull(lastModifiedIndex)) cursor.getLong(lastModifiedIndex) else null
+        val url = if (urlIndex >= 0 && !cursor.isNull(urlIndex)) cursor.getString(urlIndex) else null
         
         // Generate instanceId using RAW timestamps before any modifications
         val instanceId: String = if (recurrenceRule != null) {
@@ -239,7 +244,10 @@ class EventsService(private val activity: Activity) {
         if (lastModifiedDate != null) {
             eventMap["updatedDate"] = lastModifiedDate
         }
-        
+
+        // Add URL if available
+        url?.let { eventMap["url"] = it }
+
         return eventMap
     }
     
@@ -280,7 +288,8 @@ class EventsService(private val activity: Activity) {
                 CalendarContract.Events.AVAILABILITY,
                 CalendarContract.Events.STATUS,
                 CalendarContract.Events.EVENT_TIMEZONE,
-                CalendarContract.Events.RRULE
+                CalendarContract.Events.RRULE,
+                CalendarContract.Events.CUSTOM_APP_URI
             )
             
             val selection = "${CalendarContract.Events._ID} = ?"
@@ -308,7 +317,8 @@ class EventsService(private val activity: Activity) {
                             CalendarContract.Events.AVAILABILITY,
                             CalendarContract.Events.STATUS,
                             CalendarContract.Events.EVENT_TIMEZONE,
-                            CalendarContract.Events.RRULE
+                            CalendarContract.Events.RRULE,
+                            urlColumn = CalendarContract.Events.CUSTOM_APP_URI
                         )
                         return Result.success(eventMap)
                     } else {
@@ -400,6 +410,7 @@ class EventsService(private val activity: Activity) {
         isAllDay: Boolean,
         description: String?,
         location: String?,
+        url: String?,
         timeZone: String?,
         availability: String
     ): Result<String> {
@@ -463,7 +474,12 @@ class EventsService(private val activity: Activity) {
                 if (location != null) {
                     put(CalendarContract.Events.EVENT_LOCATION, location)
                 }
-                
+
+                // Set URL if provided
+                if (url != null) {
+                    put(CalendarContract.Events.CUSTOM_APP_URI, url)
+                }
+
                 // Set timezone
                 // For all-day events, use device timezone to make them "floating"
                 // This ensures the date components (year/month/day) stay the same

--- a/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
+++ b/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
@@ -33,9 +33,19 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
   }
 
   @override
+  Future<List<Map<String, dynamic>>> listSources() async {
+    final result = await methodChannel.invokeMethod<List<dynamic>>(
+      'listSources',
+    );
+    return result?.map((e) => Map<String, dynamic>.from(e as Map)).toList() ??
+        [];
+  }
+
+  @override
   Future<List<Map<String, dynamic>>> listCalendars() async {
-    final result =
-        await methodChannel.invokeMethod<List<dynamic>>('listCalendars');
+    final result = await methodChannel.invokeMethod<List<dynamic>>(
+      'listCalendars',
+    );
     return result?.map((e) => Map<String, dynamic>.from(e as Map)).toList() ??
         [];
   }
@@ -47,40 +57,40 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
     CreateCalendarPlatformOptions? platformOptions,
   ) async {
     String? accountName;
+    String? accountType;
     if (platformOptions is CreateCalendarOptionsAndroid) {
       accountName = platformOptions.accountName;
+      accountType = platformOptions.accountType;
     }
 
-    final result = await methodChannel.invokeMethod<String>(
-      'createCalendar',
-      <String, dynamic>{
-        'name': name,
-        'colorHex': colorHex,
-        'accountName': accountName,
-      },
-    );
+    final result = await methodChannel
+        .invokeMethod<String>('createCalendar', <String, dynamic>{
+          'name': name,
+          'colorHex': colorHex,
+          'accountName': accountName,
+          'accountType': accountType,
+        });
     return result!;
   }
 
   @override
   Future<void> updateCalendar(
-      String calendarId, String? name, String? colorHex) async {
-    await methodChannel.invokeMethod<void>(
-      'updateCalendar',
-      <String, dynamic>{
-        'calendarId': calendarId,
-        'name': name,
-        'colorHex': colorHex,
-      },
-    );
+    String calendarId,
+    String? name,
+    String? colorHex,
+  ) async {
+    await methodChannel.invokeMethod<void>('updateCalendar', <String, dynamic>{
+      'calendarId': calendarId,
+      'name': name,
+      'colorHex': colorHex,
+    });
   }
 
   @override
   Future<void> deleteCalendar(String calendarId) async {
-    await methodChannel.invokeMethod<void>(
-      'deleteCalendar',
-      <String, dynamic>{'calendarId': calendarId},
-    );
+    await methodChannel.invokeMethod<void>('deleteCalendar', <String, dynamic>{
+      'calendarId': calendarId,
+    });
   }
 
   @override
@@ -89,14 +99,12 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
     DateTime endDate,
     List<String>? calendarIds,
   ) async {
-    final result = await methodChannel.invokeMethod<List<dynamic>>(
-      'listEvents',
-      <String, dynamic>{
-        'startDate': startDate.millisecondsSinceEpoch,
-        'endDate': endDate.millisecondsSinceEpoch,
-        'calendarIds': calendarIds,
-      },
-    );
+    final result = await methodChannel
+        .invokeMethod<List<dynamic>>('listEvents', <String, dynamic>{
+          'startDate': startDate.millisecondsSinceEpoch,
+          'endDate': endDate.millisecondsSinceEpoch,
+          'calendarIds': calendarIds,
+        });
     return result?.map((e) => Map<String, dynamic>.from(e as Map)).toList() ??
         [];
   }
@@ -105,23 +113,17 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
   Future<Map<String, dynamic>?> getEvent(String eventId, int? timestamp) async {
     final result = await methodChannel.invokeMethod<Map<dynamic, dynamic>>(
       'getEvent',
-      <String, dynamic>{
-        'eventId': eventId,
-        'timestamp': timestamp,
-      },
+      <String, dynamic>{'eventId': eventId, 'timestamp': timestamp},
     );
     return result != null ? Map<String, dynamic>.from(result) : null;
   }
 
   @override
   Future<void> showEventModal(String eventId, int? timestamp) async {
-    await methodChannel.invokeMethod<void>(
-      'showEventModal',
-      <String, dynamic>{
-        'eventId': eventId,
-        'timestamp': timestamp,
-      },
-    );
+    await methodChannel.invokeMethod<void>('showEventModal', <String, dynamic>{
+      'eventId': eventId,
+      'timestamp': timestamp,
+    });
   }
 
   @override
@@ -136,31 +138,26 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
     String? timeZone,
     String availability,
   ) async {
-    final result = await methodChannel.invokeMethod<String>(
-      'createEvent',
-      <String, dynamic>{
-        'calendarId': calendarId,
-        'title': title,
-        'startDate': startDate.millisecondsSinceEpoch,
-        'endDate': endDate.millisecondsSinceEpoch,
-        'isAllDay': isAllDay,
-        'description': description,
-        'location': location,
-        'timeZone': timeZone,
-        'availability': availability,
-      },
-    );
+    final result = await methodChannel
+        .invokeMethod<String>('createEvent', <String, dynamic>{
+          'calendarId': calendarId,
+          'title': title,
+          'startDate': startDate.millisecondsSinceEpoch,
+          'endDate': endDate.millisecondsSinceEpoch,
+          'isAllDay': isAllDay,
+          'description': description,
+          'location': location,
+          'timeZone': timeZone,
+          'availability': availability,
+        });
     return result!;
   }
 
   @override
   Future<void> deleteEvent(String eventId) async {
-    await methodChannel.invokeMethod<void>(
-      'deleteEvent',
-      <String, dynamic>{
-        'eventId': eventId,
-      },
-    );
+    await methodChannel.invokeMethod<void>('deleteEvent', <String, dynamic>{
+      'eventId': eventId,
+    });
   }
 
   @override
@@ -174,18 +171,15 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
     bool? isAllDay,
     String? timeZone,
   }) async {
-    await methodChannel.invokeMethod<void>(
-      'updateEvent',
-      <String, dynamic>{
-        'eventId': eventId,
-        'title': title,
-        'startDate': startDate?.millisecondsSinceEpoch,
-        'endDate': endDate?.millisecondsSinceEpoch,
-        'description': description,
-        'location': location,
-        'isAllDay': isAllDay,
-        'timeZone': timeZone,
-      },
-    );
+    await methodChannel.invokeMethod<void>('updateEvent', <String, dynamic>{
+      'eventId': eventId,
+      'title': title,
+      'startDate': startDate?.millisecondsSinceEpoch,
+      'endDate': endDate?.millisecondsSinceEpoch,
+      'description': description,
+      'location': location,
+      'isAllDay': isAllDay,
+      'timeZone': timeZone,
+    });
   }
 }

--- a/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
+++ b/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
@@ -135,6 +135,7 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
     bool isAllDay,
     String? description,
     String? location,
+    String? url,
     String? timeZone,
     String availability,
   ) async {
@@ -147,6 +148,7 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
           'isAllDay': isAllDay,
           'description': description,
           'location': location,
+          'url': url,
           'timeZone': timeZone,
           'availability': availability,
         });

--- a/packages/device_calendar_plus_android/lib/src/create_calendar_options_android.dart
+++ b/packages/device_calendar_plus_android/lib/src/create_calendar_options_android.dart
@@ -2,29 +2,60 @@ import 'package:device_calendar_plus_platform_interface/device_calendar_plus_pla
 
 /// Android-specific options for creating a calendar.
 ///
-/// Use this class to specify the account name for the calendar on Android.
-/// The calendar will be created under the local account type with the
-/// specified account name.
+/// Use this class to specify the account name and type for the calendar on
+/// Android. By default, calendars are created as local calendars that don't
+/// sync. To create a calendar that syncs with a cloud account (e.g., Google
+/// Calendar), specify both [accountName] and [accountType].
+///
+/// Use [DeviceCalendar.listSources] to discover available accounts and their
+/// types.
 ///
 /// Example:
 /// ```dart
+/// // Create a local calendar (no cloud sync)
 /// await plugin.createCalendar(
 ///   name: 'My Calendar',
 ///   platformOptions: CreateCalendarOptionsAndroid(accountName: 'MyApp'),
 /// );
+///
+/// // Create a calendar that syncs with Google Calendar
+/// await plugin.createCalendar(
+///   name: 'My Synced Calendar',
+///   platformOptions: CreateCalendarOptionsAndroid(
+///     accountName: 'user@gmail.com',
+///     accountType: 'com.google',
+///   ),
+/// );
 /// ```
 class CreateCalendarOptionsAndroid extends CreateCalendarPlatformOptions {
-  /// The account name for the local calendar.
+  /// The account name for the calendar.
   ///
   /// Calendars with the same account name will be grouped together
   /// in the device's calendar app.
   /// Defaults to "local" if not specified via platform options.
+  ///
+  /// For cloud sync, this should match an existing account on the device
+  /// (e.g., "user@gmail.com" for Google accounts).
   final String accountName;
+
+  /// The account type for the calendar.
+  ///
+  /// Common values:
+  /// - `null` (default): Local calendar, no sync (uses `ACCOUNT_TYPE_LOCAL`)
+  /// - `"com.google"`: Google Calendar sync
+  /// - `"com.microsoft.exchange"`: Exchange/Outlook sync
+  ///
+  /// When null, defaults to local account type (no cloud sync).
+  /// For cloud sync, use [DeviceCalendar.listSources] to find valid account
+  /// types.
+  final String? accountType;
 
   /// Creates Android-specific calendar creation options.
   ///
-  /// [accountName] is the account name for the local calendar.
+  /// [accountName] is the account name for the calendar.
+  /// [accountType] is the account type. When null, creates a local calendar.
   const CreateCalendarOptionsAndroid({
     required this.accountName,
+    this.accountType,
   });
 }

--- a/packages/device_calendar_plus_android/test/device_calendar_plus_android_test.dart
+++ b/packages/device_calendar_plus_android/test/device_calendar_plus_android_test.dart
@@ -16,93 +16,85 @@ void main() {
       log = <MethodCall>[];
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(plugin.methodChannel, (methodCall) async {
-        log.add(methodCall);
-        switch (methodCall.method) {
-          case 'requestPermissions':
-            return 'granted'; // CalendarPermissionStatus.granted
-          case 'hasPermissions':
-            return 'granted'; // CalendarPermissionStatus.granted
-          case 'openAppSettings':
-            return null;
-          case 'listCalendars':
-            return [
-              {
-                'id': '1',
-                'name': 'Work',
-                'readOnly': false,
-                'isPrimary': true,
-                'hidden': false,
-              }
-            ];
-          case 'createCalendar':
-            return 'android-calendar-id-456';
-          case 'updateCalendar':
-            return null;
-          case 'deleteCalendar':
-            return null;
-          case 'listEvents':
-            return [
-              {
-                'eventId': 'event1',
-                'calendarId': 'cal1',
-                'title': 'Test Event',
-                'startDate': DateTime.now().millisecondsSinceEpoch,
-                'endDate': DateTime.now().millisecondsSinceEpoch,
-                'isAllDay': false,
-                'availability': 'busy',
-                'status': 'confirmed',
-              }
-            ];
-          case 'createEvent':
-            return 'android-event-id-789';
-          case 'deleteEvent':
-            return null;
-          case 'updateEvent':
-            return null;
-          default:
-            return null;
-        }
-      });
+            log.add(methodCall);
+            switch (methodCall.method) {
+              case 'requestPermissions':
+                return 'granted'; // CalendarPermissionStatus.granted
+              case 'hasPermissions':
+                return 'granted'; // CalendarPermissionStatus.granted
+              case 'openAppSettings':
+                return null;
+              case 'listCalendars':
+                return [
+                  {
+                    'id': '1',
+                    'name': 'Work',
+                    'readOnly': false,
+                    'isPrimary': true,
+                    'hidden': false,
+                  },
+                ];
+              case 'createCalendar':
+                return 'android-calendar-id-456';
+              case 'updateCalendar':
+                return null;
+              case 'deleteCalendar':
+                return null;
+              case 'listEvents':
+                return [
+                  {
+                    'eventId': 'event1',
+                    'calendarId': 'cal1',
+                    'title': 'Test Event',
+                    'startDate': DateTime.now().millisecondsSinceEpoch,
+                    'endDate': DateTime.now().millisecondsSinceEpoch,
+                    'isAllDay': false,
+                    'availability': 'busy',
+                    'status': 'confirmed',
+                  },
+                ];
+              case 'createEvent':
+                return 'android-event-id-789';
+              case 'deleteEvent':
+                return null;
+              case 'updateEvent':
+                return null;
+              default:
+                return null;
+            }
+          });
     });
 
     test('can be registered', () {
       DeviceCalendarPlusAndroid.registerWith();
-      expect(DeviceCalendarPlusPlatform.instance,
-          isA<DeviceCalendarPlusAndroid>());
+      expect(
+        DeviceCalendarPlusPlatform.instance,
+        isA<DeviceCalendarPlusAndroid>(),
+      );
     });
 
     test('requestPermissions returns granted status', () async {
       final status = await plugin.requestPermissions();
-      expect(
-        log,
-        <Matcher>[isMethodCall('requestPermissions', arguments: null)],
-      );
+      expect(log, <Matcher>[
+        isMethodCall('requestPermissions', arguments: null),
+      ]);
       expect(status, equals('granted')); // CalendarPermissionStatus.granted
     });
 
     test('hasPermissions returns granted status', () async {
       final status = await plugin.hasPermissions();
-      expect(
-        log,
-        <Matcher>[isMethodCall('hasPermissions', arguments: null)],
-      );
+      expect(log, <Matcher>[isMethodCall('hasPermissions', arguments: null)]);
       expect(status, equals('granted')); // CalendarPermissionStatus.granted
     });
 
     test('openAppSettings calls method', () async {
       await plugin.openAppSettings();
-      expect(
-        log,
-        <Matcher>[isMethodCall('openAppSettings', arguments: null)],
-      );
+      expect(log, <Matcher>[isMethodCall('openAppSettings', arguments: null)]);
     });
 
     test('listCalendars returns list of calendars', () async {
       final calendars = await plugin.listCalendars();
-      expect(
-        log,
-        <Matcher>[isMethodCall('listCalendars', arguments: null)],
-      );
+      expect(log, <Matcher>[isMethodCall('listCalendars', arguments: null)]);
       expect(calendars, hasLength(1));
       expect(calendars[0]['id'], equals('1'));
       expect(calendars[0]['name'], equals('Work'));
@@ -120,8 +112,11 @@ void main() {
     });
 
     test('createCalendar with name and color', () async {
-      final calendarId =
-          await plugin.createCalendar('Work Calendar', '#FF5733', null);
+      final calendarId = await plugin.createCalendar(
+        'Work Calendar',
+        '#FF5733',
+        null,
+      );
 
       expect(log.length, equals(1));
       expect(log[0].method, equals('createCalendar'));
@@ -211,10 +206,14 @@ void main() {
       expect(log[0].method, equals('createEvent'));
       expect(log[0].arguments['calendarId'], equals('cal-123'));
       expect(log[0].arguments['title'], equals('Team Meeting'));
-      expect(log[0].arguments['startDate'],
-          equals(startDate.millisecondsSinceEpoch));
       expect(
-          log[0].arguments['endDate'], equals(endDate.millisecondsSinceEpoch));
+        log[0].arguments['startDate'],
+        equals(startDate.millisecondsSinceEpoch),
+      );
+      expect(
+        log[0].arguments['endDate'],
+        equals(endDate.millisecondsSinceEpoch),
+      );
       expect(log[0].arguments['isAllDay'], equals(false));
       expect(log[0].arguments['description'], equals('Weekly sync'));
       expect(log[0].arguments['location'], equals('Conference Room A'));
@@ -286,10 +285,14 @@ void main() {
       expect(log[0].method, equals('updateEvent'));
       expect(log[0].arguments['instanceId'], equals('event-123'));
       expect(log[0].arguments['title'], equals('Updated Title'));
-      expect(log[0].arguments['startDate'],
-          equals(startDate.millisecondsSinceEpoch));
       expect(
-          log[0].arguments['endDate'], equals(endDate.millisecondsSinceEpoch));
+        log[0].arguments['startDate'],
+        equals(startDate.millisecondsSinceEpoch),
+      );
+      expect(
+        log[0].arguments['endDate'],
+        equals(endDate.millisecondsSinceEpoch),
+      );
       expect(log[0].arguments['description'], equals('Updated description'));
       expect(log[0].arguments['location'], equals('Updated location'));
       expect(log[0].arguments['isAllDay'], equals(false));
@@ -297,10 +300,7 @@ void main() {
     });
 
     test('updateEvent with minimal parameters', () async {
-      await plugin.updateEvent(
-        'event-123',
-        title: 'New Title',
-      );
+      await plugin.updateEvent('event-123', title: 'New Title');
 
       expect(log.length, equals(1));
       expect(log[0].method, equals('updateEvent'));
@@ -316,10 +316,7 @@ void main() {
     });
 
     test('updateEvent for recurring event updates entire series', () async {
-      await plugin.updateEvent(
-        'event-123',
-        title: 'Updated Series',
-      );
+      await plugin.updateEvent('event-123', title: 'Updated Series');
 
       expect(log.length, equals(1));
       expect(log[0].method, equals('updateEvent'));

--- a/packages/device_calendar_plus_android/test/device_calendar_plus_android_test.dart
+++ b/packages/device_calendar_plus_android/test/device_calendar_plus_android_test.dart
@@ -198,6 +198,7 @@ void main() {
         false,
         'Weekly sync',
         'Conference Room A',
+        'https://example.com/meeting',
         'America/New_York',
         'busy',
       );
@@ -217,6 +218,7 @@ void main() {
       expect(log[0].arguments['isAllDay'], equals(false));
       expect(log[0].arguments['description'], equals('Weekly sync'));
       expect(log[0].arguments['location'], equals('Conference Room A'));
+      expect(log[0].arguments['url'], equals('https://example.com/meeting'));
       expect(log[0].arguments['timeZone'], equals('America/New_York'));
       expect(log[0].arguments['availability'], equals('busy'));
       expect(eventId, equals('android-event-id-789'));
@@ -235,6 +237,7 @@ void main() {
         null,
         null,
         null,
+        null,
         'free',
       );
 
@@ -245,6 +248,7 @@ void main() {
       expect(log[0].arguments['isAllDay'], equals(true));
       expect(log[0].arguments['description'], isNull);
       expect(log[0].arguments['location'], isNull);
+      expect(log[0].arguments['url'], isNull);
       expect(log[0].arguments['timeZone'], isNull);
       expect(log[0].arguments['availability'], equals('free'));
       expect(eventId, equals('android-event-id-789'));

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/CalendarService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/CalendarService.swift
@@ -8,7 +8,32 @@ class CalendarService {
     self.eventStore = eventStore
     self.permissionService = permissionService
   }
-  
+
+  func listSources(completion: @escaping (Result<[[String: Any]], CalendarError>) -> Void) {
+    // Check current permission status - listing sources requires full access (reading)
+    guard permissionService.hasPermission(for: .full) else {
+      completion(.failure(CalendarError(
+        code: PlatformExceptionCodes.permissionDenied,
+        message: "Calendar permission denied. Call requestPermissions() first."
+      )))
+      return
+    }
+
+    var sourceMaps: [[String: Any]] = []
+
+    for source in eventStore.sources {
+      let sourceMap: [String: Any] = [
+        "id": source.sourceIdentifier,
+        "title": source.title,
+        "type": sourceTypeToString(sourceType: source.sourceType),
+        "allowsCalendarCreation": source.sourceType != .subscribed && source.sourceType != .birthdays
+      ]
+      sourceMaps.append(sourceMap)
+    }
+
+    completion(.success(sourceMaps))
+  }
+
   func listCalendars(completion: @escaping (Result<[[String: Any]], CalendarError>) -> Void) {
     // Check current permission status - listing calendars requires full access (reading)
     guard permissionService.hasPermission(for: .full) else {
@@ -55,7 +80,7 @@ class CalendarService {
     completion(.success(calendarMaps))
   }
   
-  func createCalendar(name: String, colorHex: String?, completion: @escaping (Result<String, CalendarError>) -> Void) {
+  func createCalendar(name: String, colorHex: String?, sourceId: String?, sourceTitle: String?, completion: @escaping (Result<String, CalendarError>) -> Void) {
     // Check current permission status - creating calendars requires full access (writing)
     guard permissionService.hasPermission(for: .full) else {
       completion(.failure(CalendarError(
@@ -64,26 +89,39 @@ class CalendarService {
       )))
       return
     }
-    
-    // Find the local source - this is the only writable source for local calendars
-    guard let localSource = eventStore.sources.first(where: { $0.sourceType == .local }) else {
+
+    // Find the appropriate source
+    let source: EKSource?
+    if let sourceId = sourceId {
+      // Find by source ID
+      source = eventStore.sources.first { $0.sourceIdentifier == sourceId }
+    } else if let sourceTitle = sourceTitle {
+      // Find by source title
+      source = eventStore.sources.first { $0.title == sourceTitle }
+    } else {
+      // Default: try iCloud first, then fall back to local
+      source = eventStore.sources.first { $0.sourceType == .calDAV && $0.title == "iCloud" }
+        ?? eventStore.sources.first { $0.sourceType == .local }
+    }
+
+    guard let calendarSource = source else {
       completion(.failure(CalendarError(
         code: PlatformExceptionCodes.calendarUnavailable,
-        message: "Could not find local calendar source"
+        message: "Could not find calendar source"
       )))
       return
     }
-    
+
     // Create a new calendar
     let calendar = EKCalendar(for: .event, eventStore: eventStore)
-    calendar.source = localSource
+    calendar.source = calendarSource
     calendar.title = name
-    
+
     // Set color if provided
     if let colorHex = colorHex {
       calendar.cgColor = ColorHelper.hexToColor(hex: colorHex)
     }
-    
+
     // Save the calendar
     do {
       try eventStore.saveCalendar(calendar, commit: true)

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
@@ -412,12 +412,13 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     // Parse optional parameters
     let description = args["description"] as? String
     let location = args["location"] as? String
+    let url = args["url"] as? String
     let timeZone = args["timeZone"] as? String
-    
+
     // Convert dates
     let startDate = Date(timeIntervalSince1970: TimeInterval(startDateMillis) / 1000.0)
     let endDate = Date(timeIntervalSince1970: TimeInterval(endDateMillis) / 1000.0)
-    
+
     eventsService.createEvent(
       calendarId: calendarId,
       title: title,
@@ -426,6 +427,7 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
       isAllDay: isAllDay,
       description: description,
       location: location,
+      url: url,
       timeZone: timeZone,
       availability: availability
     ) { serviceResult in

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
@@ -24,6 +24,8 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
       handleHasPermissions(result: result)
     case "openAppSettings":
       handleOpenAppSettings(result: result)
+    case "listSources":
+      handleListSources(result: result)
     case "listCalendars":
       handleListCalendars(result: result)
     case "createCalendar":
@@ -103,6 +105,19 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     }
   }
   
+  private func handleListSources(result: @escaping FlutterResult) {
+    calendarService.listSources { serviceResult in
+      DispatchQueue.main.async {
+        switch serviceResult {
+        case .success(let sources):
+          result(sources)
+        case .failure(let error):
+          result(FlutterError(code: error.code, message: error.message, details: nil))
+        }
+      }
+    }
+  }
+
   private func handleListCalendars(result: @escaping FlutterResult) {
     calendarService.listCalendars { serviceResult in
       DispatchQueue.main.async {
@@ -115,7 +130,7 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
       }
     }
   }
-  
+
   private func handleCreateCalendar(call: FlutterMethodCall, result: @escaping FlutterResult) {
     guard let args = call.arguments as? [String: Any] else {
       result(FlutterError(
@@ -125,7 +140,7 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
       ))
       return
     }
-    
+
     // Parse name (required)
     guard let name = args["name"] as? String else {
       result(FlutterError(
@@ -135,11 +150,15 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
       ))
       return
     }
-    
+
     // Parse colorHex (optional)
     let colorHex = args["colorHex"] as? String
-    
-    calendarService.createCalendar(name: name, colorHex: colorHex) { serviceResult in
+
+    // Parse source params (optional)
+    let sourceId = args["sourceId"] as? String
+    let sourceTitle = args["sourceTitle"] as? String
+
+    calendarService.createCalendar(name: name, colorHex: colorHex, sourceId: sourceId, sourceTitle: sourceTitle) { serviceResult in
       DispatchQueue.main.async {
         switch serviceResult {
         case .success(let calendarId):

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -121,7 +121,11 @@ class EventsService {
     if let location = event.location {
       eventMap["location"] = location
     }
-    
+
+    if let url = event.url {
+      eventMap["url"] = url.absoluteString
+    }
+
     // Convert dates to milliseconds since epoch
     var startDate = event.startDate!
     var endDate = event.endDate!
@@ -291,6 +295,7 @@ class EventsService {
     isAllDay: Bool,
     description: String?,
     location: String?,
+    url: String?,
     timeZone: String?,
     availability: String,
     completion: @escaping (Result<String, CalendarError>) -> Void
@@ -329,7 +334,11 @@ class EventsService {
     if let location = location {
       event.location = location
     }
-    
+
+    if let urlString = url, let eventUrl = URL(string: urlString) {
+      event.url = eventUrl
+    }
+
     // Set timezone (nil for all-day events)
     if !isAllDay, let timeZoneIdentifier = timeZone {
       event.timeZone = TimeZone(identifier: timeZoneIdentifier)

--- a/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
+++ b/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
@@ -135,6 +135,7 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
     bool isAllDay,
     String? description,
     String? location,
+    String? url,
     String? timeZone,
     String availability,
   ) async {
@@ -147,6 +148,7 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
           'isAllDay': isAllDay,
           'description': description,
           'location': location,
+          'url': url,
           'timeZone': timeZone,
           'availability': availability,
         });

--- a/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
+++ b/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
@@ -2,6 +2,10 @@ import 'package:device_calendar_plus_platform_interface/device_calendar_plus_pla
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+import 'src/create_calendar_options_ios.dart';
+
+export 'src/create_calendar_options_ios.dart';
+
 /// The iOS implementation of [DeviceCalendarPlusPlatform].
 class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
   /// The method channel used to interact with the native platform.
@@ -29,9 +33,19 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
   }
 
   @override
+  Future<List<Map<String, dynamic>>> listSources() async {
+    final result = await methodChannel.invokeMethod<List<dynamic>>(
+      'listSources',
+    );
+    return result?.map((e) => Map<String, dynamic>.from(e as Map)).toList() ??
+        [];
+  }
+
+  @override
   Future<List<Map<String, dynamic>>> listCalendars() async {
-    final result =
-        await methodChannel.invokeMethod<List<dynamic>>('listCalendars');
+    final result = await methodChannel.invokeMethod<List<dynamic>>(
+      'listCalendars',
+    );
     return result?.map((e) => Map<String, dynamic>.from(e as Map)).toList() ??
         [];
   }
@@ -42,37 +56,41 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
     String? colorHex,
     CreateCalendarPlatformOptions? platformOptions,
   ) async {
-    // iOS does not support platform-specific options for calendar creation
-    // platformOptions is ignored
-    final result = await methodChannel.invokeMethod<String>(
-      'createCalendar',
-      <String, dynamic>{
-        'name': name,
-        'colorHex': colorHex,
-      },
-    );
+    String? sourceId;
+    String? sourceTitle;
+    if (platformOptions is CreateCalendarOptionsIos) {
+      sourceId = platformOptions.sourceId;
+      sourceTitle = platformOptions.sourceTitle;
+    }
+
+    final result = await methodChannel
+        .invokeMethod<String>('createCalendar', <String, dynamic>{
+          'name': name,
+          'colorHex': colorHex,
+          'sourceId': sourceId,
+          'sourceTitle': sourceTitle,
+        });
     return result!;
   }
 
   @override
   Future<void> updateCalendar(
-      String calendarId, String? name, String? colorHex) async {
-    await methodChannel.invokeMethod<void>(
-      'updateCalendar',
-      <String, dynamic>{
-        'calendarId': calendarId,
-        'name': name,
-        'colorHex': colorHex,
-      },
-    );
+    String calendarId,
+    String? name,
+    String? colorHex,
+  ) async {
+    await methodChannel.invokeMethod<void>('updateCalendar', <String, dynamic>{
+      'calendarId': calendarId,
+      'name': name,
+      'colorHex': colorHex,
+    });
   }
 
   @override
   Future<void> deleteCalendar(String calendarId) async {
-    await methodChannel.invokeMethod<void>(
-      'deleteCalendar',
-      <String, dynamic>{'calendarId': calendarId},
-    );
+    await methodChannel.invokeMethod<void>('deleteCalendar', <String, dynamic>{
+      'calendarId': calendarId,
+    });
   }
 
   @override
@@ -81,14 +99,12 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
     DateTime endDate,
     List<String>? calendarIds,
   ) async {
-    final result = await methodChannel.invokeMethod<List<dynamic>>(
-      'listEvents',
-      <String, dynamic>{
-        'startDate': startDate.millisecondsSinceEpoch,
-        'endDate': endDate.millisecondsSinceEpoch,
-        'calendarIds': calendarIds,
-      },
-    );
+    final result = await methodChannel
+        .invokeMethod<List<dynamic>>('listEvents', <String, dynamic>{
+          'startDate': startDate.millisecondsSinceEpoch,
+          'endDate': endDate.millisecondsSinceEpoch,
+          'calendarIds': calendarIds,
+        });
     return result?.map((e) => Map<String, dynamic>.from(e as Map)).toList() ??
         [];
   }
@@ -97,23 +113,17 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
   Future<Map<String, dynamic>?> getEvent(String eventId, int? timestamp) async {
     final result = await methodChannel.invokeMethod<Map<dynamic, dynamic>>(
       'getEvent',
-      <String, dynamic>{
-        'eventId': eventId,
-        'timestamp': timestamp,
-      },
+      <String, dynamic>{'eventId': eventId, 'timestamp': timestamp},
     );
     return result != null ? Map<String, dynamic>.from(result) : null;
   }
 
   @override
   Future<void> showEventModal(String eventId, int? timestamp) async {
-    await methodChannel.invokeMethod<void>(
-      'showEventModal',
-      <String, dynamic>{
-        'eventId': eventId,
-        'timestamp': timestamp,
-      },
-    );
+    await methodChannel.invokeMethod<void>('showEventModal', <String, dynamic>{
+      'eventId': eventId,
+      'timestamp': timestamp,
+    });
   }
 
   @override
@@ -128,31 +138,26 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
     String? timeZone,
     String availability,
   ) async {
-    final result = await methodChannel.invokeMethod<String>(
-      'createEvent',
-      <String, dynamic>{
-        'calendarId': calendarId,
-        'title': title,
-        'startDate': startDate.millisecondsSinceEpoch,
-        'endDate': endDate.millisecondsSinceEpoch,
-        'isAllDay': isAllDay,
-        'description': description,
-        'location': location,
-        'timeZone': timeZone,
-        'availability': availability,
-      },
-    );
+    final result = await methodChannel
+        .invokeMethod<String>('createEvent', <String, dynamic>{
+          'calendarId': calendarId,
+          'title': title,
+          'startDate': startDate.millisecondsSinceEpoch,
+          'endDate': endDate.millisecondsSinceEpoch,
+          'isAllDay': isAllDay,
+          'description': description,
+          'location': location,
+          'timeZone': timeZone,
+          'availability': availability,
+        });
     return result!;
   }
 
   @override
   Future<void> deleteEvent(String eventId) async {
-    await methodChannel.invokeMethod<void>(
-      'deleteEvent',
-      <String, dynamic>{
-        'eventId': eventId,
-      },
-    );
+    await methodChannel.invokeMethod<void>('deleteEvent', <String, dynamic>{
+      'eventId': eventId,
+    });
   }
 
   @override
@@ -166,18 +171,15 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
     bool? isAllDay,
     String? timeZone,
   }) async {
-    await methodChannel.invokeMethod<void>(
-      'updateEvent',
-      <String, dynamic>{
-        'eventId': eventId,
-        'title': title,
-        'startDate': startDate?.millisecondsSinceEpoch,
-        'endDate': endDate?.millisecondsSinceEpoch,
-        'description': description,
-        'location': location,
-        'isAllDay': isAllDay,
-        'timeZone': timeZone,
-      },
-    );
+    await methodChannel.invokeMethod<void>('updateEvent', <String, dynamic>{
+      'eventId': eventId,
+      'title': title,
+      'startDate': startDate?.millisecondsSinceEpoch,
+      'endDate': endDate?.millisecondsSinceEpoch,
+      'description': description,
+      'location': location,
+      'isAllDay': isAllDay,
+      'timeZone': timeZone,
+    });
   }
 }

--- a/packages/device_calendar_plus_ios/lib/src/create_calendar_options_ios.dart
+++ b/packages/device_calendar_plus_ios/lib/src/create_calendar_options_ios.dart
@@ -1,0 +1,58 @@
+import 'package:device_calendar_plus_platform_interface/device_calendar_plus_platform_interface.dart';
+
+/// iOS-specific options for creating a calendar.
+///
+/// Use this class to specify which calendar source to create the calendar in.
+/// By default, calendars are created in the local source. To create a calendar
+/// that syncs with iCloud, specify a source with `sourceTitle: 'iCloud'` or
+/// use the source ID from [DeviceCalendar.listSources].
+///
+/// Use [DeviceCalendar.listSources] to discover available sources.
+///
+/// Example:
+/// ```dart
+/// // Create a local calendar (default behavior)
+/// await plugin.createCalendar(name: 'My Calendar');
+///
+/// // Create a calendar that syncs with iCloud
+/// await plugin.createCalendar(
+///   name: 'My iCloud Calendar',
+///   platformOptions: CreateCalendarOptionsIos(sourceTitle: 'iCloud'),
+/// );
+///
+/// // Create a calendar using a specific source ID
+/// final sources = await plugin.listSources();
+/// final icloudSource = sources.firstWhere((s) => s.title == 'iCloud');
+/// await plugin.createCalendar(
+///   name: 'My Calendar',
+///   platformOptions: CreateCalendarOptionsIos(sourceId: icloudSource.id),
+/// );
+/// ```
+///
+/// **Known Limitation**: Google accounts on iOS may not allow programmatic
+/// calendar creation. The error "That account does not allow calendars to be
+/// added or removed" has been reported. For iOS, using iCloud is recommended.
+class CreateCalendarOptionsIos extends CreateCalendarPlatformOptions {
+  /// The source identifier to create the calendar in.
+  ///
+  /// This takes precedence over [sourceTitle] if both are provided.
+  /// Get valid source IDs from [DeviceCalendar.listSources].
+  final String? sourceId;
+
+  /// The source title to search for (e.g., "iCloud").
+  ///
+  /// If [sourceId] is not provided, the plugin will search for a source
+  /// with this title. This is a convenience method for common sources.
+  ///
+  /// Common values:
+  /// - `"iCloud"` - Apple's iCloud calendar sync
+  /// - `"On My iPhone"` or `"On My iPad"` - Local device storage
+  final String? sourceTitle;
+
+  /// Creates iOS-specific calendar creation options.
+  ///
+  /// At least one of [sourceId] or [sourceTitle] should be provided.
+  /// If neither is provided, the default behavior is to try iCloud first,
+  /// then fall back to local storage.
+  const CreateCalendarOptionsIos({this.sourceId, this.sourceTitle});
+}

--- a/packages/device_calendar_plus_ios/test/device_calendar_plus_ios_test.dart
+++ b/packages/device_calendar_plus_ios/test/device_calendar_plus_ios_test.dart
@@ -16,53 +16,53 @@ void main() {
       log = <MethodCall>[];
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(plugin.methodChannel, (methodCall) async {
-        log.add(methodCall);
-        switch (methodCall.method) {
-          case 'requestPermissions':
-            return 'granted'; // CalendarPermissionStatus.granted
-          case 'hasPermissions':
-            return 'granted'; // CalendarPermissionStatus.granted
-          case 'openAppSettings':
-            return null;
-          case 'listCalendars':
-            return [
-              {
-                'id': '1',
-                'name': 'Work',
-                'readOnly': false,
-                'isPrimary': true,
-                'hidden': false,
-              }
-            ];
-          case 'createCalendar':
-            return 'test-calendar-id-123';
-          case 'updateCalendar':
-            return null;
-          case 'deleteCalendar':
-            return null;
-          case 'listEvents':
-            return [
-              {
-                'eventId': 'event1',
-                'calendarId': 'cal1',
-                'title': 'Test Event',
-                'startDate': DateTime.now().millisecondsSinceEpoch,
-                'endDate': DateTime.now().millisecondsSinceEpoch,
-                'isAllDay': false,
-                'availability': 'busy',
-                'status': 'confirmed',
-              }
-            ];
-          case 'createEvent':
-            return 'ios-event-id-456';
-          case 'deleteEvent':
-            return null;
-          case 'updateEvent':
-            return null;
-          default:
-            return null;
-        }
-      });
+            log.add(methodCall);
+            switch (methodCall.method) {
+              case 'requestPermissions':
+                return 'granted'; // CalendarPermissionStatus.granted
+              case 'hasPermissions':
+                return 'granted'; // CalendarPermissionStatus.granted
+              case 'openAppSettings':
+                return null;
+              case 'listCalendars':
+                return [
+                  {
+                    'id': '1',
+                    'name': 'Work',
+                    'readOnly': false,
+                    'isPrimary': true,
+                    'hidden': false,
+                  },
+                ];
+              case 'createCalendar':
+                return 'test-calendar-id-123';
+              case 'updateCalendar':
+                return null;
+              case 'deleteCalendar':
+                return null;
+              case 'listEvents':
+                return [
+                  {
+                    'eventId': 'event1',
+                    'calendarId': 'cal1',
+                    'title': 'Test Event',
+                    'startDate': DateTime.now().millisecondsSinceEpoch,
+                    'endDate': DateTime.now().millisecondsSinceEpoch,
+                    'isAllDay': false,
+                    'availability': 'busy',
+                    'status': 'confirmed',
+                  },
+                ];
+              case 'createEvent':
+                return 'ios-event-id-456';
+              case 'deleteEvent':
+                return null;
+              case 'updateEvent':
+                return null;
+              default:
+                return null;
+            }
+          });
     });
 
     test('can be registered', () {
@@ -72,36 +72,26 @@ void main() {
 
     test('requestPermissions returns granted status', () async {
       final status = await plugin.requestPermissions();
-      expect(
-        log,
-        <Matcher>[isMethodCall('requestPermissions', arguments: null)],
-      );
+      expect(log, <Matcher>[
+        isMethodCall('requestPermissions', arguments: null),
+      ]);
       expect(status, equals('granted')); // CalendarPermissionStatus.granted
     });
 
     test('hasPermissions returns granted status', () async {
       final status = await plugin.hasPermissions();
-      expect(
-        log,
-        <Matcher>[isMethodCall('hasPermissions', arguments: null)],
-      );
+      expect(log, <Matcher>[isMethodCall('hasPermissions', arguments: null)]);
       expect(status, equals('granted')); // CalendarPermissionStatus.granted
     });
 
     test('openAppSettings calls method', () async {
       await plugin.openAppSettings();
-      expect(
-        log,
-        <Matcher>[isMethodCall('openAppSettings', arguments: null)],
-      );
+      expect(log, <Matcher>[isMethodCall('openAppSettings', arguments: null)]);
     });
 
     test('listCalendars returns list of calendars', () async {
       final calendars = await plugin.listCalendars();
-      expect(
-        log,
-        <Matcher>[isMethodCall('listCalendars', arguments: null)],
-      );
+      expect(log, <Matcher>[isMethodCall('listCalendars', arguments: null)]);
       expect(calendars, hasLength(1));
       expect(calendars[0]['id'], equals('1'));
       expect(calendars[0]['name'], equals('Work'));
@@ -118,8 +108,11 @@ void main() {
     });
 
     test('createCalendar with name and color', () async {
-      final calendarId =
-          await plugin.createCalendar('Work Calendar', '#FF5733', null);
+      final calendarId = await plugin.createCalendar(
+        'Work Calendar',
+        '#FF5733',
+        null,
+      );
 
       expect(log.length, equals(1));
       expect(log[0].method, equals('createCalendar'));
@@ -193,10 +186,14 @@ void main() {
       expect(log[0].method, equals('createEvent'));
       expect(log[0].arguments['calendarId'], equals('cal-123'));
       expect(log[0].arguments['title'], equals('Team Meeting'));
-      expect(log[0].arguments['startDate'],
-          equals(startDate.millisecondsSinceEpoch));
       expect(
-          log[0].arguments['endDate'], equals(endDate.millisecondsSinceEpoch));
+        log[0].arguments['startDate'],
+        equals(startDate.millisecondsSinceEpoch),
+      );
+      expect(
+        log[0].arguments['endDate'],
+        equals(endDate.millisecondsSinceEpoch),
+      );
       expect(log[0].arguments['isAllDay'], equals(false));
       expect(log[0].arguments['description'], equals('Weekly sync'));
       expect(log[0].arguments['location'], equals('Conference Room A'));
@@ -268,10 +265,14 @@ void main() {
       expect(log[0].method, equals('updateEvent'));
       expect(log[0].arguments['instanceId'], equals('event-123'));
       expect(log[0].arguments['title'], equals('Updated Title'));
-      expect(log[0].arguments['startDate'],
-          equals(startDate.millisecondsSinceEpoch));
       expect(
-          log[0].arguments['endDate'], equals(endDate.millisecondsSinceEpoch));
+        log[0].arguments['startDate'],
+        equals(startDate.millisecondsSinceEpoch),
+      );
+      expect(
+        log[0].arguments['endDate'],
+        equals(endDate.millisecondsSinceEpoch),
+      );
       expect(log[0].arguments['description'], equals('Updated description'));
       expect(log[0].arguments['location'], equals('Updated location'));
       expect(log[0].arguments['isAllDay'], equals(false));
@@ -279,10 +280,7 @@ void main() {
     });
 
     test('updateEvent with minimal parameters', () async {
-      await plugin.updateEvent(
-        'event-123',
-        title: 'New Title',
-      );
+      await plugin.updateEvent('event-123', title: 'New Title');
 
       expect(log.length, equals(1));
       expect(log[0].method, equals('updateEvent'));
@@ -298,10 +296,7 @@ void main() {
     });
 
     test('updateEvent for recurring event updates entire series', () async {
-      await plugin.updateEvent(
-        'event-123',
-        title: 'Updated Series',
-      );
+      await plugin.updateEvent('event-123', title: 'Updated Series');
 
       expect(log.length, equals(1));
       expect(log[0].method, equals('updateEvent'));

--- a/packages/device_calendar_plus_ios/test/device_calendar_plus_ios_test.dart
+++ b/packages/device_calendar_plus_ios/test/device_calendar_plus_ios_test.dart
@@ -178,6 +178,7 @@ void main() {
         false,
         'Weekly sync',
         'Conference Room A',
+        'https://example.com/meeting',
         'America/New_York',
         'busy',
       );
@@ -197,6 +198,7 @@ void main() {
       expect(log[0].arguments['isAllDay'], equals(false));
       expect(log[0].arguments['description'], equals('Weekly sync'));
       expect(log[0].arguments['location'], equals('Conference Room A'));
+      expect(log[0].arguments['url'], equals('https://example.com/meeting'));
       expect(log[0].arguments['timeZone'], equals('America/New_York'));
       expect(log[0].arguments['availability'], equals('busy'));
       expect(eventId, equals('ios-event-id-456'));
@@ -215,6 +217,7 @@ void main() {
         null,
         null,
         null,
+        null,
         'free',
       );
 
@@ -225,6 +228,7 @@ void main() {
       expect(log[0].arguments['isAllDay'], equals(true));
       expect(log[0].arguments['description'], isNull);
       expect(log[0].arguments['location'], isNull);
+      expect(log[0].arguments['url'], isNull);
       expect(log[0].arguments['timeZone'], isNull);
       expect(log[0].arguments['availability'], equals('free'));
       expect(eventId, equals('ios-event-id-456'));

--- a/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
+++ b/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
@@ -159,6 +159,7 @@ abstract class DeviceCalendarPlusPlatform extends PlatformInterface {
   /// [isAllDay] indicates if this is an all-day event.
   /// [description] is optional event notes/description.
   /// [location] is optional event location.
+  /// [url] is optional URL associated with the event.
   /// [timeZone] is optional timezone identifier (null for all-day events).
   /// [availability] is the availability status (busy, free, tentative, unavailable).
   ///
@@ -172,6 +173,7 @@ abstract class DeviceCalendarPlusPlatform extends PlatformInterface {
     bool isAllDay,
     String? description,
     String? location,
+    String? url,
     String? timeZone,
     String availability,
   );

--- a/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
+++ b/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
@@ -67,6 +67,16 @@ abstract class DeviceCalendarPlusPlatform extends PlatformInterface {
   /// On Android, opens the app info page where users can navigate to permissions.
   Future<void> openAppSettings();
 
+  /// Lists all calendar sources/accounts available on the device.
+  ///
+  /// Returns a list of source data as maps. The main API layer
+  /// converts these to [CalendarSource] objects.
+  ///
+  /// On iOS, returns `EKSource` objects from EventKit.
+  /// On Android, returns unique account name + account type combinations
+  /// from the Calendar Provider.
+  Future<List<Map<String, dynamic>>> listSources();
+
   /// Lists all calendars available on the device.
   ///
   /// Returns a list of calendar data as maps. The main API layer
@@ -100,7 +110,10 @@ abstract class DeviceCalendarPlusPlatform extends PlatformInterface {
   /// At least one of [name] or [colorHex] must be provided.
   /// Requires calendar write permissions.
   Future<void> updateCalendar(
-      String calendarId, String? name, String? colorHex);
+    String calendarId,
+    String? name,
+    String? colorHex,
+  );
 
   /// Deletes a calendar from the device.
   ///

--- a/packages/device_calendar_plus_platform_interface/lib/src/create_calendar_options.dart
+++ b/packages/device_calendar_plus_platform_interface/lib/src/create_calendar_options.dart
@@ -5,7 +5,7 @@
 ///
 /// Platform-specific implementations append the platform name:
 /// - Android: [CreateCalendarOptionsAndroid]
-/// - iOS: (not yet implemented)
+/// - iOS: [CreateCalendarOptionsIos]
 ///
 /// Example:
 /// ```dart

--- a/packages/device_calendar_plus_platform_interface/test/device_calendar_plus_platform_interface_test.dart
+++ b/packages/device_calendar_plus_platform_interface/test/device_calendar_plus_platform_interface_test.dart
@@ -14,6 +14,9 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
   Future<void> openAppSettings() async {}
 
   @override
+  Future<List<Map<String, dynamic>>> listSources() async => [];
+
+  @override
   Future<List<Map<String, dynamic>>> listCalendars() async => [];
 
   @override
@@ -21,12 +24,14 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     String name,
     String? colorHex,
     CreateCalendarPlatformOptions? platformOptions,
-  ) async =>
-      'mock-calendar-id';
+  ) async => 'mock-calendar-id';
 
   @override
   Future<void> updateCalendar(
-      String calendarId, String? name, String? colorHex) async {}
+    String calendarId,
+    String? name,
+    String? colorHex,
+  ) async {}
 
   @override
   Future<void> deleteCalendar(String calendarId) async {}
@@ -36,13 +41,13 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     DateTime startDate,
     DateTime endDate,
     List<String>? calendarIds,
-  ) async =>
-      [];
+  ) async => [];
 
   @override
   Future<Map<String, dynamic>?> getEvent(
-          String eventId, int? timestamp) async =>
-      null;
+    String eventId,
+    int? timestamp,
+  ) async => null;
 
   @override
   Future<void> showEventModal(String eventId, int? timestamp) async {}
@@ -58,8 +63,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     String? location,
     String? timeZone,
     String availability,
-  ) async =>
-      'mock-event-id';
+  ) async => 'mock-event-id';
 
   @override
   Future<void> deleteEvent(String eventId) async {}
@@ -87,15 +91,19 @@ void main() {
   test('requestPermissions returns expected value', () async {
     final mock = MockDeviceCalendarPlusPlatform();
     DeviceCalendarPlusPlatform.instance = mock;
-    expect(await DeviceCalendarPlusPlatform.instance.requestPermissions(),
-        'granted');
+    expect(
+      await DeviceCalendarPlusPlatform.instance.requestPermissions(),
+      'granted',
+    );
   });
 
   test('hasPermissions returns expected value', () async {
     final mock = MockDeviceCalendarPlusPlatform();
     DeviceCalendarPlusPlatform.instance = mock;
     expect(
-        await DeviceCalendarPlusPlatform.instance.hasPermissions(), 'granted');
+      await DeviceCalendarPlusPlatform.instance.hasPermissions(),
+      'granted',
+    );
   });
 
   test('openAppSettings completes successfully', () async {
@@ -114,16 +122,22 @@ void main() {
   test('createCalendar returns expected value', () async {
     final mock = MockDeviceCalendarPlusPlatform();
     DeviceCalendarPlusPlatform.instance = mock;
-    final calendarId = await DeviceCalendarPlusPlatform.instance
-        .createCalendar('Test Calendar', '#FF5733', null);
+    final calendarId = await DeviceCalendarPlusPlatform.instance.createCalendar(
+      'Test Calendar',
+      '#FF5733',
+      null,
+    );
     expect(calendarId, equals('mock-calendar-id'));
   });
 
   test('updateCalendar completes', () async {
     final mock = MockDeviceCalendarPlusPlatform();
     DeviceCalendarPlusPlatform.instance = mock;
-    await DeviceCalendarPlusPlatform.instance
-        .updateCalendar('calendar-123', 'New Name', '#00FF00');
+    await DeviceCalendarPlusPlatform.instance.updateCalendar(
+      'calendar-123',
+      'New Name',
+      '#00FF00',
+    );
     // Should complete without error
   });
 
@@ -148,8 +162,10 @@ void main() {
   test('getEvent returns expected value', () async {
     final mock = MockDeviceCalendarPlusPlatform();
     DeviceCalendarPlusPlatform.instance = mock;
-    final result =
-        await DeviceCalendarPlusPlatform.instance.getEvent('event-123', null);
+    final result = await DeviceCalendarPlusPlatform.instance.getEvent(
+      'event-123',
+      null,
+    );
     expect(result, null);
   });
 
@@ -187,8 +203,9 @@ void main() {
   test('deleteEvent for recurring event deletes entire series', () async {
     final mock = MockDeviceCalendarPlusPlatform();
     DeviceCalendarPlusPlatform.instance = mock;
-    await DeviceCalendarPlusPlatform.instance
-        .deleteEvent('event-123@123456789');
+    await DeviceCalendarPlusPlatform.instance.deleteEvent(
+      'event-123@123456789',
+    );
     // Should complete without error
   });
 

--- a/packages/device_calendar_plus_platform_interface/test/device_calendar_plus_platform_interface_test.dart
+++ b/packages/device_calendar_plus_platform_interface/test/device_calendar_plus_platform_interface_test.dart
@@ -61,6 +61,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     bool isAllDay,
     String? description,
     String? location,
+    String? url,
     String? timeZone,
     String availability,
   ) async => 'mock-event-id';
@@ -187,6 +188,7 @@ void main() {
       false,
       'Weekly team sync',
       'Conference Room A',
+      'https://example.com/meeting',
       'America/New_York',
       'busy',
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -238,18 +238,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   melos:
     dependency: "direct dev"
     description:
@@ -403,10 +403,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -464,5 +464,5 @@ packages:
     source: hosted
     version: "2.2.2"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
- Add listSources() to discover available calendar accounts/sources
- Add CalendarSource model with id, title, type, allowsCalendarCreation
- Add accountType parameter to CreateCalendarOptionsAndroid for Google sync
- Add CreateCalendarOptionsIos with sourceId/sourceTitle for iCloud sync
- iOS defaults to iCloud if available, falls back to local
- Android defaults to ACCOUNT_TYPE_LOCAL for backward compatibility