### PR TITLE
feat: add read-only attendees to Event

### DIFF
--- a/packages/device_calendar_plus/example/integration_test/all_tests.dart
+++ b/packages/device_calendar_plus/example/integration_test/all_tests.dart
@@ -1,7 +1,9 @@
+import 'attendee_test.dart' as attendee;
 import 'device_calendar_test.dart' as device_calendar;
 import 'recurrence_test.dart' as recurrence;
 
 void main() {
   device_calendar.main();
   recurrence.main();
+  attendee.main();
 }

--- a/packages/device_calendar_plus/example/integration_test/attendee_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/attendee_test.dart
@@ -1,0 +1,90 @@
+import 'package:device_calendar_plus/device_calendar_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+/// Integration tests for attendee reading.
+///
+/// These tests verify that attendees are correctly read from events on both
+/// platforms. Since neither platform supports programmatic attendee creation
+/// through this plugin, the test creates an event and verifies the attendees
+/// field is either null (no attendees) or a valid list.
+///
+/// For full attendee verification, manually add attendees to an event via the
+/// native calendar app, then run these tests.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  final plugin = DeviceCalendar.instance;
+
+  String? testCalendarId;
+
+  setUpAll(() async {
+    await plugin.requestPermissions();
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    testCalendarId = await plugin.createCalendar(
+      name: 'Attendee Test $timestamp',
+    );
+  });
+
+  tearDownAll(() async {
+    if (testCalendarId != null) {
+      await plugin.deleteCalendar(testCalendarId!);
+    }
+  });
+
+  testWidgets('Event without attendees has null attendees field',
+      (tester) async {
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, now.day, 10, 0);
+    final end = DateTime(now.year, now.month, now.day, 11, 0);
+
+    final eventId = await plugin.createEvent(
+      calendarId: testCalendarId!,
+      title: 'No Attendees Event',
+      startDate: start,
+      endDate: end,
+    );
+
+    final events = await plugin.listEvents(
+      start.subtract(Duration(hours: 1)),
+      end.add(Duration(hours: 1)),
+      calendarIds: [testCalendarId!],
+    );
+
+    final event = events.firstWhere((e) => e.eventId == eventId);
+    // Event created without attendees should have null or empty attendees
+    expect(event.attendees == null || event.attendees!.isEmpty, isTrue);
+  });
+
+  testWidgets('Attendees have correct field types when present',
+      (tester) async {
+    // Fetch all events from all calendars — look for any with attendees
+    final now = DateTime.now();
+    final events = await plugin.listEvents(
+      now.subtract(Duration(days: 30)),
+      now.add(Duration(days: 30)),
+    );
+
+    final eventsWithAttendees =
+        events.where((e) => e.attendees != null && e.attendees!.isNotEmpty);
+
+    if (eventsWithAttendees.isEmpty) {
+      // No events with attendees found — skip gracefully
+      // To test fully, add attendees to an event via native calendar app
+      return;
+    }
+
+    for (final event in eventsWithAttendees.take(3)) {
+      for (final attendee in event.attendees!) {
+        // Verify types are correct
+        expect(attendee.role, isA<AttendeeRole>());
+        expect(attendee.status, isA<AttendeeStatus>());
+        // Name or email should be present (at least one)
+        expect(
+          attendee.name != null || attendee.emailAddress != null,
+          isTrue,
+          reason: 'Attendee should have at least a name or email: $attendee',
+        );
+      }
+    }
+  });
+}

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -14,6 +14,7 @@ export 'package:device_calendar_plus_android/device_calendar_plus_android.dart'
 export 'package:device_calendar_plus_platform_interface/device_calendar_plus_platform_interface.dart'
     show CreateCalendarPlatformOptions, InstanceIdParser, ParsedInstanceId;
 
+export 'src/attendee.dart';
 export 'src/calendar.dart';
 export 'src/calendar_permission_status.dart';
 export 'src/device_calendar_error.dart';

--- a/packages/device_calendar_plus/lib/src/attendee.dart
+++ b/packages/device_calendar_plus/lib/src/attendee.dart
@@ -1,0 +1,145 @@
+/// Role of an attendee in a calendar event.
+enum AttendeeRole {
+  /// Attendance is required.
+  ///
+  /// Available on: Android, iOS
+  required,
+
+  /// Attendance is optional.
+  ///
+  /// Available on: Android, iOS
+  optional,
+
+  /// Attendee is the chair/organizer of the event.
+  ///
+  /// Available on: Android, iOS
+  chair,
+
+  /// Attendee is a non-participant (e.g. room resource, FYI).
+  ///
+  /// Available on: Android, iOS
+  nonParticipant;
+
+  /// Safely parses a string to an AttendeeRole enum.
+  /// Returns [required] if the value doesn't match any known case.
+  static AttendeeRole fromName(String name) {
+    return AttendeeRole.values.firstWhere(
+      (e) => e.name == name,
+      orElse: () => AttendeeRole.required,
+    );
+  }
+}
+
+/// RSVP status of an attendee.
+enum AttendeeStatus {
+  /// Attendee has accepted the invitation.
+  ///
+  /// Available on: Android, iOS
+  accepted,
+
+  /// Attendee has declined the invitation.
+  ///
+  /// Available on: Android, iOS
+  declined,
+
+  /// Attendee has tentatively accepted.
+  ///
+  /// Available on: Android, iOS
+  tentative,
+
+  /// Invitation is pending (no response yet).
+  ///
+  /// Available on: Android, iOS
+  pending,
+
+  /// Attendee has delegated attendance to another person.
+  ///
+  /// Available on: iOS only
+  delegated,
+
+  /// Attendee has completed (for to-do style events).
+  ///
+  /// Available on: iOS only
+  completed,
+
+  /// Attendee is in process (for to-do style events).
+  ///
+  /// Available on: iOS only
+  inProcess,
+
+  /// Status is unknown or not set.
+  ///
+  /// Available on: Android, iOS
+  none;
+
+  /// Safely parses a string to an AttendeeStatus enum.
+  /// Returns [none] if the value doesn't match any known case.
+  static AttendeeStatus fromName(String name) {
+    return AttendeeStatus.values.firstWhere(
+      (e) => e.name == name,
+      orElse: () => AttendeeStatus.none,
+    );
+  }
+}
+
+/// A participant in a calendar event (read-only).
+///
+/// Attendees are populated when fetching events. Neither platform supports
+/// programmatic attendee creation through this plugin — use
+/// [DeviceCalendar.showCreateEventModal] to let users add attendees via
+/// the native UI.
+class Attendee {
+  /// Display name of the attendee.
+  final String? name;
+
+  /// Email address of the attendee.
+  final String? emailAddress;
+
+  /// Role in the event (required, optional, chair, etc.).
+  final AttendeeRole role;
+
+  /// RSVP status (accepted, declined, tentative, etc.).
+  final AttendeeStatus status;
+
+  const Attendee({
+    this.name,
+    this.emailAddress,
+    required this.role,
+    required this.status,
+  });
+
+  factory Attendee.fromMap(Map<String, dynamic> map) {
+    return Attendee(
+      name: map['name'] as String?,
+      emailAddress: map['emailAddress'] as String?,
+      role: AttendeeRole.fromName(map['role'] as String? ?? 'required'),
+      status: AttendeeStatus.fromName(map['status'] as String? ?? 'none'),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      if (name != null) 'name': name,
+      if (emailAddress != null) 'emailAddress': emailAddress,
+      'role': role.name,
+      'status': status.name,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is Attendee &&
+        other.name == name &&
+        other.emailAddress == emailAddress &&
+        other.role == role &&
+        other.status == status;
+  }
+
+  @override
+  int get hashCode => Object.hash(name, emailAddress, role, status);
+
+  @override
+  String toString() =>
+      'Attendee(name: $name, email: $emailAddress, role: $role, status: $status)';
+}

--- a/packages/device_calendar_plus/lib/src/event.dart
+++ b/packages/device_calendar_plus/lib/src/event.dart
@@ -1,3 +1,6 @@
+import 'package:flutter/foundation.dart';
+
+import 'attendee.dart';
 import 'event_availability.dart';
 import 'event_status.dart';
 import 'recurrence_rule.dart';
@@ -88,6 +91,13 @@ class Event {
   /// the original platform string.
   final RecurrenceRule? recurrenceRule;
 
+  /// Attendees of this event (read-only).
+  ///
+  /// Null if the event has no attendees or attendees are not available.
+  /// iOS and Android both support reading attendees but neither platform
+  /// supports programmatic write via this plugin.
+  final List<Attendee>? attendees;
+
   Event({
     required this.eventId,
     required this.instanceId,
@@ -103,11 +113,13 @@ class Event {
     this.timeZone,
     required this.isRecurring,
     this.recurrenceRule,
+    this.attendees,
   });
 
   /// Creates an Event from a map returned by the platform.
   factory Event.fromMap(Map<String, dynamic> map) {
     final rruleString = map['recurrenceRule'] as String?;
+    final attendeesList = map['attendees'] as List<dynamic>?;
     return Event(
       eventId: map['eventId'] as String,
       instanceId: map['instanceId'] as String,
@@ -125,6 +137,9 @@ class Event {
       recurrenceRule: rruleString != null
           ? RecurrenceRule.fromRruleString(rruleString)
           : null,
+      attendees: attendeesList
+          ?.map((a) => Attendee.fromMap(Map<String, dynamic>.from(a as Map)))
+          .toList(),
     );
   }
 
@@ -148,6 +163,9 @@ class Event {
     if (timeZone != null) map['timeZone'] = timeZone;
     if (recurrenceRule != null) {
       map['recurrenceRule'] = recurrenceRule!.rruleString;
+    }
+    if (attendees != null) {
+      map['attendees'] = attendees!.map((a) => a.toMap()).toList();
     }
 
     return map;
@@ -177,7 +195,8 @@ class Event {
         other.status == status &&
         other.timeZone == timeZone &&
         other.isRecurring == isRecurring &&
-        other.recurrenceRule == recurrenceRule;
+        other.recurrenceRule == recurrenceRule &&
+        listEquals(other.attendees, attendees);
   }
 
   @override
@@ -197,6 +216,7 @@ class Event {
       timeZone,
       isRecurring,
       recurrenceRule,
+      attendees != null ? Object.hashAll(attendees!) : null,
     );
   }
 }

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -242,8 +242,85 @@ class EventsService(private val activity: Activity) {
         if (lastModifiedDate != null) {
             eventMap["updatedDate"] = lastModifiedDate
         }
-        
+
+        // Query attendees
+        val attendees = queryAttendees(eventId.toLong())
+        if (attendees.isNotEmpty()) {
+            eventMap["attendees"] = attendees
+        }
+
         return eventMap
+    }
+
+    private fun queryAttendees(eventId: Long): List<Map<String, Any?>> {
+        val attendees = mutableListOf<Map<String, Any?>>()
+
+        try {
+            activity.contentResolver.query(
+                CalendarContract.Attendees.CONTENT_URI,
+                arrayOf(
+                    CalendarContract.Attendees.ATTENDEE_NAME,
+                    CalendarContract.Attendees.ATTENDEE_EMAIL,
+                    CalendarContract.Attendees.ATTENDEE_TYPE,
+                    CalendarContract.Attendees.ATTENDEE_RELATIONSHIP,
+                    CalendarContract.Attendees.ATTENDEE_STATUS,
+                ),
+                "${CalendarContract.Attendees.EVENT_ID} = ?",
+                arrayOf(eventId.toString()),
+                null
+            )?.use { cursor ->
+                while (cursor.moveToNext()) {
+                    val relationship = cursor.getInt(
+                        cursor.getColumnIndexOrThrow(CalendarContract.Attendees.ATTENDEE_RELATIONSHIP)
+                    )
+                    // Skip the organizer
+                    if (relationship == CalendarContract.Attendees.RELATIONSHIP_ORGANIZER) continue
+
+                    val name = cursor.getString(
+                        cursor.getColumnIndexOrThrow(CalendarContract.Attendees.ATTENDEE_NAME)
+                    )
+                    val email = cursor.getString(
+                        cursor.getColumnIndexOrThrow(CalendarContract.Attendees.ATTENDEE_EMAIL)
+                    )
+                    val type = cursor.getInt(
+                        cursor.getColumnIndexOrThrow(CalendarContract.Attendees.ATTENDEE_TYPE)
+                    )
+                    val status = cursor.getInt(
+                        cursor.getColumnIndexOrThrow(CalendarContract.Attendees.ATTENDEE_STATUS)
+                    )
+
+                    attendees.add(mapOf(
+                        "name" to name,
+                        "emailAddress" to email,
+                        "role" to attendeeTypeToRole(type),
+                        "status" to attendeeStatusToString(status),
+                    ))
+                }
+            }
+        } catch (_: Exception) {
+            // Silently return empty if attendee query fails
+        }
+
+        return attendees
+    }
+
+    private fun attendeeTypeToRole(type: Int): String {
+        return when (type) {
+            CalendarContract.Attendees.TYPE_REQUIRED -> "required"
+            CalendarContract.Attendees.TYPE_OPTIONAL -> "optional"
+            CalendarContract.Attendees.TYPE_RESOURCE -> "nonParticipant"
+            else -> "required"
+        }
+    }
+
+    private fun attendeeStatusToString(status: Int): String {
+        return when (status) {
+            CalendarContract.Attendees.ATTENDEE_STATUS_ACCEPTED -> "accepted"
+            CalendarContract.Attendees.ATTENDEE_STATUS_DECLINED -> "declined"
+            CalendarContract.Attendees.ATTENDEE_STATUS_TENTATIVE -> "tentative"
+            CalendarContract.Attendees.ATTENDEE_STATUS_INVITED -> "pending"
+            else -> "none"
+        }
     }
     
     fun getEvent(eventId: String, timestamp: Long?): Result<Map<String, Any>?> {

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -163,13 +163,71 @@ class EventsService {
     
     // Set isRecurring flag
     eventMap["isRecurring"] = event.hasRecurrenceRules
-    
+
     // Serialize recurrence rule to RRULE string
     if event.hasRecurrenceRules, let rule = event.recurrenceRules?.first {
       eventMap["recurrenceRule"] = ekRecurrenceRuleToRruleString(rule)
     }
-    
+
+    // Serialize attendees
+    if let participants = event.attendees, !participants.isEmpty {
+      let attendees: [[String: Any]] = participants.compactMap { participant in
+        // Skip the organizer
+        if participant.participantRole == .chair {
+          return nil
+        }
+
+        var attendeeMap: [String: Any] = [
+          "role": participantRoleToString(participant.participantRole),
+          "status": participantStatusToString(participant.participantStatus),
+        ]
+
+        if let name = participant.name {
+          attendeeMap["name"] = name
+        }
+
+        // Email is embedded in the URL property as mailto:
+        if let url = participant.url {
+          let urlString = url.absoluteString
+          if urlString.hasPrefix("mailto:") {
+            attendeeMap["emailAddress"] = String(urlString.dropFirst(7))
+          }
+        }
+
+        return attendeeMap
+      }
+
+      if !attendees.isEmpty {
+        eventMap["attendees"] = attendees
+      }
+    }
+
     return eventMap
+  }
+
+  private func participantRoleToString(_ role: EKParticipantRole) -> String {
+    switch role {
+    case .required: return "required"
+    case .optional: return "optional"
+    case .chair: return "chair"
+    case .nonParticipant: return "nonParticipant"
+    case .unknown: return "required"
+    @unknown default: return "required"
+    }
+  }
+
+  private func participantStatusToString(_ status: EKParticipantStatus) -> String {
+    switch status {
+    case .accepted: return "accepted"
+    case .declined: return "declined"
+    case .tentative: return "tentative"
+    case .pending: return "pending"
+    case .delegated: return "delegated"
+    case .completed: return "completed"
+    case .inProcess: return "inProcess"
+    case .unknown: return "none"
+    @unknown default: return "none"
+    }
   }
   
   func getEvent(

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -187,11 +187,9 @@ class EventsService {
         }
 
         // Email is embedded in the URL property as mailto:
-        if let url = participant.url {
-          let urlString = url.absoluteString
-          if urlString.hasPrefix("mailto:") {
-            attendeeMap["emailAddress"] = String(urlString.dropFirst(7))
-          }
+        let urlString = participant.url.absoluteString
+        if urlString.hasPrefix("mailto:") {
+          attendeeMap["emailAddress"] = String(urlString.dropFirst(7))
         }
 
         return attendeeMap


### PR DESCRIPTION
## Summary
- Add `Attendee` model with `name`, `emailAddress`, `role`, `status`
- Read attendees from events on both platforms (read-only — neither platform supports programmatic write)
- Android: queries `CalendarContract.Attendees` table per event
- iOS: reads `EKEvent.attendees` (`[EKParticipant]`)

## Changes
- `AttendeeRole` enum: required, optional, chair, nonParticipant
- `AttendeeStatus` enum: accepted, declined, tentative, pending, delegated (iOS), completed (iOS), inProcess (iOS), none
- `Event.attendees` field (nullable list)
- Android: `queryAttendees()` in EventsService, maps type/status to shared enums
- iOS: serializes `EKParticipant` array, parses email from `mailto:` URL
- Both platforms filter out the organizer

## Testing
- Integration tests pass on both Android emulator and iOS simulator
- Tests verify null attendees on new events and correct field types when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)