### PR TITLE
feat: add recurrence rule support with typed API

### DIFF
--- a/packages/device_calendar_plus/README.md
+++ b/packages/device_calendar_plus/README.md
@@ -326,11 +326,11 @@ await plugin.createEvent(
 );
 ```
 
-Monthly and yearly recurrences use `byDayOfMonth` or `byWeekday` — they're sealed subtypes so you can't accidentally mix them:
+Monthly and yearly have sealed subtypes — the default constructor is by day of month, use `.byWeekday` for weekday patterns:
 
 ```dart
 // Monthly on the 1st and 15th
-MonthlyRecurrence.byDayOfMonth(daysOfMonth: [1, 15])
+MonthlyRecurrence(daysOfMonth: [1, 15])
 
 // Monthly on the 2nd Tuesday
 MonthlyRecurrence.byWeekday(
@@ -343,7 +343,7 @@ MonthlyRecurrence.byWeekday(
 )
 
 // Yearly on Christmas
-YearlyRecurrence.byDayOfMonth(months: [12], daysOfMonth: [25])
+YearlyRecurrence(months: [12], daysOfMonth: [25])
 
 // Yearly on the 4th Thursday of November (Thanksgiving)
 YearlyRecurrence.byWeekday(

--- a/packages/device_calendar_plus/README.md
+++ b/packages/device_calendar_plus/README.md
@@ -35,7 +35,7 @@ Created by [Bullet](https://bullet.to) — a personal task + notes + calendar ap
 - **Native UI**: Open native event modal for viewing/editing in both android and iOS
 - **All-Day Events**: Proper handling of floating calendar dates
 - **Timezones**: Correct timezone behavior for timed events
-- **Recurring Events**: Read recurring event instances; update/delete entire series
+- **Recurring Events**: Create, read, and delete recurring events (daily, weekly, monthly, yearly) with full RRULE support
 
 ## 🧩 Installation
 
@@ -355,6 +355,19 @@ await plugin.deleteEvent(event.instanceId);
 // For recurring events, this deletes the ENTIRE series (all occurrences)
 await plugin.deleteEvent(event.instanceId);
 ```
+
+## 📋 Roadmap
+
+- [x] **Permissions** — request, check, and open settings
+- [x] **Calendars** — create, read, update, delete
+- [x] **Events** — create, read, update, delete
+- [x] **All-day events** — proper floating date handling across timezones
+- [x] **Native UI** — show event modal on both platforms
+- [x] **Recurring events** — create and read with sealed RecurrenceRule model (daily, weekly, monthly, yearly)
+- [ ] **Update recurrence rules** — change/add/remove recurrence rule via `updateEvent`
+- [ ] **Attendees** — read on both platforms; write on Android (iOS EventKit is read-only for participants)
+- [ ] **Reminders / alarms** — read/write on both platforms
+- [ ] **Platform-specific extras** — event URL, organizer, and other platform-native fields exposed where supported
 
 ## 🤝 Contributing
 

--- a/packages/device_calendar_plus/README.md
+++ b/packages/device_calendar_plus/README.md
@@ -299,6 +299,96 @@ final detailedEventId = await plugin.createEvent(
 );
 ```
 
+### Recurring Events
+
+Create recurring events by passing a `RecurrenceRule` to `createEvent`. The rule types are sealed classes, so the compiler ensures you handle all cases.
+
+```dart
+// Every day for 30 days
+await plugin.createEvent(
+  calendarId: calendarId,
+  title: 'Daily Standup',
+  startDate: DateTime(2024, 3, 20, 9, 0),
+  endDate: DateTime(2024, 3, 20, 9, 15),
+  recurrenceRule: DailyRecurrence(end: CountEnd(30)),
+);
+
+// Every 2 weeks on Monday and Friday
+await plugin.createEvent(
+  calendarId: calendarId,
+  title: 'Sprint Review',
+  startDate: DateTime(2024, 3, 20, 14, 0),
+  endDate: DateTime(2024, 3, 20, 15, 0),
+  recurrenceRule: WeeklyRecurrence(
+    interval: 2,
+    daysOfWeek: [DayOfWeek.monday, DayOfWeek.friday],
+  ),
+);
+```
+
+Monthly and yearly recurrences use `byDayOfMonth` or `byWeekday` — they're sealed subtypes so you can't accidentally mix them:
+
+```dart
+// Monthly on the 1st and 15th
+MonthlyRecurrence.byDayOfMonth(daysOfMonth: [1, 15])
+
+// Monthly on the 2nd Tuesday
+MonthlyRecurrence.byWeekday(
+  daysOfWeek: [RecurrenceDay(DayOfWeek.tuesday, position: 2)],
+)
+
+// Monthly on the last Friday
+MonthlyRecurrence.byWeekday(
+  daysOfWeek: [RecurrenceDay(DayOfWeek.friday, position: -1)],
+)
+
+// Yearly on Christmas
+YearlyRecurrence.byDayOfMonth(months: [12], daysOfMonth: [25])
+
+// Yearly on the 4th Thursday of November (Thanksgiving)
+YearlyRecurrence.byWeekday(
+  months: [11],
+  daysOfWeek: [RecurrenceDay(DayOfWeek.thursday, position: 4)],
+)
+
+// Last weekday of every month (uses BYSETPOS)
+MonthlyRecurrence.byWeekday(
+  daysOfWeek: [
+    RecurrenceDay(DayOfWeek.monday),
+    RecurrenceDay(DayOfWeek.tuesday),
+    RecurrenceDay(DayOfWeek.wednesday),
+    RecurrenceDay(DayOfWeek.thursday),
+    RecurrenceDay(DayOfWeek.friday),
+  ],
+  setPositions: [-1],
+)
+```
+
+End conditions are either a count or a date — or omit for forever:
+
+```dart
+DailyRecurrence(end: CountEnd(10))           // after 10 occurrences
+DailyRecurrence(end: UntilEnd(DateTime.utc(2025, 12, 31)))  // until a date
+DailyRecurrence()                            // forever
+```
+
+When reading events back, `event.recurrenceRule` gives you the typed model. For RRULE properties the typed model doesn't cover, use the `rruleString` escape hatch — it preserves the original platform string:
+
+```dart
+final event = await plugin.getEvent(eventId);
+final rule = event?.recurrenceRule;
+
+// Typed access
+if (rule is MonthlyByWeekday) {
+  print(rule.daysOfWeek);
+  print(rule.setPositions);
+}
+
+// Raw RRULE string — preserves platform-specific properties
+// like BYHOUR or BYSETPOS combinations the typed model doesn't cover
+print(rule?.rruleString); // e.g. "FREQ=MONTHLY;BYDAY=2TU;COUNT=12"
+```
+
 ### Update Event
 
 ```dart

--- a/packages/device_calendar_plus/example/integration_test/all_tests.dart
+++ b/packages/device_calendar_plus/example/integration_test/all_tests.dart
@@ -1,0 +1,7 @@
+import 'device_calendar_test.dart' as device_calendar;
+import 'recurrence_test.dart' as recurrence;
+
+void main() {
+  device_calendar.main();
+  recurrence.main();
+}

--- a/packages/device_calendar_plus/example/integration_test/recurrence_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/recurrence_test.dart
@@ -1,0 +1,430 @@
+import 'package:device_calendar_plus/device_calendar_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Recurrence Roundtrip Tests', () {
+    late DeviceCalendar plugin;
+    String? calendarId;
+
+    setUpAll(() async {
+      plugin = DeviceCalendar.instance;
+      await plugin.requestPermissions();
+
+      // Create a test calendar
+      calendarId = await plugin.createCalendar(
+        name: 'Recurrence Test ${DateTime.now().millisecondsSinceEpoch}',
+        colorHex: '#FF0000',
+      );
+    });
+
+    tearDownAll(() async {
+      if (calendarId != null) {
+        await plugin.deleteCalendar(calendarId!);
+      }
+    });
+
+    /// Helper: create event, read it back, return the recurrence rule.
+    Future<RecurrenceRule?> roundtrip(
+      RecurrenceRule rule, {
+      String title = 'Test Event',
+      String? timeZone,
+    }) async {
+      final start = DateTime.now().add(const Duration(hours: 1));
+      final end = start.add(const Duration(hours: 1));
+
+      final eventId = await plugin.createEvent(
+        calendarId: calendarId!,
+        title: title,
+        startDate: start,
+        endDate: end,
+        isAllDay: false,
+        recurrenceRule: rule,
+        timeZone: timeZone ?? 'UTC',
+      );
+
+      expect(eventId, isNotNull);
+      expect(eventId, isNotEmpty);
+
+      // Read back events in a window around the start date
+      final events = await plugin.listEvents(
+        start.subtract(const Duration(hours: 2)),
+        end.add(const Duration(hours: 2)),
+        calendarIds: [calendarId!],
+      );
+
+      final matchingEvents = events.where((e) => e.eventId == eventId).toList();
+      expect(matchingEvents, isNotEmpty,
+          reason: 'Event should be found in the date range');
+
+      final event = matchingEvents.first;
+      expect(event.isRecurring, isTrue, reason: 'Event should be recurring');
+
+      return event.recurrenceRule;
+    }
+
+    // -- Frequency roundtrips --
+
+    test('Daily recurrence roundtrip', () async {
+      if (calendarId == null) return;
+
+      final rule = roundtrip(const DailyRecurrence(end: CountEnd(5)));
+      final result = await rule;
+
+      expect(result, isNotNull);
+      expect(result, isA<DailyRecurrence>());
+      expect((result!.end as CountEnd).count, 5);
+    });
+
+    test('Weekly recurrence roundtrip', () async {
+      if (calendarId == null) return;
+
+      final result = await roundtrip(const WeeklyRecurrence(
+        daysOfWeek: [DayOfWeek.monday, DayOfWeek.wednesday, DayOfWeek.friday],
+        end: CountEnd(10),
+      ));
+
+      expect(result, isNotNull);
+      expect(result, isA<WeeklyRecurrence>());
+      final weekly = result as WeeklyRecurrence;
+      expect(weekly.daysOfWeek, isNotNull);
+      expect(weekly.daysOfWeek!.length, 3);
+      expect(weekly.daysOfWeek!, contains(DayOfWeek.monday));
+      expect(weekly.daysOfWeek!, contains(DayOfWeek.wednesday));
+      expect(weekly.daysOfWeek!, contains(DayOfWeek.friday));
+      expect((weekly.end as CountEnd).count, 10);
+    });
+
+    test('Monthly recurrence with BYMONTHDAY roundtrip', () async {
+      if (calendarId == null) return;
+
+      final result = await roundtrip(MonthlyRecurrence.byDayOfMonth(
+        daysOfMonth: [15],
+        end: CountEnd(12),
+      ));
+
+      expect(result, isNotNull);
+      expect(result, isA<MonthlyByDate>());
+      final monthly = result as MonthlyByDate;
+      expect(monthly.daysOfMonth, [15]);
+      expect((monthly.end as CountEnd).count, 12);
+    });
+
+    test('Yearly recurrence roundtrip', () async {
+      if (calendarId == null) return;
+
+      final result = await roundtrip(YearlyRecurrence.byDayOfMonth(
+        end: CountEnd(5),
+      ));
+
+      expect(result, isNotNull);
+      expect(result, isA<YearlyByDate>());
+      expect((result!.end as CountEnd).count, 5);
+    });
+
+    test('Monthly by weekday - 2nd Tuesday roundtrip', () async {
+      if (calendarId == null) return;
+
+      final result = await roundtrip(MonthlyRecurrence.byWeekday(
+        daysOfWeek: [RecurrenceDay(DayOfWeek.tuesday, position: 2)],
+        end: CountEnd(6),
+      ));
+
+      expect(result, isNotNull);
+      expect(result, isA<MonthlyByWeekday>());
+      final monthly = result as MonthlyByWeekday;
+      expect(monthly.daysOfWeek.length, 1);
+      expect(monthly.daysOfWeek[0].day, DayOfWeek.tuesday);
+      expect(monthly.daysOfWeek[0].position, 2);
+      expect((monthly.end as CountEnd).count, 6);
+    });
+
+    test('Monthly by weekday - last Friday roundtrip', () async {
+      if (calendarId == null) return;
+
+      final result = await roundtrip(MonthlyRecurrence.byWeekday(
+        daysOfWeek: [RecurrenceDay(DayOfWeek.friday, position: -1)],
+        end: CountEnd(12),
+      ));
+
+      expect(result, isNotNull);
+      expect(result, isA<MonthlyByWeekday>());
+      final monthly = result as MonthlyByWeekday;
+      expect(monthly.daysOfWeek[0].day, DayOfWeek.friday);
+      expect(monthly.daysOfWeek[0].position, -1);
+    });
+
+    test('Monthly with multiple BYMONTHDAY roundtrip', () async {
+      if (calendarId == null) return;
+
+      final result = await roundtrip(MonthlyRecurrence.byDayOfMonth(
+        daysOfMonth: [1, 15],
+        end: CountEnd(12),
+      ));
+
+      expect(result, isNotNull);
+      expect(result, isA<MonthlyByDate>());
+      final monthly = result as MonthlyByDate;
+      expect(monthly.daysOfMonth, isNotNull);
+      expect(monthly.daysOfMonth!.length, 2);
+      expect(monthly.daysOfMonth!, contains(1));
+      expect(monthly.daysOfMonth!, contains(15));
+    });
+
+    test('Yearly by weekday - 4th Thursday of November roundtrip', () async {
+      if (calendarId == null) return;
+
+      final result = await roundtrip(YearlyRecurrence.byWeekday(
+        months: [11],
+        daysOfWeek: [RecurrenceDay(DayOfWeek.thursday, position: 4)],
+        end: CountEnd(5),
+      ));
+
+      expect(result, isNotNull);
+      expect(result, isA<YearlyByWeekday>());
+      final yearly = result as YearlyByWeekday;
+      expect(yearly.months, [11]);
+      expect(yearly.daysOfWeek.length, 1);
+      expect(yearly.daysOfWeek[0].day, DayOfWeek.thursday);
+      expect(yearly.daysOfWeek[0].position, 4);
+    });
+
+    test('Yearly by weekday - last Monday of May roundtrip', () async {
+      if (calendarId == null) return;
+
+      final result = await roundtrip(YearlyRecurrence.byWeekday(
+        months: [5],
+        daysOfWeek: [RecurrenceDay(DayOfWeek.monday, position: -1)],
+        end: CountEnd(5),
+      ));
+
+      expect(result, isNotNull);
+      expect(result, isA<YearlyByWeekday>());
+      final yearly = result as YearlyByWeekday;
+      expect(yearly.months, [5]);
+      expect(yearly.daysOfWeek[0].day, DayOfWeek.monday);
+      expect(yearly.daysOfWeek[0].position, -1);
+    });
+
+    test('Yearly with multiple months roundtrip', () async {
+      if (calendarId == null) return;
+
+      final result = await roundtrip(YearlyRecurrence.byDayOfMonth(
+        months: [6, 12],
+        daysOfMonth: [15],
+        end: CountEnd(10),
+      ));
+
+      expect(result, isNotNull);
+      expect(result, isA<YearlyByDate>());
+      final yearly = result as YearlyByDate;
+      expect(yearly.months, isNotNull);
+      expect(yearly.months!.length, 2);
+      expect(yearly.months!, contains(6));
+      expect(yearly.months!, contains(12));
+      expect(yearly.daysOfMonth, [15]);
+    });
+
+    // -- BYSETPOS roundtrips --
+
+    test('Monthly BYSETPOS - last weekday of month roundtrip', () async {
+      if (calendarId == null) return;
+
+      final result = await roundtrip(MonthlyRecurrence.byWeekday(
+        daysOfWeek: [
+          RecurrenceDay(DayOfWeek.monday),
+          RecurrenceDay(DayOfWeek.tuesday),
+          RecurrenceDay(DayOfWeek.wednesday),
+          RecurrenceDay(DayOfWeek.thursday),
+          RecurrenceDay(DayOfWeek.friday),
+        ],
+        setPositions: [-1],
+        end: CountEnd(6),
+      ));
+
+      expect(result, isNotNull);
+      expect(result, isA<MonthlyByWeekday>());
+      final monthly = result as MonthlyByWeekday;
+      expect(monthly.daysOfWeek.length, 5);
+      expect(monthly.setPositions, [-1]);
+      expect((monthly.end as CountEnd).count, 6);
+    });
+
+    test('Monthly BYSETPOS - first weekday of month roundtrip', () async {
+      if (calendarId == null) return;
+
+      final result = await roundtrip(MonthlyRecurrence.byWeekday(
+        daysOfWeek: [
+          RecurrenceDay(DayOfWeek.monday),
+          RecurrenceDay(DayOfWeek.tuesday),
+          RecurrenceDay(DayOfWeek.wednesday),
+          RecurrenceDay(DayOfWeek.thursday),
+          RecurrenceDay(DayOfWeek.friday),
+        ],
+        setPositions: [1],
+        end: CountEnd(6),
+      ));
+
+      expect(result, isNotNull);
+      expect(result, isA<MonthlyByWeekday>());
+      final monthly = result as MonthlyByWeekday;
+      expect(monthly.setPositions, [1]);
+    });
+
+    test('Yearly BYSETPOS - last weekday of January roundtrip', () async {
+      if (calendarId == null) return;
+
+      final result = await roundtrip(YearlyRecurrence.byWeekday(
+        months: [1],
+        daysOfWeek: [
+          RecurrenceDay(DayOfWeek.monday),
+          RecurrenceDay(DayOfWeek.tuesday),
+          RecurrenceDay(DayOfWeek.wednesday),
+          RecurrenceDay(DayOfWeek.thursday),
+          RecurrenceDay(DayOfWeek.friday),
+        ],
+        setPositions: [-1],
+        end: CountEnd(5),
+      ));
+
+      expect(result, isNotNull);
+      expect(result, isA<YearlyByWeekday>());
+      final yearly = result as YearlyByWeekday;
+      expect(yearly.months, [1]);
+      expect(yearly.daysOfWeek.length, 5);
+      expect(yearly.setPositions, [-1]);
+    });
+
+    // -- Interval roundtrip --
+
+    test('Weekly with interval=2 roundtrip', () async {
+      if (calendarId == null) return;
+
+      final result = await roundtrip(const WeeklyRecurrence(
+        interval: 2,
+        daysOfWeek: [DayOfWeek.tuesday],
+        end: CountEnd(8),
+      ));
+
+      expect(result, isNotNull);
+      expect(result, isA<WeeklyRecurrence>());
+      expect(result!.interval, 2);
+    });
+
+    // -- COUNT roundtrip --
+
+    test('COUNT roundtrip', () async {
+      if (calendarId == null) return;
+
+      final result = await roundtrip(const DailyRecurrence(end: CountEnd(30)));
+
+      expect(result, isNotNull);
+      expect(result!.end, isA<CountEnd>());
+      expect((result.end as CountEnd).count, 30);
+    });
+
+    // -- UNTIL edge case roundtrips --
+
+    test('UNTIL date-only roundtrip', () async {
+      if (calendarId == null) return;
+
+      final untilDate = DateTime.utc(2027, 6, 15);
+      final result = await roundtrip(DailyRecurrence(end: UntilEnd(untilDate)));
+
+      expect(result, isNotNull);
+      expect(result!.end, isA<UntilEnd>());
+      final until = (result.end as UntilEnd).until;
+      // At minimum, the date should be preserved
+      expect(until.year, 2027);
+      expect(until.month, 6);
+      expect(until.day, 15);
+    });
+
+    test('UNTIL date-time roundtrip', () async {
+      if (calendarId == null) return;
+
+      final untilDate = DateTime.utc(2027, 6, 15, 14, 30);
+      final result = await roundtrip(DailyRecurrence(end: UntilEnd(untilDate)));
+
+      expect(result, isNotNull);
+      expect(result!.end, isA<UntilEnd>());
+      final until = (result.end as UntilEnd).until;
+      // Check date preserved. Time may or may not be preserved (iOS may truncate).
+      expect(until.year, 2027);
+      expect(until.month, 6);
+      expect(until.day, 15);
+      // Log time for diagnostic purposes (may be truncated on iOS)
+      // ignore: avoid_print
+      print('UNTIL date-time roundtrip: wrote ${untilDate.toIso8601String()}, '
+          'got ${until.toIso8601String()}');
+    });
+
+    test('UNTIL with non-UTC timezone event roundtrip', () async {
+      if (calendarId == null) return;
+
+      final untilDate = DateTime.utc(2027, 6, 15);
+      final result = await roundtrip(
+        DailyRecurrence(end: UntilEnd(untilDate)),
+        timeZone: 'America/New_York',
+      );
+
+      expect(result, isNotNull);
+      expect(result!.end, isA<UntilEnd>());
+      final until = (result.end as UntilEnd).until;
+      // The calendar date should be preserved regardless of timezone
+      expect(until.year, 2027);
+      expect(until.month, 6);
+      expect(until.day, 15);
+    });
+
+    test('UNTIL near DST boundary roundtrip', () async {
+      if (calendarId == null) return;
+
+      // March 9, 2025 is near US DST spring-forward
+      final untilDate = DateTime.utc(2027, 3, 9);
+      final result = await roundtrip(
+        DailyRecurrence(end: UntilEnd(untilDate)),
+        timeZone: 'America/New_York',
+      );
+
+      expect(result, isNotNull);
+      expect(result!.end, isA<UntilEnd>());
+      final until = (result.end as UntilEnd).until;
+      expect(until.year, 2027);
+      expect(until.month, 3);
+      expect(until.day, 9);
+    });
+
+    // -- No end condition (recurs forever) --
+
+    test('Infinite recurrence roundtrip', () async {
+      if (calendarId == null) return;
+
+      final result = await roundtrip(const DailyRecurrence());
+
+      expect(result, isNotNull);
+      expect(result, isA<DailyRecurrence>());
+      expect(result!.end, isNull);
+    });
+
+    // -- rruleString preservation --
+
+    test('rruleString preserves platform RRULE', () async {
+      if (calendarId == null) return;
+
+      final result = await roundtrip(const WeeklyRecurrence(
+        daysOfWeek: [DayOfWeek.monday],
+        end: CountEnd(5),
+      ));
+
+      expect(result, isNotNull);
+      // The rruleString should be a valid RRULE string containing the key parts
+      final rrule = result!.rruleString;
+      expect(rrule, contains('FREQ=WEEKLY'));
+      expect(rrule, contains('MO'));
+      expect(rrule, contains('COUNT=5'));
+    });
+  });
+}

--- a/packages/device_calendar_plus/example/integration_test/recurrence_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/recurrence_test.dart
@@ -100,7 +100,7 @@ void main() {
     test('Monthly recurrence with BYMONTHDAY roundtrip', () async {
       if (calendarId == null) return;
 
-      final result = await roundtrip(MonthlyRecurrence.byDayOfMonth(
+      final result = await roundtrip(MonthlyRecurrence(
         daysOfMonth: [15],
         end: CountEnd(12),
       ));
@@ -115,7 +115,7 @@ void main() {
     test('Yearly recurrence roundtrip', () async {
       if (calendarId == null) return;
 
-      final result = await roundtrip(YearlyRecurrence.byDayOfMonth(
+      final result = await roundtrip(YearlyRecurrence(
         end: CountEnd(5),
       ));
 
@@ -159,7 +159,7 @@ void main() {
     test('Monthly with multiple BYMONTHDAY roundtrip', () async {
       if (calendarId == null) return;
 
-      final result = await roundtrip(MonthlyRecurrence.byDayOfMonth(
+      final result = await roundtrip(MonthlyRecurrence(
         daysOfMonth: [1, 15],
         end: CountEnd(12),
       ));
@@ -211,7 +211,7 @@ void main() {
     test('Yearly with multiple months roundtrip', () async {
       if (calendarId == null) return;
 
-      final result = await roundtrip(YearlyRecurrence.byDayOfMonth(
+      final result = await roundtrip(YearlyRecurrence(
         months: [6, 12],
         daysOfMonth: [15],
         end: CountEnd(10),

--- a/packages/device_calendar_plus/example/run_integration_tests.sh
+++ b/packages/device_calendar_plus/example/run_integration_tests.sh
@@ -122,18 +122,17 @@ elif [ "$PLATFORM" == "android" ]; then
     echo ""
 fi
 
-# Run the integration tests
+cd "$(dirname "$0")"
+
 echo "🚀 Running integration tests on $DEVICE_ID..."
 echo ""
 
-cd "$(dirname "$0")"
-
-# Build test command based on platform
+# Run all integration tests in a single app launch
 if [ "$PLATFORM" == "android" ]; then
     # Use custom driver that grants permissions via adb
     if flutter drive \
         --driver=integration_test/integration_test_driver.dart \
-        --target=integration_test/device_calendar_test.dart \
+        --target=integration_test/all_tests.dart \
         -d "$DEVICE_ID"; then
         EXIT_CODE=0
     else
@@ -141,21 +140,20 @@ if [ "$PLATFORM" == "android" ]; then
     fi
 else
     # iOS: Use regular flutter test
-    if flutter test integration_test/device_calendar_test.dart -d "$DEVICE_ID"; then
+    if flutter test integration_test/all_tests.dart -d "$DEVICE_ID"; then
         EXIT_CODE=0
     else
         EXIT_CODE=1
     fi
 fi
 
-echo ""
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 
 if [ $EXIT_CODE -eq 0 ]; then
     echo -e "${GREEN}✅ All integration tests passed!${NC}"
 else
     echo -e "${RED}❌ Some tests failed${NC}"
-    
+
     if [ "$PLATFORM" == "ios" ]; then
         echo ""
         echo "If tests failed due to permissions:"

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -6,6 +6,7 @@ import 'src/calendar_permission_status.dart';
 import 'src/event.dart';
 import 'src/event_availability.dart';
 import 'src/platform_exception_converter.dart';
+import 'src/recurrence_rule.dart';
 
 export 'package:device_calendar_plus_android/device_calendar_plus_android.dart'
     show CreateCalendarOptionsAndroid;
@@ -20,6 +21,7 @@ export 'src/event.dart';
 export 'src/event_availability.dart';
 export 'src/event_status.dart';
 export 'src/platform_exception_codes.dart';
+export 'src/recurrence_rule.dart';
 
 /// Main API for accessing device calendar functionality.
 class DeviceCalendar {
@@ -501,8 +503,8 @@ class DeviceCalendar {
   /// [location] is optional event location.
   /// [timeZone] is optional timezone identifier (null for all-day events).
   ///   The platform will validate the timezone string.
-  /// [url] is optional event URL (supported on both platforms).
   /// [availability] is the availability status (default: EventAvailability.busy).
+  /// [recurrenceRule] is an optional recurrence rule for repeating events.
   ///
   /// Returns the system-generated event ID.
   /// Requires calendar write permissions - call [requestPermissions] first.
@@ -519,16 +521,13 @@ class DeviceCalendar {
   ///   endDate: DateTime.now().add(Duration(hours: 1)),
   /// );
   ///
-  /// // Create an event with all options
-  /// final detailedEventId = await plugin.createEvent(
+  /// // Create a recurring event
+  /// final recurringId = await plugin.createEvent(
   ///   calendarId: 'cal-123',
-  ///   title: 'Project Review',
-  ///   startDate: DateTime(2024, 3, 15, 14, 0),
-  ///   endDate: DateTime(2024, 3, 15, 15, 0),
-  ///   description: 'Q1 project review meeting',
-  ///   location: 'Conference Room A',
-  ///   timeZone: 'America/New_York',
-  ///   availability: EventAvailability.busy,
+  ///   title: 'Daily Standup',
+  ///   startDate: DateTime(2024, 3, 15, 9, 0),
+  ///   endDate: DateTime(2024, 3, 15, 9, 15),
+  ///   recurrenceRule: DailyRecurrence(end: CountEnd(30)),
   /// );
   /// ```
   Future<String> createEvent({
@@ -541,6 +540,7 @@ class DeviceCalendar {
     String? location,
     String? timeZone,
     EventAvailability availability = EventAvailability.busy,
+    RecurrenceRule? recurrenceRule,
   }) async {
     // Validate required fields
     if (calendarId.trim().isEmpty) {
@@ -595,6 +595,7 @@ class DeviceCalendar {
         location,
         timeZone,
         availability.name,
+        recurrenceRule?.toRruleString(),
       );
       return eventId;
     } on PlatformException catch (e, stackTrace) {

--- a/packages/device_calendar_plus/lib/src/event.dart
+++ b/packages/device_calendar_plus/lib/src/event.dart
@@ -1,5 +1,6 @@
 import 'event_availability.dart';
 import 'event_status.dart';
+import 'recurrence_rule.dart';
 
 /// Represents a calendar event.
 class Event {
@@ -78,6 +79,15 @@ class Event {
   /// True for recurring events, false for one-time events.
   final bool isRecurring;
 
+  /// Parsed recurrence rule for this event.
+  ///
+  /// Null if the event is not recurring, or if the platform RRULE uses
+  /// features outside the supported subset (e.g. FREQ=MINUTELY).
+  ///
+  /// For full RRULE access, use [recurrenceRule?.rruleString] which preserves
+  /// the original platform string.
+  final RecurrenceRule? recurrenceRule;
+
   Event({
     required this.eventId,
     required this.instanceId,
@@ -92,10 +102,12 @@ class Event {
     required this.status,
     this.timeZone,
     required this.isRecurring,
+    this.recurrenceRule,
   });
 
   /// Creates an Event from a map returned by the platform.
   factory Event.fromMap(Map<String, dynamic> map) {
+    final rruleString = map['recurrenceRule'] as String?;
     return Event(
       eventId: map['eventId'] as String,
       instanceId: map['instanceId'] as String,
@@ -110,6 +122,9 @@ class Event {
       status: EventStatus.fromName(map['status'] as String),
       timeZone: map['timeZone'] as String?,
       isRecurring: map['isRecurring'] as bool? ?? false,
+      recurrenceRule: rruleString != null
+          ? RecurrenceRule.fromRruleString(rruleString)
+          : null,
     );
   }
 
@@ -131,6 +146,9 @@ class Event {
     if (description != null) map['description'] = description;
     if (location != null) map['location'] = location;
     if (timeZone != null) map['timeZone'] = timeZone;
+    if (recurrenceRule != null) {
+      map['recurrenceRule'] = recurrenceRule!.rruleString;
+    }
 
     return map;
   }
@@ -158,7 +176,8 @@ class Event {
         other.availability == availability &&
         other.status == status &&
         other.timeZone == timeZone &&
-        other.isRecurring == isRecurring;
+        other.isRecurring == isRecurring &&
+        other.recurrenceRule == recurrenceRule;
   }
 
   @override
@@ -177,6 +196,7 @@ class Event {
       status,
       timeZone,
       isRecurring,
+      recurrenceRule,
     );
   }
 }

--- a/packages/device_calendar_plus/lib/src/recurrence_rule.dart
+++ b/packages/device_calendar_plus/lib/src/recurrence_rule.dart
@@ -1,0 +1,845 @@
+/// Days of the week for recurrence rules.
+enum DayOfWeek {
+  monday,
+  tuesday,
+  wednesday,
+  thursday,
+  friday,
+  saturday,
+  sunday;
+
+  /// Converts to RRULE BYDAY format (MO, TU, WE, TH, FR, SA, SU).
+  String toRruleDay() {
+    return switch (this) {
+      DayOfWeek.monday => 'MO',
+      DayOfWeek.tuesday => 'TU',
+      DayOfWeek.wednesday => 'WE',
+      DayOfWeek.thursday => 'TH',
+      DayOfWeek.friday => 'FR',
+      DayOfWeek.saturday => 'SA',
+      DayOfWeek.sunday => 'SU',
+    };
+  }
+
+  /// Parses a BYDAY code to [DayOfWeek]. Returns null if unrecognized.
+  static DayOfWeek? fromRruleDay(String day) {
+    return switch (day.toUpperCase()) {
+      'MO' => DayOfWeek.monday,
+      'TU' => DayOfWeek.tuesday,
+      'WE' => DayOfWeek.wednesday,
+      'TH' => DayOfWeek.thursday,
+      'FR' => DayOfWeek.friday,
+      'SA' => DayOfWeek.saturday,
+      'SU' => DayOfWeek.sunday,
+      _ => null,
+    };
+  }
+}
+
+/// End condition for a recurrence rule.
+///
+/// Either the recurrence ends after a number of occurrences ([CountEnd]),
+/// or on a specific date ([UntilEnd]). These are mutually exclusive per RFC 5545.
+sealed class RecurrenceEnd {
+  const RecurrenceEnd();
+}
+
+/// Recurrence ends after [count] occurrences.
+class CountEnd extends RecurrenceEnd {
+  final int count;
+
+  const CountEnd(this.count) : assert(count >= 1, 'Count must be at least 1');
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is CountEnd && other.count == count;
+
+  @override
+  int get hashCode => count.hashCode;
+
+  @override
+  String toString() => 'CountEnd($count)';
+}
+
+/// Recurrence ends on or before [until] (inclusive / closed interval).
+///
+/// This differs from [Event.endDate] which uses an open interval.
+/// The [until] value should be in UTC.
+class UntilEnd extends RecurrenceEnd {
+  final DateTime until;
+
+  const UntilEnd(this.until);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is UntilEnd && other.until == until;
+
+  @override
+  int get hashCode => until.hashCode;
+
+  @override
+  String toString() => 'UntilEnd($until)';
+}
+
+/// Recurrence rule for calendar events (RFC 5545 RRULE subset).
+///
+/// This models the cross-platform subset of RRULE that both iOS (EKRecurrenceRule)
+/// and Android (CalendarContract) support reliably.
+///
+/// For full RRULE access (e.g. BYHOUR on Android), use [rruleString].
+sealed class RecurrenceRule {
+  /// Interval between recurrences. Defaults to 1.
+  ///
+  /// For example, `interval: 2` with [WeeklyRecurrence] means every 2 weeks.
+  final int interval;
+
+  /// Optional end condition (count or until date). Null means recurs forever.
+  final RecurrenceEnd? end;
+
+  /// Stored raw RRULE string when parsed from a platform event.
+  final String? _rawRrule;
+
+  const RecurrenceRule({this.interval = 1, this.end, String? rawRrule})
+      : _rawRrule = rawRrule,
+        assert(interval >= 1, 'Interval must be at least 1');
+
+  /// The raw RRULE string.
+  ///
+  /// When parsed from a platform event, this is the original string as returned
+  /// by the platform. On Android this is the exact CalendarContract string
+  /// (full fidelity). On iOS this is reconstructed from EKRecurrenceRule
+  /// (may lose properties like BYHOUR that EventKit doesn't model).
+  ///
+  /// When constructed in Dart, this is generated from [toRruleString].
+  ///
+  /// Use this if you need RRULE properties beyond what the typed model exposes.
+  String get rruleString => _rawRrule ?? toRruleString();
+
+  /// Serializes this rule to an RRULE string (without the "RRULE:" prefix).
+  String toRruleString();
+
+  /// Parses an RRULE string into a typed [RecurrenceRule].
+  ///
+  /// Accepts strings with or without the "RRULE:" prefix.
+  /// Returns null if the string is unparseable or uses an unsupported frequency.
+  static RecurrenceRule? fromRruleString(String rrule) {
+    return _RruleParser.parse(rrule);
+  }
+
+  /// Builds the common RRULE parts (end condition).
+  String _endParts() {
+    if (end == null) return '';
+    return switch (end!) {
+      CountEnd(:final count) => ';COUNT=$count',
+      UntilEnd(:final until) => ';UNTIL=${_formatRruleDate(until)}',
+    };
+  }
+
+  /// Formats a DateTime as an RRULE date string.
+  ///
+  /// If the time is midnight (00:00:00), emits date-only: `YYYYMMDD`.
+  /// Otherwise emits date-time in UTC: `YYYYMMDDTHHMMSSZ`.
+  static String _formatRruleDate(DateTime dt) {
+    final utc = dt.toUtc();
+    final date =
+        '${utc.year.toString().padLeft(4, '0')}${utc.month.toString().padLeft(2, '0')}${utc.day.toString().padLeft(2, '0')}';
+    if (utc.hour == 0 && utc.minute == 0 && utc.second == 0) {
+      return date;
+    }
+    return '${date}T${utc.hour.toString().padLeft(2, '0')}${utc.minute.toString().padLeft(2, '0')}${utc.second.toString().padLeft(2, '0')}Z';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RecurrenceRule &&
+        other.runtimeType == runtimeType &&
+        other.interval == interval &&
+        other.end == end;
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, interval, end);
+}
+
+/// Event repeats every N days.
+class DailyRecurrence extends RecurrenceRule {
+  const DailyRecurrence({super.interval, super.end, super.rawRrule});
+
+  @override
+  String toRruleString() {
+    final buf = StringBuffer('FREQ=DAILY');
+    if (interval > 1) buf.write(';INTERVAL=$interval');
+    buf.write(_endParts());
+    return buf.toString();
+  }
+
+  @override
+  String toString() => 'DailyRecurrence(interval: $interval, end: $end)';
+}
+
+/// Event repeats every N weeks, optionally on specific days.
+class WeeklyRecurrence extends RecurrenceRule {
+  /// Days of the week on which the event recurs.
+  ///
+  /// If null, defaults to the day of the event's start date (platform behavior).
+  final List<DayOfWeek>? daysOfWeek;
+
+  /// The day the week starts on (WKST).
+  ///
+  /// Affects how BYDAY is calculated for weekly recurrences.
+  /// Defaults to Monday per RFC 5545 when null.
+  ///
+  /// **Note:** iOS can read this from events but cannot set it when creating
+  /// events (EKRecurrenceRule does not expose it in its initializer).
+  /// The value still round-trips via [rruleString].
+  final DayOfWeek? wkst;
+
+  const WeeklyRecurrence({
+    this.daysOfWeek,
+    this.wkst,
+    super.interval,
+    super.end,
+    super.rawRrule,
+  });
+
+  @override
+  String toRruleString() {
+    final buf = StringBuffer('FREQ=WEEKLY');
+    if (interval > 1) buf.write(';INTERVAL=$interval');
+    if (daysOfWeek != null && daysOfWeek!.isNotEmpty) {
+      buf.write(';BYDAY=${daysOfWeek!.map((d) => d.toRruleDay()).join(',')}');
+    }
+    buf.write(_endParts());
+    if (wkst != null) buf.write(';WKST=${wkst!.toRruleDay()}');
+    return buf.toString();
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is WeeklyRecurrence &&
+        other.interval == interval &&
+        other.end == end &&
+        other.wkst == wkst &&
+        _listEquals(other.daysOfWeek, daysOfWeek);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        super.hashCode,
+        wkst,
+        daysOfWeek != null ? Object.hashAll(daysOfWeek!) : null,
+      );
+
+  @override
+  String toString() =>
+      'WeeklyRecurrence(interval: $interval, daysOfWeek: $daysOfWeek, wkst: $wkst, end: $end)';
+}
+
+/// Event repeats every N months.
+///
+/// ```dart
+/// MonthlyRecurrence.byDayOfMonth()                        // same day as event start
+/// MonthlyRecurrence.byDayOfMonth(daysOfMonth: [1, 15])    // 1st and 15th
+/// MonthlyRecurrence.byWeekday(daysOfWeek: [               // 2nd Tuesday
+///   RecurrenceDay(DayOfWeek.tuesday, position: 2),
+/// ])
+/// ```
+sealed class MonthlyRecurrence extends RecurrenceRule {
+  /// Filters the result set to specific positions (BYSETPOS).
+  ///
+  /// Used to select specific occurrences from the set generated by BYDAY
+  /// or BYMONTHDAY. For example, "last weekday of the month":
+  /// ```dart
+  /// MonthlyRecurrence.byWeekday(
+  ///   daysOfWeek: [
+  ///     RecurrenceDay(DayOfWeek.monday),
+  ///     RecurrenceDay(DayOfWeek.tuesday),
+  ///     RecurrenceDay(DayOfWeek.wednesday),
+  ///     RecurrenceDay(DayOfWeek.thursday),
+  ///     RecurrenceDay(DayOfWeek.friday),
+  ///   ],
+  ///   setPositions: [-1],
+  /// )
+  /// ```
+  ///
+  /// Positive values count from the start, negative from the end.
+  /// Range: -366 to 366 (non-zero).
+  final List<int>? setPositions;
+
+  const MonthlyRecurrence._({
+    this.setPositions,
+    super.interval,
+    super.end,
+    super.rawRrule,
+  });
+
+  /// Creates a monthly recurrence on specific days of the month (BYMONTHDAY).
+  ///
+  /// If [daysOfMonth] is null, the event recurs on the same day as the start date.
+  factory MonthlyRecurrence.byDayOfMonth({
+    List<int>? daysOfMonth,
+    List<int>? setPositions,
+    int interval,
+    RecurrenceEnd? end,
+    String? rawRrule,
+  }) = MonthlyByDate;
+
+  /// Creates a monthly recurrence on specific weekdays (BYDAY).
+  ///
+  /// Use [RecurrenceDay] with [position] for patterns like "2nd Tuesday"
+  /// or without for "every Tuesday in the month".
+  factory MonthlyRecurrence.byWeekday({
+    required List<RecurrenceDay> daysOfWeek,
+    List<int>? setPositions,
+    int interval,
+    RecurrenceEnd? end,
+    String? rawRrule,
+  }) = MonthlyByWeekday;
+
+  /// Serializes BYSETPOS to RRULE format.
+  String _setPosParts() {
+    if (setPositions == null || setPositions!.isEmpty) return '';
+    return ';BYSETPOS=${setPositions!.join(',')}';
+  }
+}
+
+/// Monthly recurrence on specific days of the month (BYMONTHDAY).
+class MonthlyByDate extends MonthlyRecurrence {
+  /// Days of the month (1-31) on which the event recurs.
+  ///
+  /// If null, the event recurs on the same day as the start date.
+  final List<int>? daysOfMonth;
+
+  MonthlyByDate({
+    this.daysOfMonth,
+    super.setPositions,
+    super.interval,
+    super.end,
+    super.rawRrule,
+  })  : assert(
+          daysOfMonth == null || daysOfMonth.every((d) => d >= 1 && d <= 31),
+          'daysOfMonth values must be between 1 and 31',
+        ),
+        super._();
+
+  @override
+  String toRruleString() {
+    final buf = StringBuffer('FREQ=MONTHLY');
+    if (interval > 1) buf.write(';INTERVAL=$interval');
+    if (daysOfMonth != null && daysOfMonth!.isNotEmpty) {
+      buf.write(';BYMONTHDAY=${daysOfMonth!.join(',')}');
+    }
+    buf.write(_setPosParts());
+    buf.write(_endParts());
+    return buf.toString();
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is MonthlyByDate &&
+        other.interval == interval &&
+        other.end == end &&
+        _listEquals(other.daysOfMonth, daysOfMonth) &&
+        _listEquals(other.setPositions, setPositions);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        super.hashCode,
+        daysOfMonth != null ? Object.hashAll(daysOfMonth!) : null,
+        setPositions != null ? Object.hashAll(setPositions!) : null,
+      );
+
+  @override
+  String toString() =>
+      'MonthlyByDate(interval: $interval, daysOfMonth: $daysOfMonth, setPositions: $setPositions, end: $end)';
+}
+
+/// Monthly recurrence on specific weekdays (BYDAY).
+class MonthlyByWeekday extends MonthlyRecurrence {
+  /// Day-of-week rules, optionally with position (e.g., 2nd Tuesday, last Friday).
+  final List<RecurrenceDay> daysOfWeek;
+
+  const MonthlyByWeekday({
+    required this.daysOfWeek,
+    super.setPositions,
+    super.interval,
+    super.end,
+    super.rawRrule,
+  }) : super._();
+
+  @override
+  String toRruleString() {
+    final buf = StringBuffer('FREQ=MONTHLY');
+    if (interval > 1) buf.write(';INTERVAL=$interval');
+    if (daysOfWeek.isNotEmpty) {
+      buf.write(';BYDAY=${daysOfWeek.map((d) => d.toRruleByDay()).join(',')}');
+    }
+    buf.write(_setPosParts());
+    buf.write(_endParts());
+    return buf.toString();
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is MonthlyByWeekday &&
+        other.interval == interval &&
+        other.end == end &&
+        _listEquals(other.daysOfWeek, daysOfWeek) &&
+        _listEquals(other.setPositions, setPositions);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        super.hashCode,
+        Object.hashAll(daysOfWeek),
+        setPositions != null ? Object.hashAll(setPositions!) : null,
+      );
+
+  @override
+  String toString() =>
+      'MonthlyByWeekday(interval: $interval, daysOfWeek: $daysOfWeek, setPositions: $setPositions, end: $end)';
+}
+
+/// Event repeats every N years.
+///
+/// ```dart
+/// YearlyRecurrence.byDayOfMonth()                                    // same date as event start
+/// YearlyRecurrence.byDayOfMonth(months: [12], daysOfMonth: [25])     // Christmas
+/// YearlyRecurrence.byDayOfMonth(months: [6, 12], daysOfMonth: [15])  // 15th of June and December
+/// YearlyRecurrence.byWeekday(                                        // last Monday of May
+///   months: [5],
+///   daysOfWeek: [RecurrenceDay(DayOfWeek.monday, position: -1)],
+/// )
+/// ```
+sealed class YearlyRecurrence extends RecurrenceRule {
+  /// Filters the result set to specific positions (BYSETPOS).
+  ///
+  /// See [MonthlyRecurrence.setPositions] for details.
+  final List<int>? setPositions;
+
+  const YearlyRecurrence._({
+    this.setPositions,
+    super.interval,
+    super.end,
+    super.rawRrule,
+  });
+
+  /// Creates a yearly recurrence on specific months and days of month (BYMONTH + BYMONTHDAY).
+  ///
+  /// If both are null, the event recurs on the same date as the start date.
+  factory YearlyRecurrence.byDayOfMonth({
+    List<int>? months,
+    List<int>? daysOfMonth,
+    List<int>? setPositions,
+    int interval,
+    RecurrenceEnd? end,
+    String? rawRrule,
+  }) = YearlyByDate;
+
+  /// Creates a yearly recurrence on specific weekdays within months (BYMONTH + BYDAY).
+  ///
+  /// Use [RecurrenceDay] with [position] for patterns like "last Monday of May".
+  factory YearlyRecurrence.byWeekday({
+    List<int>? months,
+    required List<RecurrenceDay> daysOfWeek,
+    List<int>? setPositions,
+    int interval,
+    RecurrenceEnd? end,
+    String? rawRrule,
+  }) = YearlyByWeekday;
+
+  /// Serializes BYSETPOS to RRULE format.
+  String _setPosParts() {
+    if (setPositions == null || setPositions!.isEmpty) return '';
+    return ';BYSETPOS=${setPositions!.join(',')}';
+  }
+}
+
+/// Yearly recurrence on specific months and days of month (BYMONTH + BYMONTHDAY).
+class YearlyByDate extends YearlyRecurrence {
+  /// Months of the year (1-12). If null, uses the event's start date month.
+  final List<int>? months;
+
+  /// Days of the month (1-31). If null, uses the event's start date day.
+  final List<int>? daysOfMonth;
+
+  YearlyByDate({
+    this.months,
+    this.daysOfMonth,
+    super.setPositions,
+    super.interval,
+    super.end,
+    super.rawRrule,
+  })  : assert(
+          months == null || months.every((m) => m >= 1 && m <= 12),
+          'months values must be between 1 and 12',
+        ),
+        assert(
+          daysOfMonth == null || daysOfMonth.every((d) => d >= 1 && d <= 31),
+          'daysOfMonth values must be between 1 and 31',
+        ),
+        super._();
+
+  @override
+  String toRruleString() {
+    final buf = StringBuffer('FREQ=YEARLY');
+    if (interval > 1) buf.write(';INTERVAL=$interval');
+    if (months != null && months!.isNotEmpty) {
+      buf.write(';BYMONTH=${months!.join(',')}');
+    }
+    if (daysOfMonth != null && daysOfMonth!.isNotEmpty) {
+      buf.write(';BYMONTHDAY=${daysOfMonth!.join(',')}');
+    }
+    buf.write(_setPosParts());
+    buf.write(_endParts());
+    return buf.toString();
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is YearlyByDate &&
+        other.interval == interval &&
+        other.end == end &&
+        _listEquals(other.months, months) &&
+        _listEquals(other.daysOfMonth, daysOfMonth) &&
+        _listEquals(other.setPositions, setPositions);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        super.hashCode,
+        months != null ? Object.hashAll(months!) : null,
+        daysOfMonth != null ? Object.hashAll(daysOfMonth!) : null,
+        setPositions != null ? Object.hashAll(setPositions!) : null,
+      );
+
+  @override
+  String toString() =>
+      'YearlyByDate(interval: $interval, months: $months, daysOfMonth: $daysOfMonth, setPositions: $setPositions, end: $end)';
+}
+
+/// Yearly recurrence on specific weekdays within months (BYMONTH + BYDAY).
+class YearlyByWeekday extends YearlyRecurrence {
+  /// Months of the year (1-12). If null, uses the event's start date month.
+  final List<int>? months;
+
+  /// Day-of-week rules, optionally with position (e.g., last Monday of May).
+  final List<RecurrenceDay> daysOfWeek;
+
+  YearlyByWeekday({
+    this.months,
+    required this.daysOfWeek,
+    super.setPositions,
+    super.interval,
+    super.end,
+    super.rawRrule,
+  })  : assert(
+          months == null || months.every((m) => m >= 1 && m <= 12),
+          'months values must be between 1 and 12',
+        ),
+        super._();
+
+  @override
+  String toRruleString() {
+    final buf = StringBuffer('FREQ=YEARLY');
+    if (interval > 1) buf.write(';INTERVAL=$interval');
+    if (months != null && months!.isNotEmpty) {
+      buf.write(';BYMONTH=${months!.join(',')}');
+    }
+    if (daysOfWeek.isNotEmpty) {
+      buf.write(';BYDAY=${daysOfWeek.map((d) => d.toRruleByDay()).join(',')}');
+    }
+    buf.write(_setPosParts());
+    buf.write(_endParts());
+    return buf.toString();
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is YearlyByWeekday &&
+        other.interval == interval &&
+        other.end == end &&
+        _listEquals(other.months, months) &&
+        _listEquals(other.daysOfWeek, daysOfWeek) &&
+        _listEquals(other.setPositions, setPositions);
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        super.hashCode,
+        months != null ? Object.hashAll(months!) : null,
+        Object.hashAll(daysOfWeek),
+        setPositions != null ? Object.hashAll(setPositions!) : null,
+      );
+
+  @override
+  String toString() =>
+      'YearlyByWeekday(interval: $interval, months: $months, daysOfWeek: $daysOfWeek, setPositions: $setPositions, end: $end)';
+}
+
+/// A day of the week with an optional position for recurring events.
+///
+/// Used in [MonthlyRecurrence] and [YearlyRecurrence] to express BYDAY patterns.
+///
+/// Without [position]: "every Tuesday" (`BYDAY=TU`).
+/// With [position]: "2nd Tuesday" (`BYDAY=2TU`) or "last Friday" (`BYDAY=-1FR`).
+///
+/// Maps to RFC 5545 BYDAY and iOS `EKRecurrenceDayOfWeek`.
+class RecurrenceDay {
+  /// The day of the week.
+  final DayOfWeek day;
+
+  /// Which occurrence of this weekday within the recurrence period.
+  ///
+  /// The scope depends on the frequency:
+  /// - For [MonthlyRecurrence]: Nth occurrence within the **month**
+  ///   (e.g., `position: 2` = 2nd Tuesday of the month).
+  /// - For [YearlyRecurrence]: Nth occurrence within the **year**
+  ///   (e.g., `position: 2` = 2nd Tuesday of the year).
+  ///
+  /// Positive values count from the start (1 = first, 2 = second, etc.).
+  /// Negative values count from the end (-1 = last, -2 = second-to-last).
+  /// Null means every occurrence of the day in the period.
+  ///
+  /// Range: -53 to 53 (non-zero).
+  final int? position;
+
+  const RecurrenceDay(this.day, {this.position})
+      : assert(
+          position == null ||
+              (position >= -53 && position <= 53 && position != 0),
+          'position must be between -53 and 53 (non-zero)',
+        );
+
+  /// Serializes to RRULE BYDAY format (e.g., `TU`, `2TU`, `-1FR`).
+  String toRruleByDay() =>
+      position != null ? '$position${day.toRruleDay()}' : day.toRruleDay();
+
+  /// Parses a BYDAY value, with or without numeric prefix.
+  /// Returns null if the format is invalid.
+  static RecurrenceDay? fromRruleByDay(String byDay) {
+    final trimmed = byDay.trim().toUpperCase();
+
+    // Try positional format first (e.g., 2TU, -1FR)
+    final match = RegExp(r'^(-?\d+)([A-Z]{2})$').firstMatch(trimmed);
+    if (match != null) {
+      final pos = int.tryParse(match.group(1)!);
+      final day = DayOfWeek.fromRruleDay(match.group(2)!);
+      if (pos == null || pos == 0 || day == null) return null;
+      return RecurrenceDay(day, position: pos);
+    }
+
+    // Plain day code (e.g., TU)
+    final day = DayOfWeek.fromRruleDay(trimmed);
+    if (day == null) return null;
+    return RecurrenceDay(day);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is RecurrenceDay && other.day == day && other.position == position;
+
+  @override
+  int get hashCode => Object.hash(day, position);
+
+  @override
+  String toString() => position != null
+      ? 'RecurrenceDay($day, position: $position)'
+      : 'RecurrenceDay($day)';
+}
+
+// -- Private helpers --
+
+bool _listEquals<T>(List<T>? a, List<T>? b) {
+  if (identical(a, b)) return true;
+  if (a == null || b == null) return a == b;
+  if (a.length != b.length) return false;
+  for (int i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
+}
+
+class _RruleParser {
+  static RecurrenceRule? parse(String rrule) {
+    try {
+      final ruleString =
+          rrule.startsWith('RRULE:') ? rrule.substring(6) : rrule;
+      final parts = ruleString.split(';');
+      final params = <String, String>{};
+
+      for (final part in parts) {
+        final idx = part.indexOf('=');
+        if (idx > 0) {
+          params[part.substring(0, idx).toUpperCase()] =
+              part.substring(idx + 1);
+        }
+      }
+
+      final freqStr = params['FREQ']?.toUpperCase();
+      if (freqStr == null) return null;
+
+      final interval = int.tryParse(params['INTERVAL'] ?? '1') ?? 1;
+
+      // Parse end condition
+      RecurrenceEnd? end;
+      final countStr = params['COUNT'];
+      final untilStr = params['UNTIL'];
+      if (countStr != null) {
+        final count = int.tryParse(countStr);
+        if (count != null && count >= 1) end = CountEnd(count);
+      } else if (untilStr != null) {
+        final dt = _parseRruleDate(untilStr);
+        if (dt != null) end = UntilEnd(dt);
+      }
+
+      return switch (freqStr) {
+        'DAILY' => DailyRecurrence(
+            interval: interval,
+            end: end,
+            rawRrule: rrule,
+          ),
+        'WEEKLY' => WeeklyRecurrence(
+            interval: interval,
+            daysOfWeek: _parseDaysOfWeek(params['BYDAY']),
+            wkst: params['WKST'] != null
+                ? DayOfWeek.fromRruleDay(params['WKST']!)
+                : null,
+            end: end,
+            rawRrule: rrule,
+          ),
+        'MONTHLY' => _parseMonthly(params, interval, end, rrule),
+        'YEARLY' => _parseYearly(params, interval, end, rrule),
+        _ => null, // Unsupported frequency (MINUTELY, HOURLY, etc.)
+      };
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static List<DayOfWeek>? _parseDaysOfWeek(String? byDay) {
+    if (byDay == null || byDay.isEmpty) return null;
+    final days = byDay
+        .split(',')
+        .map((d) => DayOfWeek.fromRruleDay(d.trim()))
+        .whereType<DayOfWeek>()
+        .toList();
+    return days.isEmpty ? null : days;
+  }
+
+  static List<RecurrenceDay>? _parseRecurrenceDays(String? byDay) {
+    if (byDay == null || byDay.isEmpty) return null;
+    final days = byDay
+        .split(',')
+        .map((d) => RecurrenceDay.fromRruleByDay(d.trim()))
+        .whereType<RecurrenceDay>()
+        .toList();
+    return days.isEmpty ? null : days;
+  }
+
+  static List<int>? _parseDaysOfMonth(String? byMonthDay) {
+    if (byMonthDay == null || byMonthDay.isEmpty) return null;
+    final days = byMonthDay
+        .split(',')
+        .map((d) => int.tryParse(d.trim()))
+        .whereType<int>()
+        .toList();
+    return days.isEmpty ? null : days;
+  }
+
+  static MonthlyRecurrence _parseMonthly(
+    Map<String, String> params,
+    int interval,
+    RecurrenceEnd? end,
+    String rrule,
+  ) {
+    final setPositions = _parseIntList(params['BYSETPOS']);
+    final byDay = _parseRecurrenceDays(params['BYDAY']);
+    if (byDay != null) {
+      return MonthlyRecurrence.byWeekday(
+        daysOfWeek: byDay,
+        setPositions: setPositions,
+        interval: interval,
+        end: end,
+        rawRrule: rrule,
+      );
+    }
+    return MonthlyRecurrence.byDayOfMonth(
+      daysOfMonth: _parseDaysOfMonth(params['BYMONTHDAY']),
+      setPositions: setPositions,
+      interval: interval,
+      end: end,
+      rawRrule: rrule,
+    );
+  }
+
+  static List<int>? _parseIntList(String? value) {
+    if (value == null || value.isEmpty) return null;
+    final ints = value
+        .split(',')
+        .map((d) => int.tryParse(d.trim()))
+        .whereType<int>()
+        .toList();
+    return ints.isEmpty ? null : ints;
+  }
+
+  static YearlyRecurrence _parseYearly(
+    Map<String, String> params,
+    int interval,
+    RecurrenceEnd? end,
+    String rrule,
+  ) {
+    final months = _parseIntList(params['BYMONTH']);
+    final setPositions = _parseIntList(params['BYSETPOS']);
+    final byDay = _parseRecurrenceDays(params['BYDAY']);
+    if (byDay != null) {
+      return YearlyRecurrence.byWeekday(
+        months: months,
+        daysOfWeek: byDay,
+        setPositions: setPositions,
+        interval: interval,
+        end: end,
+        rawRrule: rrule,
+      );
+    }
+    return YearlyRecurrence.byDayOfMonth(
+      months: months,
+      daysOfMonth: _parseIntList(params['BYMONTHDAY']),
+      setPositions: setPositions,
+      interval: interval,
+      end: end,
+      rawRrule: rrule,
+    );
+  }
+
+  /// Parses RRULE date string: `YYYYMMDD` or `YYYYMMDDTHHMMSSZ`.
+  static DateTime? _parseRruleDate(String dateStr) {
+    try {
+      final clean = dateStr.replaceAll('Z', '');
+      if (clean.length < 8) return null;
+
+      final year = int.parse(clean.substring(0, 4));
+      final month = int.parse(clean.substring(4, 6));
+      final day = int.parse(clean.substring(6, 8));
+
+      if (clean.length >= 15 && clean[8] == 'T') {
+        final hour = int.parse(clean.substring(9, 11));
+        final minute = int.parse(clean.substring(11, 13));
+        final second = int.parse(clean.substring(13, 15));
+        return DateTime.utc(year, month, day, hour, minute, second);
+      }
+
+      return DateTime.utc(year, month, day);
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/packages/device_calendar_plus/lib/src/recurrence_rule.dart
+++ b/packages/device_calendar_plus/lib/src/recurrence_rule.dart
@@ -240,8 +240,8 @@ class WeeklyRecurrence extends RecurrenceRule {
 /// Event repeats every N months.
 ///
 /// ```dart
-/// MonthlyRecurrence.byDayOfMonth()                        // same day as event start
-/// MonthlyRecurrence.byDayOfMonth(daysOfMonth: [1, 15])    // 1st and 15th
+/// MonthlyRecurrence()                                     // same day as event start
+/// MonthlyRecurrence(daysOfMonth: [1, 15])                 // 1st and 15th
 /// MonthlyRecurrence.byWeekday(daysOfWeek: [               // 2nd Tuesday
 ///   RecurrenceDay(DayOfWeek.tuesday, position: 2),
 /// ])
@@ -278,7 +278,7 @@ sealed class MonthlyRecurrence extends RecurrenceRule {
   /// Creates a monthly recurrence on specific days of the month (BYMONTHDAY).
   ///
   /// If [daysOfMonth] is null, the event recurs on the same day as the start date.
-  factory MonthlyRecurrence.byDayOfMonth({
+  factory MonthlyRecurrence({
     List<int>? daysOfMonth,
     List<int>? setPositions,
     int interval,
@@ -408,9 +408,9 @@ class MonthlyByWeekday extends MonthlyRecurrence {
 /// Event repeats every N years.
 ///
 /// ```dart
-/// YearlyRecurrence.byDayOfMonth()                                    // same date as event start
-/// YearlyRecurrence.byDayOfMonth(months: [12], daysOfMonth: [25])     // Christmas
-/// YearlyRecurrence.byDayOfMonth(months: [6, 12], daysOfMonth: [15])  // 15th of June and December
+/// YearlyRecurrence()                                                 // same date as event start
+/// YearlyRecurrence(months: [12], daysOfMonth: [25])                  // Christmas
+/// YearlyRecurrence(months: [6, 12], daysOfMonth: [15])               // 15th of June and December
 /// YearlyRecurrence.byWeekday(                                        // last Monday of May
 ///   months: [5],
 ///   daysOfWeek: [RecurrenceDay(DayOfWeek.monday, position: -1)],
@@ -432,7 +432,7 @@ sealed class YearlyRecurrence extends RecurrenceRule {
   /// Creates a yearly recurrence on specific months and days of month (BYMONTH + BYMONTHDAY).
   ///
   /// If both are null, the event recurs on the same date as the start date.
-  factory YearlyRecurrence.byDayOfMonth({
+  factory YearlyRecurrence({
     List<int>? months,
     List<int>? daysOfMonth,
     List<int>? setPositions,
@@ -772,7 +772,7 @@ class _RruleParser {
         rawRrule: rrule,
       );
     }
-    return MonthlyRecurrence.byDayOfMonth(
+    return MonthlyRecurrence(
       daysOfMonth: _parseDaysOfMonth(params['BYMONTHDAY']),
       setPositions: setPositions,
       interval: interval,
@@ -810,7 +810,7 @@ class _RruleParser {
         rawRrule: rrule,
       );
     }
-    return YearlyRecurrence.byDayOfMonth(
+    return YearlyRecurrence(
       months: months,
       daysOfMonth: _parseIntList(params['BYMONTHDAY']),
       setPositions: setPositions,

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -24,6 +24,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     String? location,
     String? timeZone,
     String availability,
+    String? recurrenceRule,
   )? _createEventCallback;
 
   // Callback to capture updateEvent arguments
@@ -74,6 +75,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
       String? location,
       String? timeZone,
       String availability,
+      String? recurrenceRule,
     ) callback,
   ) {
     _createEventCallback = callback;
@@ -193,6 +195,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     String? location,
     String? timeZone,
     String availability,
+    String? recurrenceRule,
   ) async {
     if (_exceptionToThrow != null) {
       throw _exceptionToThrow!;
@@ -210,6 +213,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
         location,
         timeZone,
         availability,
+        recurrenceRule,
       );
     }
 
@@ -979,6 +983,7 @@ void main() {
           location,
           timeZone,
           availability,
+          recurrenceRule,
         ) {
           capturedStart = startDate;
           capturedEnd = endDate;
@@ -1034,6 +1039,7 @@ void main() {
           location,
           timeZone,
           availability,
+          recurrenceRule,
         ) {
           capturedStart = startDate;
           capturedEnd = endDate;

--- a/packages/device_calendar_plus/test/recurrence_rule_test.dart
+++ b/packages/device_calendar_plus/test/recurrence_rule_test.dart
@@ -1,0 +1,913 @@
+import 'package:device_calendar_plus/src/recurrence_rule.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('DayOfWeek', () {
+    test('toRruleDay returns correct codes', () {
+      expect(DayOfWeek.monday.toRruleDay(), 'MO');
+      expect(DayOfWeek.tuesday.toRruleDay(), 'TU');
+      expect(DayOfWeek.wednesday.toRruleDay(), 'WE');
+      expect(DayOfWeek.thursday.toRruleDay(), 'TH');
+      expect(DayOfWeek.friday.toRruleDay(), 'FR');
+      expect(DayOfWeek.saturday.toRruleDay(), 'SA');
+      expect(DayOfWeek.sunday.toRruleDay(), 'SU');
+    });
+
+    test('fromRruleDay parses correctly', () {
+      expect(DayOfWeek.fromRruleDay('MO'), DayOfWeek.monday);
+      expect(DayOfWeek.fromRruleDay('tu'), DayOfWeek.tuesday);
+      expect(DayOfWeek.fromRruleDay('XX'), isNull);
+    });
+  });
+
+  group('RecurrenceDay', () {
+    test('without position serializes to plain day code', () {
+      const day = RecurrenceDay(DayOfWeek.tuesday);
+      expect(day.toRruleByDay(), 'TU');
+    });
+
+    test('with positive position serializes with prefix', () {
+      const day = RecurrenceDay(DayOfWeek.tuesday, position: 2);
+      expect(day.toRruleByDay(), '2TU');
+    });
+
+    test('with negative position serializes with prefix', () {
+      const day = RecurrenceDay(DayOfWeek.friday, position: -1);
+      expect(day.toRruleByDay(), '-1FR');
+    });
+
+    test('fromRruleByDay parses plain day code', () {
+      final day = RecurrenceDay.fromRruleByDay('TU');
+      expect(day, isNotNull);
+      expect(day!.day, DayOfWeek.tuesday);
+      expect(day.position, isNull);
+    });
+
+    test('fromRruleByDay parses positive position', () {
+      final day = RecurrenceDay.fromRruleByDay('2TU');
+      expect(day, isNotNull);
+      expect(day!.day, DayOfWeek.tuesday);
+      expect(day.position, 2);
+    });
+
+    test('fromRruleByDay parses negative position', () {
+      final day = RecurrenceDay.fromRruleByDay('-1FR');
+      expect(day, isNotNull);
+      expect(day!.day, DayOfWeek.friday);
+      expect(day.position, -1);
+    });
+
+    test('fromRruleByDay is case insensitive', () {
+      final day = RecurrenceDay.fromRruleByDay('2tu');
+      expect(day, isNotNull);
+      expect(day!.day, DayOfWeek.tuesday);
+      expect(day.position, 2);
+    });
+
+    test('fromRruleByDay returns null for invalid input', () {
+      expect(RecurrenceDay.fromRruleByDay('XX'), isNull);
+      expect(RecurrenceDay.fromRruleByDay('0TU'), isNull);
+      expect(RecurrenceDay.fromRruleByDay(''), isNull);
+    });
+
+    test('equality', () {
+      const a = RecurrenceDay(DayOfWeek.tuesday, position: 2);
+      const b = RecurrenceDay(DayOfWeek.tuesday, position: 2);
+      const c = RecurrenceDay(DayOfWeek.tuesday);
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('position must be non-zero', () {
+      expect(
+        () => RecurrenceDay(DayOfWeek.monday, position: 0),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
+  group('RecurrenceEnd', () {
+    test('CountEnd equality', () {
+      expect(CountEnd(5), equals(CountEnd(5)));
+      expect(CountEnd(5), isNot(equals(CountEnd(10))));
+    });
+
+    test('UntilEnd equality', () {
+      final dt = DateTime.utc(2025, 6, 15);
+      expect(UntilEnd(dt), equals(UntilEnd(dt)));
+      expect(UntilEnd(dt), isNot(equals(UntilEnd(DateTime.utc(2025, 7, 1)))));
+    });
+  });
+
+  group('toRruleString', () {
+    group('DailyRecurrence', () {
+      test('basic daily', () {
+        const rule = DailyRecurrence();
+        expect(rule.toRruleString(), 'FREQ=DAILY');
+      });
+
+      test('daily with interval', () {
+        const rule = DailyRecurrence(interval: 3);
+        expect(rule.toRruleString(), 'FREQ=DAILY;INTERVAL=3');
+      });
+
+      test('daily with count', () {
+        const rule = DailyRecurrence(end: CountEnd(10));
+        expect(rule.toRruleString(), 'FREQ=DAILY;COUNT=10');
+      });
+
+      test('daily with until (date-only, midnight)', () {
+        final rule = DailyRecurrence(end: UntilEnd(DateTime.utc(2025, 6, 15)));
+        expect(rule.toRruleString(), 'FREQ=DAILY;UNTIL=20250615');
+      });
+
+      test('daily with until (date-time)', () {
+        final rule =
+            DailyRecurrence(end: UntilEnd(DateTime.utc(2025, 6, 15, 14, 30)));
+        expect(rule.toRruleString(), 'FREQ=DAILY;UNTIL=20250615T143000Z');
+      });
+
+      test('interval=1 is omitted', () {
+        const rule = DailyRecurrence(interval: 1);
+        expect(rule.toRruleString(), 'FREQ=DAILY');
+      });
+    });
+
+    group('WeeklyRecurrence', () {
+      test('basic weekly', () {
+        const rule = WeeklyRecurrence();
+        expect(rule.toRruleString(), 'FREQ=WEEKLY');
+      });
+
+      test('weekly with days', () {
+        const rule = WeeklyRecurrence(
+          daysOfWeek: [DayOfWeek.monday, DayOfWeek.wednesday, DayOfWeek.friday],
+        );
+        expect(rule.toRruleString(), 'FREQ=WEEKLY;BYDAY=MO,WE,FR');
+      });
+
+      test('weekly with interval and count', () {
+        const rule = WeeklyRecurrence(
+          interval: 2,
+          daysOfWeek: [DayOfWeek.tuesday],
+          end: CountEnd(8),
+        );
+        expect(rule.toRruleString(), 'FREQ=WEEKLY;INTERVAL=2;BYDAY=TU;COUNT=8');
+      });
+    });
+
+    group('MonthlyRecurrence', () {
+      test('basic monthly by date', () {
+        final rule = MonthlyRecurrence.byDayOfMonth();
+        expect(rule.toRruleString(), 'FREQ=MONTHLY');
+      });
+
+      test('monthly on day 15', () {
+        final rule = MonthlyRecurrence.byDayOfMonth(daysOfMonth: [15]);
+        expect(rule.toRruleString(), 'FREQ=MONTHLY;BYMONTHDAY=15');
+      });
+
+      test('monthly on multiple days', () {
+        final rule = MonthlyRecurrence.byDayOfMonth(daysOfMonth: [1, 15]);
+        expect(rule.toRruleString(), 'FREQ=MONTHLY;BYMONTHDAY=1,15');
+      });
+
+      test('monthly with interval and until', () {
+        final rule = MonthlyRecurrence.byDayOfMonth(
+          interval: 3,
+          daysOfMonth: [1],
+          end: UntilEnd(DateTime.utc(2026, 12, 31)),
+        );
+        expect(rule.toRruleString(),
+            'FREQ=MONTHLY;INTERVAL=3;BYMONTHDAY=1;UNTIL=20261231');
+      });
+
+      test('monthly by weekday - 2nd Tuesday', () {
+        final rule = MonthlyRecurrence.byWeekday(
+          daysOfWeek: [RecurrenceDay(DayOfWeek.tuesday, position: 2)],
+        );
+        expect(rule.toRruleString(), 'FREQ=MONTHLY;BYDAY=2TU');
+      });
+
+      test('monthly by weekday - last Friday', () {
+        final rule = MonthlyRecurrence.byWeekday(
+          daysOfWeek: [RecurrenceDay(DayOfWeek.friday, position: -1)],
+        );
+        expect(rule.toRruleString(), 'FREQ=MONTHLY;BYDAY=-1FR');
+      });
+
+      test('monthly by weekday - every Tuesday (no position)', () {
+        final rule = MonthlyRecurrence.byWeekday(
+          daysOfWeek: [RecurrenceDay(DayOfWeek.tuesday)],
+        );
+        expect(rule.toRruleString(), 'FREQ=MONTHLY;BYDAY=TU');
+      });
+
+      test('monthly by weekday with interval and count', () {
+        final rule = MonthlyRecurrence.byWeekday(
+          interval: 2,
+          daysOfWeek: [RecurrenceDay(DayOfWeek.monday, position: 1)],
+          end: CountEnd(6),
+        );
+        expect(
+            rule.toRruleString(), 'FREQ=MONTHLY;INTERVAL=2;BYDAY=1MO;COUNT=6');
+      });
+    });
+
+    group('YearlyRecurrence', () {
+      test('basic yearly by date', () {
+        final rule = YearlyRecurrence.byDayOfMonth();
+        expect(rule.toRruleString(), 'FREQ=YEARLY');
+      });
+
+      test('yearly with month and day', () {
+        final rule =
+            YearlyRecurrence.byDayOfMonth(months: [3], daysOfMonth: [15]);
+        expect(rule.toRruleString(), 'FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=15');
+      });
+
+      test('yearly with multiple months', () {
+        final rule =
+            YearlyRecurrence.byDayOfMonth(months: [6, 12], daysOfMonth: [15]);
+        expect(rule.toRruleString(), 'FREQ=YEARLY;BYMONTH=6,12;BYMONTHDAY=15');
+      });
+
+      test('yearly with multiple months and days', () {
+        final rule = YearlyRecurrence.byDayOfMonth(
+            months: [6, 12], daysOfMonth: [1, 15]);
+        expect(
+            rule.toRruleString(), 'FREQ=YEARLY;BYMONTH=6,12;BYMONTHDAY=1,15');
+      });
+
+      test('yearly with count', () {
+        final rule = YearlyRecurrence.byDayOfMonth(end: CountEnd(5));
+        expect(rule.toRruleString(), 'FREQ=YEARLY;COUNT=5');
+      });
+
+      test('yearly by weekday - last Monday of May', () {
+        final rule = YearlyRecurrence.byWeekday(
+          months: [5],
+          daysOfWeek: [RecurrenceDay(DayOfWeek.monday, position: -1)],
+        );
+        expect(rule.toRruleString(), 'FREQ=YEARLY;BYMONTH=5;BYDAY=-1MO');
+      });
+
+      test('yearly by weekday - 4th Thursday of November (Thanksgiving)', () {
+        final rule = YearlyRecurrence.byWeekday(
+          months: [11],
+          daysOfWeek: [RecurrenceDay(DayOfWeek.thursday, position: 4)],
+        );
+        expect(rule.toRruleString(), 'FREQ=YEARLY;BYMONTH=11;BYDAY=4TH');
+      });
+
+      test('yearly by weekday - last Friday of June and December', () {
+        final rule = YearlyRecurrence.byWeekday(
+          months: [6, 12],
+          daysOfWeek: [RecurrenceDay(DayOfWeek.friday, position: -1)],
+        );
+        expect(rule.toRruleString(), 'FREQ=YEARLY;BYMONTH=6,12;BYDAY=-1FR');
+      });
+
+      test('yearly by weekday with interval', () {
+        final rule = YearlyRecurrence.byWeekday(
+          interval: 2,
+          months: [1],
+          daysOfWeek: [RecurrenceDay(DayOfWeek.monday, position: 3)],
+          end: CountEnd(5),
+        );
+        expect(rule.toRruleString(),
+            'FREQ=YEARLY;INTERVAL=2;BYMONTH=1;BYDAY=3MO;COUNT=5');
+      });
+    });
+  });
+
+  group('fromRruleString', () {
+    test('parses basic daily', () {
+      final rule = RecurrenceRule.fromRruleString('FREQ=DAILY');
+      expect(rule, isA<DailyRecurrence>());
+      expect(rule!.interval, 1);
+      expect(rule.end, isNull);
+    });
+
+    test('parses daily with interval and count', () {
+      final rule =
+          RecurrenceRule.fromRruleString('FREQ=DAILY;INTERVAL=3;COUNT=10');
+      expect(rule, isA<DailyRecurrence>());
+      expect(rule!.interval, 3);
+      expect(rule.end, isA<CountEnd>());
+      expect((rule.end as CountEnd).count, 10);
+    });
+
+    test('parses weekly with BYDAY', () {
+      final rule = RecurrenceRule.fromRruleString('FREQ=WEEKLY;BYDAY=MO,WE,FR');
+      expect(rule, isA<WeeklyRecurrence>());
+      final weekly = rule as WeeklyRecurrence;
+      expect(weekly.daysOfWeek, [
+        DayOfWeek.monday,
+        DayOfWeek.wednesday,
+        DayOfWeek.friday,
+      ]);
+    });
+
+    test('parses monthly with BYMONTHDAY', () {
+      final rule = RecurrenceRule.fromRruleString('FREQ=MONTHLY;BYMONTHDAY=15');
+      expect(rule, isA<MonthlyByDate>());
+      expect((rule as MonthlyByDate).daysOfMonth, [15]);
+    });
+
+    test('parses monthly with multiple BYMONTHDAY', () {
+      final rule =
+          RecurrenceRule.fromRruleString('FREQ=MONTHLY;BYMONTHDAY=1,15');
+      expect(rule, isA<MonthlyByDate>());
+      expect((rule as MonthlyByDate).daysOfMonth, [1, 15]);
+    });
+
+    test('parses monthly with positional BYDAY', () {
+      final rule = RecurrenceRule.fromRruleString('FREQ=MONTHLY;BYDAY=2TU');
+      expect(rule, isA<MonthlyByWeekday>());
+      final monthly = rule as MonthlyByWeekday;
+      expect(monthly.daysOfWeek.length, 1);
+      expect(monthly.daysOfWeek[0].day, DayOfWeek.tuesday);
+      expect(monthly.daysOfWeek[0].position, 2);
+    });
+
+    test('parses monthly with negative positional BYDAY', () {
+      final rule = RecurrenceRule.fromRruleString('FREQ=MONTHLY;BYDAY=-1FR');
+      expect(rule, isA<MonthlyByWeekday>());
+      final monthly = rule as MonthlyByWeekday;
+      expect(monthly.daysOfWeek[0].day, DayOfWeek.friday);
+      expect(monthly.daysOfWeek[0].position, -1);
+    });
+
+    test('parses monthly with plain BYDAY (no position)', () {
+      final rule = RecurrenceRule.fromRruleString('FREQ=MONTHLY;BYDAY=TU');
+      expect(rule, isA<MonthlyByWeekday>());
+      final monthly = rule as MonthlyByWeekday;
+      expect(monthly.daysOfWeek[0].day, DayOfWeek.tuesday);
+      expect(monthly.daysOfWeek[0].position, isNull);
+    });
+
+    test('parses monthly with no BYDAY or BYMONTHDAY as MonthlyByDate', () {
+      final rule = RecurrenceRule.fromRruleString('FREQ=MONTHLY');
+      expect(rule, isA<MonthlyByDate>());
+      expect((rule as MonthlyByDate).daysOfMonth, isNull);
+    });
+
+    test('parses yearly with BYMONTH and BYMONTHDAY', () {
+      final rule =
+          RecurrenceRule.fromRruleString('FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=15');
+      expect(rule, isA<YearlyByDate>());
+      final yearly = rule as YearlyByDate;
+      expect(yearly.months, [3]);
+      expect(yearly.daysOfMonth, [15]);
+    });
+
+    test('parses yearly with multiple BYMONTH', () {
+      final rule = RecurrenceRule.fromRruleString(
+          'FREQ=YEARLY;BYMONTH=6,12;BYMONTHDAY=15');
+      expect(rule, isA<YearlyByDate>());
+      final yearly = rule as YearlyByDate;
+      expect(yearly.months, [6, 12]);
+      expect(yearly.daysOfMonth, [15]);
+    });
+
+    test('parses yearly with BYMONTH and positional BYDAY', () {
+      final rule =
+          RecurrenceRule.fromRruleString('FREQ=YEARLY;BYMONTH=5;BYDAY=-1MO');
+      expect(rule, isA<YearlyByWeekday>());
+      final yearly = rule as YearlyByWeekday;
+      expect(yearly.months, [5]);
+      expect(yearly.daysOfWeek.length, 1);
+      expect(yearly.daysOfWeek[0].day, DayOfWeek.monday);
+      expect(yearly.daysOfWeek[0].position, -1);
+    });
+
+    test('parses yearly with no BYDAY as YearlyByDate', () {
+      final rule = RecurrenceRule.fromRruleString('FREQ=YEARLY;BYMONTH=12');
+      expect(rule, isA<YearlyByDate>());
+      expect((rule as YearlyByDate).months, [12]);
+    });
+
+    test('handles RRULE: prefix', () {
+      final rule = RecurrenceRule.fromRruleString('RRULE:FREQ=DAILY;COUNT=5');
+      expect(rule, isA<DailyRecurrence>());
+      expect((rule!.end as CountEnd).count, 5);
+    });
+
+    test('returns null for unsupported frequency', () {
+      expect(RecurrenceRule.fromRruleString('FREQ=MINUTELY'), isNull);
+      expect(RecurrenceRule.fromRruleString('FREQ=HOURLY'), isNull);
+      expect(RecurrenceRule.fromRruleString('FREQ=SECONDLY'), isNull);
+    });
+
+    test('returns null for missing FREQ', () {
+      expect(RecurrenceRule.fromRruleString('INTERVAL=2;COUNT=5'), isNull);
+    });
+
+    test('returns null for empty string', () {
+      expect(RecurrenceRule.fromRruleString(''), isNull);
+    });
+
+    test('returns null for garbage', () {
+      expect(RecurrenceRule.fromRruleString('not a rrule'), isNull);
+    });
+  });
+
+  group('UNTIL date parsing', () {
+    test('parses date-only UNTIL (YYYYMMDD)', () {
+      final rule = RecurrenceRule.fromRruleString('FREQ=DAILY;UNTIL=20250615');
+      expect(rule, isNotNull);
+      final until = (rule!.end as UntilEnd).until;
+      expect(until, DateTime.utc(2025, 6, 15));
+      expect(until.hour, 0);
+      expect(until.minute, 0);
+      expect(until.second, 0);
+    });
+
+    test('parses date-time UNTIL (YYYYMMDDTHHMMSSZ)', () {
+      final rule =
+          RecurrenceRule.fromRruleString('FREQ=DAILY;UNTIL=20250615T143000Z');
+      expect(rule, isNotNull);
+      final until = (rule!.end as UntilEnd).until;
+      expect(until, DateTime.utc(2025, 6, 15, 14, 30, 0));
+    });
+
+    test('parses date-time UNTIL without Z suffix', () {
+      final rule =
+          RecurrenceRule.fromRruleString('FREQ=DAILY;UNTIL=20250615T143000');
+      expect(rule, isNotNull);
+      final until = (rule!.end as UntilEnd).until;
+      expect(until, DateTime.utc(2025, 6, 15, 14, 30, 0));
+    });
+  });
+
+  group('UNTIL date serialization', () {
+    test('midnight DateTime serializes as date-only', () {
+      final rule = DailyRecurrence(end: UntilEnd(DateTime.utc(2025, 6, 15)));
+      final rrule = rule.toRruleString();
+      expect(rrule, contains('UNTIL=20250615'));
+      // Should not have a time component (no T after the date digits)
+      expect(rrule, isNot(contains('UNTIL=20250615T')));
+    });
+
+    test('non-midnight DateTime serializes with time and Z', () {
+      final rule =
+          DailyRecurrence(end: UntilEnd(DateTime.utc(2025, 6, 15, 14, 30)));
+      expect(rule.toRruleString(), contains('UNTIL=20250615T143000Z'));
+    });
+
+    test('local DateTime is converted to UTC before serialization', () {
+      // Create a local DateTime (not UTC)
+      final localDt = DateTime(2025, 6, 15, 14, 30);
+      final rule = DailyRecurrence(end: UntilEnd(localDt));
+      final rrule = rule.toRruleString();
+      // The UNTIL should contain the UTC-converted time
+      expect(rrule, contains('UNTIL='));
+      expect(rrule, contains('Z'));
+    });
+  });
+
+  group('serialization roundtrip', () {
+    test('daily roundtrip', () {
+      const original = DailyRecurrence(interval: 2, end: CountEnd(10));
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      expect(parsed, isA<DailyRecurrence>());
+      expect(parsed!.interval, original.interval);
+      expect(parsed.end, original.end);
+    });
+
+    test('weekly roundtrip with days', () {
+      const original = WeeklyRecurrence(
+        interval: 1,
+        daysOfWeek: [DayOfWeek.monday, DayOfWeek.friday],
+        end: CountEnd(20),
+      );
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      expect(parsed, isA<WeeklyRecurrence>());
+      final weekly = parsed as WeeklyRecurrence;
+      expect(weekly.daysOfWeek, original.daysOfWeek);
+      expect(weekly.end, original.end);
+    });
+
+    test('monthly by date roundtrip', () {
+      final original =
+          MonthlyRecurrence.byDayOfMonth(daysOfMonth: [28], end: CountEnd(12));
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      expect(parsed, isA<MonthlyByDate>());
+      expect((parsed as MonthlyByDate).daysOfMonth, [28]);
+    });
+
+    test('monthly by date roundtrip with multiple days', () {
+      final original = MonthlyRecurrence.byDayOfMonth(
+          daysOfMonth: [1, 15], end: CountEnd(12));
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      expect(parsed, isA<MonthlyByDate>());
+      expect((parsed as MonthlyByDate).daysOfMonth, [1, 15]);
+    });
+
+    test('monthly by weekday roundtrip - positional', () {
+      final original = MonthlyRecurrence.byWeekday(
+        daysOfWeek: [RecurrenceDay(DayOfWeek.tuesday, position: 2)],
+        end: CountEnd(12),
+      );
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      expect(parsed, isA<MonthlyByWeekday>());
+      final monthly = parsed as MonthlyByWeekday;
+      expect(monthly.daysOfWeek.length, 1);
+      expect(monthly.daysOfWeek[0].day, DayOfWeek.tuesday);
+      expect(monthly.daysOfWeek[0].position, 2);
+    });
+
+    test('monthly by weekday roundtrip - negative position', () {
+      final original = MonthlyRecurrence.byWeekday(
+        daysOfWeek: [RecurrenceDay(DayOfWeek.friday, position: -1)],
+      );
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      expect(parsed, isA<MonthlyByWeekday>());
+      final monthly = parsed as MonthlyByWeekday;
+      expect(monthly.daysOfWeek[0].day, DayOfWeek.friday);
+      expect(monthly.daysOfWeek[0].position, -1);
+    });
+
+    test('monthly by weekday roundtrip - no position', () {
+      final original = MonthlyRecurrence.byWeekday(
+        daysOfWeek: [RecurrenceDay(DayOfWeek.wednesday)],
+      );
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      expect(parsed, isA<MonthlyByWeekday>());
+      final monthly = parsed as MonthlyByWeekday;
+      expect(monthly.daysOfWeek[0].day, DayOfWeek.wednesday);
+      expect(monthly.daysOfWeek[0].position, isNull);
+    });
+
+    test('yearly by date roundtrip', () {
+      final original = YearlyRecurrence.byDayOfMonth(
+          months: [12], daysOfMonth: [25], end: CountEnd(5));
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      expect(parsed, isA<YearlyByDate>());
+      final yearly = parsed as YearlyByDate;
+      expect(yearly.months, [12]);
+      expect(yearly.daysOfMonth, [25]);
+    });
+
+    test('yearly by date roundtrip with multiple months', () {
+      final original =
+          YearlyRecurrence.byDayOfMonth(months: [6, 12], daysOfMonth: [1, 15]);
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      expect(parsed, isA<YearlyByDate>());
+      final yearly = parsed as YearlyByDate;
+      expect(yearly.months, [6, 12]);
+      expect(yearly.daysOfMonth, [1, 15]);
+    });
+
+    test('yearly by weekday roundtrip', () {
+      final original = YearlyRecurrence.byWeekday(
+        months: [11],
+        daysOfWeek: [RecurrenceDay(DayOfWeek.thursday, position: 4)],
+      );
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      expect(parsed, isA<YearlyByWeekday>());
+      final yearly = parsed as YearlyByWeekday;
+      expect(yearly.months, [11]);
+      expect(yearly.daysOfWeek[0].day, DayOfWeek.thursday);
+      expect(yearly.daysOfWeek[0].position, 4);
+    });
+
+    test('yearly by weekday roundtrip with multiple months', () {
+      final original = YearlyRecurrence.byWeekday(
+        months: [6, 12],
+        daysOfWeek: [RecurrenceDay(DayOfWeek.friday, position: -1)],
+      );
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      expect(parsed, isA<YearlyByWeekday>());
+      final yearly = parsed as YearlyByWeekday;
+      expect(yearly.months, [6, 12]);
+      expect(yearly.daysOfWeek[0].day, DayOfWeek.friday);
+      expect(yearly.daysOfWeek[0].position, -1);
+    });
+
+    test('UNTIL date-only roundtrip', () {
+      final original =
+          DailyRecurrence(end: UntilEnd(DateTime.utc(2025, 6, 15)));
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      final until = (parsed!.end as UntilEnd).until;
+      expect(until, DateTime.utc(2025, 6, 15));
+    });
+
+    test('UNTIL date-time roundtrip', () {
+      final original =
+          DailyRecurrence(end: UntilEnd(DateTime.utc(2025, 6, 15, 14, 30, 45)));
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      final until = (parsed!.end as UntilEnd).until;
+      expect(until, DateTime.utc(2025, 6, 15, 14, 30, 45));
+    });
+  });
+
+  group('rruleString getter', () {
+    test('returns toRruleString when constructed directly', () {
+      const rule = DailyRecurrence(interval: 2, end: CountEnd(5));
+      expect(rule.rruleString, rule.toRruleString());
+    });
+
+    test('returns original raw string when parsed', () {
+      const raw = 'FREQ=DAILY;INTERVAL=2;COUNT=5;BYHOUR=9';
+      final rule = RecurrenceRule.fromRruleString(raw);
+      // rruleString preserves the original including BYHOUR
+      expect(rule!.rruleString, raw);
+    });
+
+    test('preserves RRULE: prefix in raw string', () {
+      const raw = 'RRULE:FREQ=WEEKLY;BYDAY=MO';
+      final rule = RecurrenceRule.fromRruleString(raw);
+      expect(rule!.rruleString, raw);
+    });
+  });
+
+  group('equality', () {
+    test('same DailyRecurrence are equal', () {
+      const a = DailyRecurrence(interval: 2, end: CountEnd(5));
+      const b = DailyRecurrence(interval: 2, end: CountEnd(5));
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('different frequencies are not equal', () {
+      const daily = DailyRecurrence(end: CountEnd(5));
+      const weekly = WeeklyRecurrence(end: CountEnd(5));
+      expect(daily, isNot(equals(weekly)));
+    });
+
+    test('WeeklyRecurrence with different days are not equal', () {
+      const a = WeeklyRecurrence(daysOfWeek: [DayOfWeek.monday]);
+      const b = WeeklyRecurrence(daysOfWeek: [DayOfWeek.friday]);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('MonthlyByDate with different daysOfMonth are not equal', () {
+      final a = MonthlyRecurrence.byDayOfMonth(daysOfMonth: [1]);
+      final b = MonthlyRecurrence.byDayOfMonth(daysOfMonth: [15]);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('MonthlyByWeekday with different days are not equal', () {
+      final a = MonthlyRecurrence.byWeekday(
+        daysOfWeek: [RecurrenceDay(DayOfWeek.tuesday, position: 2)],
+      );
+      final b = MonthlyRecurrence.byWeekday(
+        daysOfWeek: [RecurrenceDay(DayOfWeek.friday, position: -1)],
+      );
+      expect(a, isNot(equals(b)));
+    });
+
+    test('MonthlyByDate and MonthlyByWeekday are not equal', () {
+      final a = MonthlyRecurrence.byDayOfMonth(daysOfMonth: [15]);
+      final b = MonthlyRecurrence.byWeekday(
+        daysOfWeek: [RecurrenceDay(DayOfWeek.tuesday, position: 2)],
+      );
+      expect(a, isNot(equals(b)));
+    });
+  });
+
+  group('WKST', () {
+    test('weekly with wkst serializes correctly', () {
+      const rule = WeeklyRecurrence(
+        daysOfWeek: [DayOfWeek.monday],
+        wkst: DayOfWeek.sunday,
+      );
+      expect(rule.toRruleString(), 'FREQ=WEEKLY;BYDAY=MO;WKST=SU');
+    });
+
+    test('weekly without wkst omits it', () {
+      const rule = WeeklyRecurrence(daysOfWeek: [DayOfWeek.monday]);
+      expect(rule.toRruleString(), isNot(contains('WKST')));
+    });
+
+    test('parses WKST from rrule string', () {
+      final rule =
+          RecurrenceRule.fromRruleString('FREQ=WEEKLY;BYDAY=MO;WKST=SU');
+      expect(rule, isA<WeeklyRecurrence>());
+      expect((rule as WeeklyRecurrence).wkst, DayOfWeek.sunday);
+    });
+
+    test('WKST roundtrip', () {
+      const original = WeeklyRecurrence(
+        daysOfWeek: [DayOfWeek.monday, DayOfWeek.friday],
+        wkst: DayOfWeek.sunday,
+        end: CountEnd(10),
+      );
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      expect(parsed, isA<WeeklyRecurrence>());
+      final weekly = parsed as WeeklyRecurrence;
+      expect(weekly.wkst, DayOfWeek.sunday);
+      expect(weekly.daysOfWeek, original.daysOfWeek);
+    });
+
+    test('WKST equality', () {
+      const a = WeeklyRecurrence(
+          daysOfWeek: [DayOfWeek.monday], wkst: DayOfWeek.sunday);
+      const b = WeeklyRecurrence(
+          daysOfWeek: [DayOfWeek.monday], wkst: DayOfWeek.sunday);
+      const c = WeeklyRecurrence(
+          daysOfWeek: [DayOfWeek.monday], wkst: DayOfWeek.monday);
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+  });
+
+  group('BYSETPOS', () {
+    test('monthly byWeekday with setPositions - last weekday', () {
+      final rule = MonthlyRecurrence.byWeekday(
+        daysOfWeek: [
+          RecurrenceDay(DayOfWeek.monday),
+          RecurrenceDay(DayOfWeek.tuesday),
+          RecurrenceDay(DayOfWeek.wednesday),
+          RecurrenceDay(DayOfWeek.thursday),
+          RecurrenceDay(DayOfWeek.friday),
+        ],
+        setPositions: [-1],
+      );
+      expect(rule.toRruleString(),
+          'FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-1');
+    });
+
+    test('monthly byWeekday with setPositions - first and last', () {
+      final rule = MonthlyRecurrence.byWeekday(
+        daysOfWeek: [
+          RecurrenceDay(DayOfWeek.monday),
+          RecurrenceDay(DayOfWeek.friday),
+        ],
+        setPositions: [1, -1],
+      );
+      expect(rule.toRruleString(), 'FREQ=MONTHLY;BYDAY=MO,FR;BYSETPOS=1,-1');
+    });
+
+    test('monthly without setPositions omits it', () {
+      final rule = MonthlyRecurrence.byWeekday(
+        daysOfWeek: [RecurrenceDay(DayOfWeek.monday)],
+      );
+      expect(rule.toRruleString(), isNot(contains('BYSETPOS')));
+    });
+
+    test('parses BYSETPOS from monthly rrule', () {
+      final rule = RecurrenceRule.fromRruleString(
+          'FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=-1');
+      expect(rule, isA<MonthlyByWeekday>());
+      final monthly = rule as MonthlyByWeekday;
+      expect(monthly.setPositions, [-1]);
+      expect(monthly.daysOfWeek.length, 5);
+    });
+
+    test('parses BYSETPOS from yearly rrule', () {
+      final rule = RecurrenceRule.fromRruleString(
+          'FREQ=YEARLY;BYMONTH=1;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=1');
+      expect(rule, isA<YearlyByWeekday>());
+      final yearly = rule as YearlyByWeekday;
+      expect(yearly.setPositions, [1]);
+    });
+
+    test('BYSETPOS monthly roundtrip', () {
+      final original = MonthlyRecurrence.byWeekday(
+        daysOfWeek: [
+          RecurrenceDay(DayOfWeek.monday),
+          RecurrenceDay(DayOfWeek.tuesday),
+          RecurrenceDay(DayOfWeek.wednesday),
+          RecurrenceDay(DayOfWeek.thursday),
+          RecurrenceDay(DayOfWeek.friday),
+        ],
+        setPositions: [-1],
+        end: CountEnd(12),
+      );
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      expect(parsed, isA<MonthlyByWeekday>());
+      final monthly = parsed as MonthlyByWeekday;
+      expect(monthly.setPositions, [-1]);
+      expect(monthly.daysOfWeek.length, 5);
+      expect((monthly.end as CountEnd).count, 12);
+    });
+
+    test('BYSETPOS yearly roundtrip', () {
+      final original = YearlyRecurrence.byWeekday(
+        months: [1],
+        daysOfWeek: [
+          RecurrenceDay(DayOfWeek.monday),
+          RecurrenceDay(DayOfWeek.friday),
+        ],
+        setPositions: [1, -1],
+      );
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      expect(parsed, isA<YearlyByWeekday>());
+      final yearly = parsed as YearlyByWeekday;
+      expect(yearly.setPositions, [1, -1]);
+    });
+
+    test('BYSETPOS equality', () {
+      final a = MonthlyRecurrence.byWeekday(
+        daysOfWeek: [RecurrenceDay(DayOfWeek.monday)],
+        setPositions: [-1],
+      );
+      final b = MonthlyRecurrence.byWeekday(
+        daysOfWeek: [RecurrenceDay(DayOfWeek.monday)],
+        setPositions: [-1],
+      );
+      final c = MonthlyRecurrence.byWeekday(
+        daysOfWeek: [RecurrenceDay(DayOfWeek.monday)],
+        setPositions: [1],
+      );
+      expect(a, equals(b));
+      expect(a, isNot(equals(c)));
+    });
+  });
+
+  group('validation', () {
+    test('interval must be >= 1', () {
+      expect(
+          () => DailyRecurrence(interval: 0), throwsA(isA<AssertionError>()));
+    });
+
+    test('CountEnd count must be >= 1', () {
+      expect(() => CountEnd(0), throwsA(isA<AssertionError>()));
+    });
+
+    test('MonthlyByDate daysOfMonth range', () {
+      expect(
+        () => MonthlyRecurrence.byDayOfMonth(daysOfMonth: [0]),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => MonthlyRecurrence.byDayOfMonth(daysOfMonth: [32]),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => MonthlyRecurrence.byDayOfMonth(daysOfMonth: [1, 15, 31]),
+        returnsNormally,
+      );
+    });
+
+    test('YearlyByDate months range', () {
+      expect(
+        () => YearlyRecurrence.byDayOfMonth(months: [0]),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => YearlyRecurrence.byDayOfMonth(months: [13]),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => YearlyRecurrence.byDayOfMonth(months: [1, 6, 12]),
+        returnsNormally,
+      );
+    });
+
+    test('YearlyByDate daysOfMonth range', () {
+      expect(
+        () => YearlyRecurrence.byDayOfMonth(daysOfMonth: [0]),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => YearlyRecurrence.byDayOfMonth(daysOfMonth: [32]),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('YearlyByWeekday months range', () {
+      expect(
+        () => YearlyRecurrence.byWeekday(
+          months: [0],
+          daysOfWeek: [RecurrenceDay(DayOfWeek.monday)],
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => YearlyRecurrence.byWeekday(
+          months: [13],
+          daysOfWeek: [RecurrenceDay(DayOfWeek.monday)],
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('RecurrenceDay position range', () {
+      expect(
+        () => RecurrenceDay(DayOfWeek.monday, position: 0),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => RecurrenceDay(DayOfWeek.monday, position: 54),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => RecurrenceDay(DayOfWeek.monday, position: -54),
+        throwsA(isA<AssertionError>()),
+      );
+      // Valid bounds
+      expect(
+        () => RecurrenceDay(DayOfWeek.monday, position: 53),
+        returnsNormally,
+      );
+      expect(
+        () => RecurrenceDay(DayOfWeek.monday, position: -53),
+        returnsNormally,
+      );
+    });
+  });
+}

--- a/packages/device_calendar_plus/test/recurrence_rule_test.dart
+++ b/packages/device_calendar_plus/test/recurrence_rule_test.dart
@@ -158,22 +158,22 @@ void main() {
 
     group('MonthlyRecurrence', () {
       test('basic monthly by date', () {
-        final rule = MonthlyRecurrence.byDayOfMonth();
+        final rule = MonthlyRecurrence();
         expect(rule.toRruleString(), 'FREQ=MONTHLY');
       });
 
       test('monthly on day 15', () {
-        final rule = MonthlyRecurrence.byDayOfMonth(daysOfMonth: [15]);
+        final rule = MonthlyRecurrence(daysOfMonth: [15]);
         expect(rule.toRruleString(), 'FREQ=MONTHLY;BYMONTHDAY=15');
       });
 
       test('monthly on multiple days', () {
-        final rule = MonthlyRecurrence.byDayOfMonth(daysOfMonth: [1, 15]);
+        final rule = MonthlyRecurrence(daysOfMonth: [1, 15]);
         expect(rule.toRruleString(), 'FREQ=MONTHLY;BYMONTHDAY=1,15');
       });
 
       test('monthly with interval and until', () {
-        final rule = MonthlyRecurrence.byDayOfMonth(
+        final rule = MonthlyRecurrence(
           interval: 3,
           daysOfMonth: [1],
           end: UntilEnd(DateTime.utc(2026, 12, 31)),
@@ -216,31 +216,31 @@ void main() {
 
     group('YearlyRecurrence', () {
       test('basic yearly by date', () {
-        final rule = YearlyRecurrence.byDayOfMonth();
+        final rule = YearlyRecurrence();
         expect(rule.toRruleString(), 'FREQ=YEARLY');
       });
 
       test('yearly with month and day', () {
         final rule =
-            YearlyRecurrence.byDayOfMonth(months: [3], daysOfMonth: [15]);
+            YearlyRecurrence(months: [3], daysOfMonth: [15]);
         expect(rule.toRruleString(), 'FREQ=YEARLY;BYMONTH=3;BYMONTHDAY=15');
       });
 
       test('yearly with multiple months', () {
         final rule =
-            YearlyRecurrence.byDayOfMonth(months: [6, 12], daysOfMonth: [15]);
+            YearlyRecurrence(months: [6, 12], daysOfMonth: [15]);
         expect(rule.toRruleString(), 'FREQ=YEARLY;BYMONTH=6,12;BYMONTHDAY=15');
       });
 
       test('yearly with multiple months and days', () {
-        final rule = YearlyRecurrence.byDayOfMonth(
+        final rule = YearlyRecurrence(
             months: [6, 12], daysOfMonth: [1, 15]);
         expect(
             rule.toRruleString(), 'FREQ=YEARLY;BYMONTH=6,12;BYMONTHDAY=1,15');
       });
 
       test('yearly with count', () {
-        final rule = YearlyRecurrence.byDayOfMonth(end: CountEnd(5));
+        final rule = YearlyRecurrence(end: CountEnd(5));
         expect(rule.toRruleString(), 'FREQ=YEARLY;COUNT=5');
       });
 
@@ -491,14 +491,14 @@ void main() {
 
     test('monthly by date roundtrip', () {
       final original =
-          MonthlyRecurrence.byDayOfMonth(daysOfMonth: [28], end: CountEnd(12));
+          MonthlyRecurrence(daysOfMonth: [28], end: CountEnd(12));
       final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
       expect(parsed, isA<MonthlyByDate>());
       expect((parsed as MonthlyByDate).daysOfMonth, [28]);
     });
 
     test('monthly by date roundtrip with multiple days', () {
-      final original = MonthlyRecurrence.byDayOfMonth(
+      final original = MonthlyRecurrence(
           daysOfMonth: [1, 15], end: CountEnd(12));
       final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
       expect(parsed, isA<MonthlyByDate>());
@@ -541,7 +541,7 @@ void main() {
     });
 
     test('yearly by date roundtrip', () {
-      final original = YearlyRecurrence.byDayOfMonth(
+      final original = YearlyRecurrence(
           months: [12], daysOfMonth: [25], end: CountEnd(5));
       final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
       expect(parsed, isA<YearlyByDate>());
@@ -552,7 +552,7 @@ void main() {
 
     test('yearly by date roundtrip with multiple months', () {
       final original =
-          YearlyRecurrence.byDayOfMonth(months: [6, 12], daysOfMonth: [1, 15]);
+          YearlyRecurrence(months: [6, 12], daysOfMonth: [1, 15]);
       final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
       expect(parsed, isA<YearlyByDate>());
       final yearly = parsed as YearlyByDate;
@@ -644,8 +644,8 @@ void main() {
     });
 
     test('MonthlyByDate with different daysOfMonth are not equal', () {
-      final a = MonthlyRecurrence.byDayOfMonth(daysOfMonth: [1]);
-      final b = MonthlyRecurrence.byDayOfMonth(daysOfMonth: [15]);
+      final a = MonthlyRecurrence(daysOfMonth: [1]);
+      final b = MonthlyRecurrence(daysOfMonth: [15]);
       expect(a, isNot(equals(b)));
     });
 
@@ -660,7 +660,7 @@ void main() {
     });
 
     test('MonthlyByDate and MonthlyByWeekday are not equal', () {
-      final a = MonthlyRecurrence.byDayOfMonth(daysOfMonth: [15]);
+      final a = MonthlyRecurrence(daysOfMonth: [15]);
       final b = MonthlyRecurrence.byWeekday(
         daysOfWeek: [RecurrenceDay(DayOfWeek.tuesday, position: 2)],
       );
@@ -830,41 +830,41 @@ void main() {
 
     test('MonthlyByDate daysOfMonth range', () {
       expect(
-        () => MonthlyRecurrence.byDayOfMonth(daysOfMonth: [0]),
+        () => MonthlyRecurrence(daysOfMonth: [0]),
         throwsA(isA<AssertionError>()),
       );
       expect(
-        () => MonthlyRecurrence.byDayOfMonth(daysOfMonth: [32]),
+        () => MonthlyRecurrence(daysOfMonth: [32]),
         throwsA(isA<AssertionError>()),
       );
       expect(
-        () => MonthlyRecurrence.byDayOfMonth(daysOfMonth: [1, 15, 31]),
+        () => MonthlyRecurrence(daysOfMonth: [1, 15, 31]),
         returnsNormally,
       );
     });
 
     test('YearlyByDate months range', () {
       expect(
-        () => YearlyRecurrence.byDayOfMonth(months: [0]),
+        () => YearlyRecurrence(months: [0]),
         throwsA(isA<AssertionError>()),
       );
       expect(
-        () => YearlyRecurrence.byDayOfMonth(months: [13]),
+        () => YearlyRecurrence(months: [13]),
         throwsA(isA<AssertionError>()),
       );
       expect(
-        () => YearlyRecurrence.byDayOfMonth(months: [1, 6, 12]),
+        () => YearlyRecurrence(months: [1, 6, 12]),
         returnsNormally,
       );
     });
 
     test('YearlyByDate daysOfMonth range', () {
       expect(
-        () => YearlyRecurrence.byDayOfMonth(daysOfMonth: [0]),
+        () => YearlyRecurrence(daysOfMonth: [0]),
         throwsA(isA<AssertionError>()),
       );
       expect(
-        () => YearlyRecurrence.byDayOfMonth(daysOfMonth: [32]),
+        () => YearlyRecurrence(daysOfMonth: [32]),
         throwsA(isA<AssertionError>()),
       );
     });

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
@@ -328,6 +328,7 @@ class DeviceCalendarPlusAndroidPlugin :
         val location = call.argument<String>("location")
         val timeZone = call.argument<String>("timeZone")
         val availability = call.argument<String>("availability")
+        val recurrenceRule = call.argument<String>("recurrenceRule")
         
         // Validate required arguments
         if (calendarId == null || title == null || startDateMillis == null || 
@@ -352,7 +353,8 @@ class DeviceCalendarPlusAndroidPlugin :
             description,
             location,
             timeZone,
-            availability
+            availability,
+            recurrenceRule
         )
         
         serviceResult.fold(

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -229,8 +229,11 @@ class EventsService(private val activity: Activity) {
             eventMap["timeZone"] = timeZone
         }
         
-        // Set isRecurring flag
+        // Set isRecurring flag and raw RRULE string
         eventMap["isRecurring"] = (recurrenceRule != null)
+        if (recurrenceRule != null) {
+            eventMap["recurrenceRule"] = recurrenceRule
+        }
         
         // Add creation and modification dates if available
         if (createdDate != null) {
@@ -401,7 +404,8 @@ class EventsService(private val activity: Activity) {
         description: String?,
         location: String?,
         timeZone: String?,
-        availability: String
+        availability: String,
+        recurrenceRule: String?
     ): Result<String> {
         // Check for write calendar permission
         if (android.content.pm.PackageManager.PERMISSION_GRANTED != 
@@ -451,8 +455,17 @@ class EventsService(private val activity: Activity) {
                 put(CalendarContract.Events.CALENDAR_ID, calendarId.toLong())
                 put(CalendarContract.Events.TITLE, title)
                 put(CalendarContract.Events.DTSTART, startMillis)
-                put(CalendarContract.Events.DTEND, endMillis)
                 put(CalendarContract.Events.ALL_DAY, if (isAllDay) 1 else 0)
+                
+                // For recurring events, Android requires DURATION instead of DTEND
+                if (recurrenceRule != null) {
+                    val durationMillis = endMillis - startMillis
+                    val durationSeconds = durationMillis / 1000
+                    put(CalendarContract.Events.DURATION, "P${durationSeconds}S")
+                    put(CalendarContract.Events.RRULE, recurrenceRule)
+                } else {
+                    put(CalendarContract.Events.DTEND, endMillis)
+                }
                 
                 // Set description if provided
                 if (description != null) {

--- a/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
+++ b/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
@@ -135,6 +135,7 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
     String? location,
     String? timeZone,
     String availability,
+    String? recurrenceRule,
   ) async {
     final result = await methodChannel.invokeMethod<String>(
       'createEvent',
@@ -148,6 +149,7 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
         'location': location,
         'timeZone': timeZone,
         'availability': availability,
+        'recurrenceRule': recurrenceRule,
       },
     );
     return result!;

--- a/packages/device_calendar_plus_android/test/device_calendar_plus_android_test.dart
+++ b/packages/device_calendar_plus_android/test/device_calendar_plus_android_test.dart
@@ -205,6 +205,7 @@ void main() {
         'Conference Room A',
         'America/New_York',
         'busy',
+        null,
       );
 
       expect(log.length, equals(1));
@@ -237,6 +238,7 @@ void main() {
         null,
         null,
         'free',
+        null,
       );
 
       expect(log.length, equals(1));

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
@@ -394,6 +394,7 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     let description = args["description"] as? String
     let location = args["location"] as? String
     let timeZone = args["timeZone"] as? String
+    let recurrenceRule = args["recurrenceRule"] as? String
     
     // Convert dates
     let startDate = Date(timeIntervalSince1970: TimeInterval(startDateMillis) / 1000.0)
@@ -408,7 +409,8 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
       description: description,
       location: location,
       timeZone: timeZone,
-      availability: availability
+      availability: availability,
+      recurrenceRule: recurrenceRule
     ) { serviceResult in
       DispatchQueue.main.async {
         switch serviceResult {

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -164,6 +164,11 @@ class EventsService {
     // Set isRecurring flag
     eventMap["isRecurring"] = event.hasRecurrenceRules
     
+    // Serialize recurrence rule to RRULE string
+    if event.hasRecurrenceRules, let rule = event.recurrenceRules?.first {
+      eventMap["recurrenceRule"] = ekRecurrenceRuleToRruleString(rule)
+    }
+    
     return eventMap
   }
   
@@ -293,6 +298,7 @@ class EventsService {
     location: String?,
     timeZone: String?,
     availability: String,
+    recurrenceRule: String?,
     completion: @escaping (Result<String, CalendarError>) -> Void
   ) {
     // Check permission - creating events only requires write access
@@ -347,6 +353,11 @@ class EventsService {
       event.availability = .busy
     }
     
+    // Set recurrence rule if provided
+    if let rruleString = recurrenceRule, let rule = parseRecurrenceRule(rruleString) {
+      event.recurrenceRules = [rule]
+    }
+    
     // Save the event
     do {
       try eventStore.save(event, span: .thisEvent)
@@ -366,6 +377,232 @@ class EventsService {
         message: "Failed to save event: \(error.localizedDescription)"
       )))
     }
+  }
+  
+  // MARK: - RRULE <-> EKRecurrenceRule conversion
+  
+  /// Parses an RRULE string into an EKRecurrenceRule.
+  private func parseRecurrenceRule(_ rrule: String) -> EKRecurrenceRule? {
+    var params: [String: String] = [:]
+    let ruleStr = rrule.hasPrefix("RRULE:") ? String(rrule.dropFirst(6)) : rrule
+    
+    for part in ruleStr.components(separatedBy: ";") {
+      let kv = part.components(separatedBy: "=")
+      if kv.count == 2 {
+        params[kv[0].uppercased()] = kv[1]
+      }
+    }
+    
+    guard let freqStr = params["FREQ"] else { return nil }
+    
+    let frequency: EKRecurrenceFrequency
+    switch freqStr {
+    case "DAILY": frequency = .daily
+    case "WEEKLY": frequency = .weekly
+    case "MONTHLY": frequency = .monthly
+    case "YEARLY": frequency = .yearly
+    default: return nil
+    }
+    
+    let interval = Int(params["INTERVAL"] ?? "1") ?? 1
+    
+    // Parse end condition
+    var end: EKRecurrenceEnd? = nil
+    if let countStr = params["COUNT"], let count = Int(countStr) {
+      end = EKRecurrenceEnd(occurrenceCount: count)
+    } else if let untilStr = params["UNTIL"] {
+      if let date = parseRruleDate(untilStr) {
+        end = EKRecurrenceEnd(end: date)
+      }
+    }
+    
+    // Parse BYDAY (supports plain codes like "TU" and positional like "2TU", "-1FR")
+    var daysOfTheWeek: [EKRecurrenceDayOfWeek]? = nil
+    if let byDayStr = params["BYDAY"] {
+      daysOfTheWeek = byDayStr.components(separatedBy: ",").compactMap { dayStr in
+        parseByDayValue(dayStr.trimmingCharacters(in: .whitespaces))
+      }
+      if daysOfTheWeek?.isEmpty ?? true { daysOfTheWeek = nil }
+    }
+    
+    // Parse BYMONTHDAY (supports comma-separated values)
+    var daysOfTheMonth: [NSNumber]? = nil
+    if let str = params["BYMONTHDAY"] {
+      let days = str.components(separatedBy: ",").compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+      if !days.isEmpty { daysOfTheMonth = days.map { NSNumber(value: $0) } }
+    }
+
+    // Parse BYMONTH (supports comma-separated values)
+    var monthsOfTheYear: [NSNumber]? = nil
+    if let str = params["BYMONTH"] {
+      let months = str.components(separatedBy: ",").compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+      if !months.isEmpty { monthsOfTheYear = months.map { NSNumber(value: $0) } }
+    }
+    
+    // Parse BYSETPOS (supports comma-separated values)
+    var setPositions: [NSNumber]? = nil
+    if let str = params["BYSETPOS"] {
+      let positions = str.components(separatedBy: ",").compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+      if !positions.isEmpty { setPositions = positions.map { NSNumber(value: $0) } }
+    }
+
+    return EKRecurrenceRule(
+      recurrenceWith: frequency,
+      interval: interval,
+      daysOfTheWeek: daysOfTheWeek,
+      daysOfTheMonth: daysOfTheMonth,
+      monthsOfTheYear: monthsOfTheYear,
+      weeksOfTheYear: nil,
+      daysOfTheYear: nil,
+      setPositions: setPositions,
+      end: end
+    )
+  }
+  
+  /// Parses a single BYDAY value like "TU", "2TU", or "-1FR".
+  private func parseByDayValue(_ value: String) -> EKRecurrenceDayOfWeek? {
+    let dayMap: [String: EKWeekday] = [
+      "SU": .sunday, "MO": .monday, "TU": .tuesday, "WE": .wednesday,
+      "TH": .thursday, "FR": .friday, "SA": .saturday,
+    ]
+
+    // Try positional format first (e.g., "2TU", "-1FR")
+    if value.count > 2 {
+      let dayCode = String(value.suffix(2))
+      let numStr = String(value.dropLast(2))
+      if let weekday = dayMap[dayCode], let weekNumber = Int(numStr), weekNumber != 0 {
+        return EKRecurrenceDayOfWeek(weekday, weekNumber: weekNumber)
+      }
+    }
+
+    // Plain day code (e.g., "TU")
+    if let weekday = dayMap[value] {
+      return EKRecurrenceDayOfWeek(weekday)
+    }
+
+    return nil
+  }
+
+  /// Parses RRULE date: YYYYMMDD or YYYYMMDDTHHMMSSZ.
+  private func parseRruleDate(_ dateStr: String) -> Date? {
+    let clean = dateStr.replacingOccurrences(of: "Z", with: "")
+    guard clean.count >= 8 else { return nil }
+    
+    let year = Int(clean.prefix(4)) ?? 0
+    let month = Int(clean.dropFirst(4).prefix(2)) ?? 0
+    let day = Int(clean.dropFirst(6).prefix(2)) ?? 0
+    
+    var components = DateComponents()
+    components.year = year
+    components.month = month
+    components.day = day
+    components.timeZone = TimeZone(identifier: "UTC")
+    
+    if clean.count >= 15, clean.dropFirst(8).first == "T" {
+      let timeStr = clean.dropFirst(9)
+      components.hour = Int(timeStr.prefix(2)) ?? 0
+      components.minute = Int(timeStr.dropFirst(2).prefix(2)) ?? 0
+      components.second = Int(timeStr.dropFirst(4).prefix(2)) ?? 0
+    } else {
+      components.hour = 0
+      components.minute = 0
+      components.second = 0
+    }
+    
+    return Calendar(identifier: .gregorian).date(from: components)
+  }
+  
+  /// Serializes an EKRecurrenceRule back to an RRULE string.
+  private func ekRecurrenceRuleToRruleString(_ rule: EKRecurrenceRule) -> String {
+    var parts: [String] = []
+    
+    // Frequency
+    switch rule.frequency {
+    case .daily: parts.append("FREQ=DAILY")
+    case .weekly: parts.append("FREQ=WEEKLY")
+    case .monthly: parts.append("FREQ=MONTHLY")
+    case .yearly: parts.append("FREQ=YEARLY")
+    @unknown default: parts.append("FREQ=DAILY")
+    }
+    
+    // Interval
+    if rule.interval > 1 {
+      parts.append("INTERVAL=\(rule.interval)")
+    }
+    
+    // BYDAY
+    if let daysOfWeek = rule.daysOfTheWeek, !daysOfWeek.isEmpty {
+      let dayStrs = daysOfWeek.map { dow -> String in
+        let code: String
+        switch dow.dayOfTheWeek {
+        case .sunday: code = "SU"
+        case .monday: code = "MO"
+        case .tuesday: code = "TU"
+        case .wednesday: code = "WE"
+        case .thursday: code = "TH"
+        case .friday: code = "FR"
+        case .saturday: code = "SA"
+        @unknown default: code = "MO"
+        }
+        if dow.weekNumber != 0 {
+          return "\(dow.weekNumber)\(code)"
+        }
+        return code
+      }
+      parts.append("BYDAY=\(dayStrs.joined(separator: ","))")
+    }
+    
+    // BYMONTHDAY
+    if let daysOfMonth = rule.daysOfTheMonth, !daysOfMonth.isEmpty {
+      let dayStrs = daysOfMonth.map { $0.stringValue }
+      parts.append("BYMONTHDAY=\(dayStrs.joined(separator: ","))")
+    }
+    
+    // BYMONTH
+    if let months = rule.monthsOfTheYear, !months.isEmpty {
+      let monthStrs = months.map { $0.stringValue }
+      parts.append("BYMONTH=\(monthStrs.joined(separator: ","))")
+    }
+    
+    // BYSETPOS
+    if let setPositions = rule.setPositions, !setPositions.isEmpty {
+      let posStrs = setPositions.map { $0.stringValue }
+      parts.append("BYSETPOS=\(posStrs.joined(separator: ","))")
+    }
+
+    // WKST (week start day)
+    if rule.firstDayOfTheWeek != 0 {
+      let wkstMap: [Int: String] = [
+        1: "SU", 2: "MO", 3: "TU", 4: "WE", 5: "TH", 6: "FR", 7: "SA",
+      ]
+      if let wkst = wkstMap[rule.firstDayOfTheWeek] {
+        parts.append("WKST=\(wkst)")
+      }
+    }
+
+    // End condition
+    if let end = rule.recurrenceEnd {
+      if end.occurrenceCount > 0 {
+        parts.append("COUNT=\(end.occurrenceCount)")
+      } else if let endDate = end.endDate {
+        let cal = Calendar(identifier: .gregorian)
+        let utc = TimeZone(identifier: "UTC")!
+        var comps = cal.dateComponents(in: utc, from: endDate)
+        let y = String(format: "%04d", comps.year ?? 0)
+        let m = String(format: "%02d", comps.month ?? 0)
+        let d = String(format: "%02d", comps.day ?? 0)
+        let h = comps.hour ?? 0
+        let min = comps.minute ?? 0
+        let s = comps.second ?? 0
+        if h == 0 && min == 0 && s == 0 {
+          parts.append("UNTIL=\(y)\(m)\(d)")
+        } else {
+          parts.append("UNTIL=\(y)\(m)\(d)T\(String(format: "%02d", h))\(String(format: "%02d", min))\(String(format: "%02d", s))Z")
+        }
+      }
+    }
+    
+    return parts.joined(separator: ";")
   }
   
   func deleteEvent(

--- a/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
+++ b/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
@@ -127,6 +127,7 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
     String? location,
     String? timeZone,
     String availability,
+    String? recurrenceRule,
   ) async {
     final result = await methodChannel.invokeMethod<String>(
       'createEvent',
@@ -140,6 +141,7 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
         'location': location,
         'timeZone': timeZone,
         'availability': availability,
+        'recurrenceRule': recurrenceRule,
       },
     );
     return result!;

--- a/packages/device_calendar_plus_ios/test/device_calendar_plus_ios_test.dart
+++ b/packages/device_calendar_plus_ios/test/device_calendar_plus_ios_test.dart
@@ -187,6 +187,7 @@ void main() {
         'Conference Room A',
         'America/New_York',
         'busy',
+        null,
       );
 
       expect(log.length, equals(1));
@@ -219,6 +220,7 @@ void main() {
         null,
         null,
         'free',
+        null,
       );
 
       expect(log.length, equals(1));

--- a/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
+++ b/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
@@ -149,6 +149,8 @@ abstract class DeviceCalendarPlusPlatform extends PlatformInterface {
   /// [timeZone] is optional timezone identifier (null for all-day events).
   /// [availability] is the availability status (busy, free, tentative, unavailable).
   ///
+  /// [recurrenceRule] is an optional RRULE string for recurring events.
+  ///
   /// Returns the ID of the newly created event (system-generated).
   /// Requires calendar write permissions.
   Future<String> createEvent(
@@ -161,6 +163,7 @@ abstract class DeviceCalendarPlusPlatform extends PlatformInterface {
     String? location,
     String? timeZone,
     String availability,
+    String? recurrenceRule,
   );
 
   /// Deletes an event from the device.

--- a/packages/device_calendar_plus_platform_interface/test/device_calendar_plus_platform_interface_test.dart
+++ b/packages/device_calendar_plus_platform_interface/test/device_calendar_plus_platform_interface_test.dart
@@ -58,6 +58,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     String? location,
     String? timeZone,
     String availability,
+    String? recurrenceRule,
   ) async =>
       'mock-event-id';
 
@@ -173,6 +174,7 @@ void main() {
       'Conference Room A',
       'America/New_York',
       'busy',
+      null,
     );
     expect(eventId, equals('mock-event-id'));
   });


### PR DESCRIPTION
Add cross-platform recurrence rule model (RFC 5545 subset) with:
- Sealed RecurrenceRule hierarchy: Daily, Weekly, Monthly, Yearly
- Monthly/Yearly split into sealed subtypes (byDayOfMonth/byWeekday) for compile-time mutual exclusivity
- RecurrenceDay type with optional position for Nth weekday patterns (e.g., "2nd Tuesday", "last Friday")
- BYSETPOS support on Monthly/Yearly for filtering result sets (e.g., "last weekday of the month")
- WKST (week start day) support on Weekly
- Validation on list items (daysOfMonth 1-31, months 1-12)
- Bidirectional RRULE string parsing/serialization with rawRrule escape hatch for platform-specific properties
- iOS EventsService: parse/serialize weekNumber, BYSETPOS, WKST, and comma-separated BYMONTH/BYMONTHDAY
- Android: RRULE strings pass through natively
- Integration test barrel file for single app launch
- 106 unit tests, 18 integration tests (all passing on iOS simulator)