### PR TITLE
Fix Android background calendar access by using Application Context

### DIFF
--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
@@ -1,12 +1,12 @@
 package to.bullet.device_calendar_plus_android
 
 import android.Manifest
-import android.app.Activity
+import android.content.Context
 import android.content.pm.PackageManager
 import android.provider.CalendarContract
 import androidx.core.content.ContextCompat
 
-class CalendarService(private val activity: Activity) {
+class CalendarService(private val context: Context) {
     
     fun listCalendars(): Result<List<Map<String, Any>>> {
         val calendars = mutableListOf<Map<String, Any>>()
@@ -23,7 +23,7 @@ class CalendarService(private val activity: Activity) {
         )
         
         try {
-            activity.contentResolver.query(
+            context.contentResolver.query(
                 CalendarContract.Calendars.CONTENT_URI,
                 projection,
                 null,
@@ -91,7 +91,7 @@ class CalendarService(private val activity: Activity) {
     
     fun createCalendar(name: String, colorHex: String?, accountNameParam: String?): Result<String> {
         // Check for write calendar permission
-        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.WRITE_CALENDAR) 
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_CALENDAR)
             != PackageManager.PERMISSION_GRANTED) {
             return Result.failure(
                 CalendarException(
@@ -123,7 +123,7 @@ class CalendarService(private val activity: Activity) {
                 }
             }
             
-            val uri = activity.contentResolver.insert(
+            val uri = context.contentResolver.insert(
                 CalendarContract.Calendars.CONTENT_URI
                     .buildUpon()
                     .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
@@ -165,7 +165,7 @@ class CalendarService(private val activity: Activity) {
     
     fun updateCalendar(calendarId: String, name: String?, colorHex: String?): Result<Unit> {
         // Check for write calendar permission
-        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.WRITE_CALENDAR) 
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_CALENDAR)
             != PackageManager.PERMISSION_GRANTED) {
             return Result.failure(
                 CalendarException(
@@ -192,7 +192,7 @@ class CalendarService(private val activity: Activity) {
             }
             
             // Update the calendar
-            val updatedRows = activity.contentResolver.update(
+            val updatedRows = context.contentResolver.update(
                 CalendarContract.Calendars.CONTENT_URI,
                 values,
                 "${CalendarContract.Calendars._ID} = ?",
@@ -228,7 +228,7 @@ class CalendarService(private val activity: Activity) {
     
     fun deleteCalendar(calendarId: String): Result<Unit> {
         // Check for write calendar permission
-        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.WRITE_CALENDAR) 
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_CALENDAR)
             != PackageManager.PERMISSION_GRANTED) {
             return Result.failure(
                 CalendarException(
@@ -239,7 +239,7 @@ class CalendarService(private val activity: Activity) {
         }
         
         try {
-            val deletedRows = activity.contentResolver.delete(
+            val deletedRows = context.contentResolver.delete(
                 CalendarContract.Calendars.CONTENT_URI,
                 "${CalendarContract.Calendars._ID} = ?",
                 arrayOf(calendarId)

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
@@ -32,6 +32,10 @@ class DeviceCalendarPlusAndroidPlugin :
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "device_calendar_plus_android")
         channel.setMethodCallHandler(this)
+
+        val appContext = flutterPluginBinding.applicationContext
+        calendarService = CalendarService(appContext)
+        eventsService = EventsService(appContext)
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {
@@ -466,13 +470,13 @@ class DeviceCalendarPlusAndroidPlugin :
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
+        calendarService = null
+        eventsService = null
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
         activity = binding.activity
         permissionService = PermissionService(binding.activity)
-        calendarService = CalendarService(binding.activity)
-        eventsService = EventsService(binding.activity)
         binding.addRequestPermissionsResultListener(this)
         binding.addActivityResultListener(this)
     }
@@ -480,16 +484,12 @@ class DeviceCalendarPlusAndroidPlugin :
     override fun onDetachedFromActivityForConfigChanges() {
         activity = null
         permissionService = null
-        calendarService = null
-        eventsService = null
         showEventModalResult = null
     }
 
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
         activity = binding.activity
         permissionService = PermissionService(binding.activity)
-        calendarService = CalendarService(binding.activity)
-        eventsService = EventsService(binding.activity)
         binding.addRequestPermissionsResultListener(this)
         binding.addActivityResultListener(this)
     }
@@ -497,8 +497,6 @@ class DeviceCalendarPlusAndroidPlugin :
     override fun onDetachedFromActivity() {
         activity = null
         permissionService = null
-        calendarService = null
-        eventsService = null
         showEventModalResult = null
     }
 }

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -1,12 +1,12 @@
 package to.bullet.device_calendar_plus_android
 
 import android.app.Activity
-import android.content.ContentUris
+import android.content.Context
 import android.content.Intent
 import android.provider.CalendarContract
 import java.util.Date
 
-class EventsService(private val activity: Activity) {
+class EventsService(private val context: Context) {
     
     fun retrieveEvents(
         startDate: Date,
@@ -60,7 +60,7 @@ class EventsService(private val activity: Activity) {
         val selectionArgs = if (args.isNotEmpty()) args.toTypedArray() else null
         
         try {
-            activity.contentResolver.query(
+            context.contentResolver.query(
                 uri,
                 projection,
                 selection,
@@ -287,7 +287,7 @@ class EventsService(private val activity: Activity) {
             val selectionArgs = arrayOf(eventId)
             
             try {
-                activity.contentResolver.query(
+                context.contentResolver.query(
                     CalendarContract.Events.CONTENT_URI,
                     projection,
                     selection,
@@ -341,8 +341,8 @@ class EventsService(private val activity: Activity) {
     fun showEvent(activityContext: Activity, eventId: String, timestamp: Long?, requestCode: Int): Result<Unit> {
         return try {
             // Validate permissions
-            if (android.content.pm.PackageManager.PERMISSION_GRANTED != 
-                activity.checkSelfPermission(android.Manifest.permission.READ_CALENDAR)) {
+            if (android.content.pm.PackageManager.PERMISSION_GRANTED !=
+                context.checkSelfPermission(android.Manifest.permission.READ_CALENDAR)) {
                 return Result.failure(
                     CalendarException(
                         PlatformExceptionCodes.PERMISSION_DENIED,
@@ -404,8 +404,8 @@ class EventsService(private val activity: Activity) {
         availability: String
     ): Result<String> {
         // Check for write calendar permission
-        if (android.content.pm.PackageManager.PERMISSION_GRANTED != 
-            activity.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR)) {
+        if (android.content.pm.PackageManager.PERMISSION_GRANTED !=
+            context.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR)) {
             return Result.failure(
                 CalendarException(
                     PlatformExceptionCodes.PERMISSION_DENIED,
@@ -489,7 +489,7 @@ class EventsService(private val activity: Activity) {
                 put(CalendarContract.Events.STATUS, CalendarContract.Events.STATUS_CONFIRMED)
             }
             
-            val uri = activity.contentResolver.insert(
+            val uri = context.contentResolver.insert(
                 CalendarContract.Events.CONTENT_URI,
                 values
             )
@@ -526,8 +526,8 @@ class EventsService(private val activity: Activity) {
     
     fun deleteEvent(eventId: String): Result<Unit> {
         // Check for write calendar permission
-        if (android.content.pm.PackageManager.PERMISSION_GRANTED != 
-            activity.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR)) {
+        if (android.content.pm.PackageManager.PERMISSION_GRANTED !=
+            context.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR)) {
             return Result.failure(
                 CalendarException(
                     PlatformExceptionCodes.PERMISSION_DENIED,
@@ -538,7 +538,7 @@ class EventsService(private val activity: Activity) {
         
         try {
             // Delete the event (entire series for recurring events)
-            val deletedRows = activity.contentResolver.delete(
+            val deletedRows = context.contentResolver.delete(
                 CalendarContract.Events.CONTENT_URI,
                 "${CalendarContract.Events._ID} = ?",
                 arrayOf(eventId)
@@ -582,8 +582,8 @@ class EventsService(private val activity: Activity) {
         timeZone: String?
     ): Result<Unit> {
         // Check for write calendar permission
-        if (android.content.pm.PackageManager.PERMISSION_GRANTED != 
-            activity.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR)) {
+        if (android.content.pm.PackageManager.PERMISSION_GRANTED !=
+            context.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR)) {
             return Result.failure(
                 CalendarException(
                     PlatformExceptionCodes.PERMISSION_DENIED,
@@ -684,7 +684,7 @@ class EventsService(private val activity: Activity) {
             }
             
             // Perform the update
-            val updatedRows = activity.contentResolver.update(
+            val updatedRows = context.contentResolver.update(
                 CalendarContract.Events.CONTENT_URI,
                 values,
                 "${CalendarContract.Events._ID} = ?",

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -238,18 +238,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   melos:
     dependency: "direct dev"
     description:
@@ -403,10 +403,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -464,5 +464,5 @@ packages:
     source: hosted
     version: "2.2.2"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
This PR fixes an issue where calendar functions do not work when called from a foreground service or background execution on Android.

**Solution**
Replace usage of Activity context with Application context
This allows calendar functions that do not require UI to work correctly in background / foreground service mode

**Result**
Calendar read/write operations work correctly when called from a foreground service
No behavior change for normal UI usage

**Related issue**
#15