### PR TITLE
feat: add listSources() and source selection on createCalendar

### DIFF
--- a/packages/device_calendar_plus/example/integration_test/all_tests.dart
+++ b/packages/device_calendar_plus/example/integration_test/all_tests.dart
@@ -1,9 +1,11 @@
 import 'attendee_test.dart' as attendee;
 import 'device_calendar_test.dart' as device_calendar;
 import 'recurrence_test.dart' as recurrence;
+import 'sources_test.dart' as sources;
 
 void main() {
   device_calendar.main();
   recurrence.main();
   attendee.main();
+  sources.main();
 }

--- a/packages/device_calendar_plus/example/integration_test/sources_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/sources_test.dart
@@ -1,0 +1,120 @@
+import 'dart:io' show Platform;
+
+import 'package:device_calendar_plus/device_calendar_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  final plugin = DeviceCalendar.instance;
+
+  final createdCalendarIds = <String>[];
+
+  setUpAll(() async {
+    await plugin.requestPermissions();
+  });
+
+  tearDownAll(() async {
+    for (final id in createdCalendarIds) {
+      try {
+        await plugin.deleteCalendar(id);
+      } catch (_) {}
+    }
+  });
+
+  testWidgets('listSources returns non-empty list', (tester) async {
+    final sources = await plugin.listSources();
+
+    expect(sources, isNotEmpty);
+    for (final source in sources) {
+      expect(source.id, isNotEmpty);
+      expect(source.accountName, isNotEmpty);
+      expect(source.accountType, isNotEmpty);
+      expect(source.type, isA<CalendarSourceType>());
+    }
+  });
+
+  testWidgets('listSources includes local or calDav source', (tester) async {
+    final sources = await plugin.listSources();
+
+    final hasLocalOrCalDav = sources.any(
+      (s) =>
+          s.type == CalendarSourceType.local ||
+          s.type == CalendarSourceType.calDav,
+    );
+
+    expect(hasLocalOrCalDav, isTrue,
+        reason: 'Expected at least one local or calDav source');
+  });
+
+  testWidgets('createCalendar without source uses default fallback',
+      (tester) async {
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    final calendarId = await plugin.createCalendar(
+      name: 'Source Test Default $timestamp',
+    );
+    createdCalendarIds.add(calendarId);
+
+    expect(calendarId, isNotEmpty);
+
+    final calendars = await plugin.listCalendars();
+    final created = calendars.firstWhere((c) => c.id == calendarId);
+    expect(created.name, contains('Source Test Default'));
+  });
+
+  testWidgets(
+    'iOS: createCalendar with explicit sourceId',
+    (tester) async {
+      final sources = await plugin.listSources();
+
+      // Find a writable source (local or calDav)
+      final source = sources.firstWhere(
+        (s) =>
+            s.type == CalendarSourceType.local ||
+            s.type == CalendarSourceType.calDav,
+      );
+
+      final timestamp = DateTime.now().millisecondsSinceEpoch;
+      final calendarId = await plugin.createCalendar(
+        name: 'Source Test iOS $timestamp',
+        platformOptions: CreateCalendarOptionsIos(sourceId: source.id),
+      );
+      createdCalendarIds.add(calendarId);
+
+      expect(calendarId, isNotEmpty);
+
+      final calendars = await plugin.listCalendars();
+      final created = calendars.firstWhere((c) => c.id == calendarId);
+      expect(created.accountName, equals(source.accountName));
+    },
+    skip: !Platform.isIOS,
+  );
+
+  testWidgets(
+    'Android: createCalendar with explicit accountType',
+    (tester) async {
+      final sources = await plugin.listSources();
+
+      final source = sources.firstWhere(
+        (s) => s.type == CalendarSourceType.local,
+      );
+
+      final timestamp = DateTime.now().millisecondsSinceEpoch;
+      final calendarId = await plugin.createCalendar(
+        name: 'Source Test Android $timestamp',
+        platformOptions: CreateCalendarOptionsAndroid(
+          accountName: source.accountName,
+          accountType: source.accountType,
+        ),
+      );
+      createdCalendarIds.add(calendarId);
+
+      expect(calendarId, isNotEmpty);
+
+      final calendars = await plugin.listCalendars();
+      final created = calendars.firstWhere((c) => c.id == calendarId);
+      expect(created.accountName, equals(source.accountName));
+    },
+    skip: !Platform.isAndroid,
+  );
+}

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -11,6 +11,8 @@ import 'src/recurrence_rule.dart';
 
 export 'package:device_calendar_plus_android/device_calendar_plus_android.dart'
     show CreateCalendarOptionsAndroid;
+export 'package:device_calendar_plus_ios/device_calendar_plus_ios.dart'
+    show CreateCalendarOptionsIos;
 // Platform-specific options
 export 'package:device_calendar_plus_platform_interface/device_calendar_plus_platform_interface.dart'
     show CreateCalendarPlatformOptions, InstanceIdParser, ParsedInstanceId;

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 
 import 'src/calendar.dart';
 import 'src/calendar_permission_status.dart';
+import 'src/calendar_source.dart';
 import 'src/event.dart';
 import 'src/event_availability.dart';
 import 'src/platform_exception_converter.dart';
@@ -16,6 +17,7 @@ export 'package:device_calendar_plus_platform_interface/device_calendar_plus_pla
 
 export 'src/attendee.dart';
 export 'src/calendar.dart';
+export 'src/calendar_source.dart';
 export 'src/calendar_permission_status.dart';
 export 'src/device_calendar_error.dart';
 export 'src/event.dart';
@@ -186,6 +188,40 @@ class DeviceCalendar {
       final List<Map<String, dynamic>> rawCalendars =
           await DeviceCalendarPlusPlatform.instance.listCalendars();
       return rawCalendars.map((map) => Calendar.fromMap(map)).toList();
+    } on PlatformException catch (e, stackTrace) {
+      final convertedException =
+          PlatformExceptionConverter.convertPlatformException(e);
+      if (convertedException != null) {
+        Error.throwWithStackTrace(convertedException, stackTrace);
+      }
+      rethrow;
+    }
+  }
+
+  /// Lists available calendar sources/accounts on the device.
+  ///
+  /// Returns the sources that calendars can be created under. Use a source's
+  /// [CalendarSource.id] with [CreateCalendarOptionsIos], or
+  /// [CalendarSource.accountName] + [CalendarSource.accountType] with
+  /// [CreateCalendarOptionsAndroid] to create calendars under a specific account.
+  ///
+  /// **Note:** On Android, only sources that already have calendars are returned.
+  /// A freshly-added account with no calendars will not appear until its first
+  /// calendar is created.
+  ///
+  /// Example:
+  /// ```dart
+  /// final plugin = DeviceCalendar.instance;
+  /// final sources = await plugin.listSources();
+  /// for (final source in sources) {
+  ///   print('${source.accountName} (${source.type})');
+  /// }
+  /// ```
+  Future<List<CalendarSource>> listSources() async {
+    try {
+      final List<Map<String, dynamic>> rawSources =
+          await DeviceCalendarPlusPlatform.instance.listSources();
+      return rawSources.map((map) => CalendarSource.fromMap(map)).toList();
     } on PlatformException catch (e, stackTrace) {
       final convertedException =
           PlatformExceptionConverter.convertPlatformException(e);

--- a/packages/device_calendar_plus/lib/src/calendar_source.dart
+++ b/packages/device_calendar_plus/lib/src/calendar_source.dart
@@ -1,0 +1,118 @@
+/// Type of a calendar source/account.
+enum CalendarSourceType {
+  /// On-device only, not synced to any cloud service.
+  ///
+  /// Available on: Android, iOS
+  local,
+
+  /// CalDAV protocol (iCloud, Google, Fastmail, etc.).
+  ///
+  /// Available on: Android, iOS
+  calDav,
+
+  /// Microsoft Exchange / ActiveSync.
+  ///
+  /// Available on: Android, iOS
+  exchange,
+
+  /// Read-only subscribed calendar feeds (.ics).
+  ///
+  /// Available on: iOS only
+  subscribed,
+
+  /// System contacts birthdays (read-only).
+  ///
+  /// Available on: iOS only
+  birthdays,
+
+  /// Unknown or platform-specific sync adapter.
+  ///
+  /// Available on: Android, iOS
+  other;
+
+  /// Safely parses a string to a CalendarSourceType enum.
+  /// Returns [other] if the value doesn't match any known case.
+  static CalendarSourceType fromName(String name) {
+    return CalendarSourceType.values.firstWhere(
+      (e) => e.name == name,
+      orElse: () => CalendarSourceType.other,
+    );
+  }
+}
+
+/// Represents a calendar source/account that can own calendars.
+///
+/// Use [DeviceCalendar.listSources] to discover available sources, then pass
+/// a source's [id] to [CreateCalendarOptionsIos] or use [accountName] +
+/// [accountType] with [CreateCalendarOptionsAndroid] to create calendars under
+/// a specific account.
+class CalendarSource {
+  /// Stable identifier for this source.
+  ///
+  /// - **iOS**: `EKSource.sourceIdentifier` — use with [CreateCalendarOptionsIos]
+  /// - **Android**: Synthetic `"accountName|accountType"` — informational only,
+  ///   not used for creation. Use [accountName] + [accountType] with
+  ///   [CreateCalendarOptionsAndroid] instead.
+  final String id;
+
+  /// Display name or account identifier for this source.
+  ///
+  /// - **iOS**: `EKSource.title` (e.g. "iCloud", "Gmail")
+  /// - **Android**: `ACCOUNT_NAME` (e.g. "user@gmail.com", "local")
+  ///
+  /// Matches [Calendar.accountName].
+  final String accountName;
+
+  /// Raw platform type string for this source.
+  ///
+  /// - **iOS**: e.g. "caldav", "local", "exchange"
+  /// - **Android**: e.g. "com.google", "LOCAL", "com.android.exchange"
+  ///
+  /// Matches [Calendar.accountType].
+  final String accountType;
+
+  /// Normalized source type.
+  final CalendarSourceType type;
+
+  const CalendarSource({
+    required this.id,
+    required this.accountName,
+    required this.accountType,
+    required this.type,
+  });
+
+  factory CalendarSource.fromMap(Map<String, dynamic> map) {
+    return CalendarSource(
+      id: map['id'] as String,
+      accountName: map['accountName'] as String,
+      accountType: map['accountType'] as String,
+      type: CalendarSourceType.fromName(map['type'] as String? ?? 'other'),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'accountName': accountName,
+      'accountType': accountType,
+      'type': type.name,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CalendarSource &&
+        other.id == id &&
+        other.accountName == accountName &&
+        other.accountType == accountType &&
+        other.type == type;
+  }
+
+  @override
+  int get hashCode => Object.hash(id, accountName, accountType, type);
+
+  @override
+  String toString() =>
+      'CalendarSource(id: $id, accountName: $accountName, accountType: $accountType, type: $type)';
+}

--- a/packages/device_calendar_plus/lib/src/calendar_source.dart
+++ b/packages/device_calendar_plus/lib/src/calendar_source.dart
@@ -74,11 +74,19 @@ class CalendarSource {
   /// Normalized source type.
   final CalendarSourceType type;
 
+  /// Whether this source supports calendar creation from this app.
+  ///
+  /// - **iOS**: true for local, CalDAV, and Exchange sources
+  /// - **Android**: true only for local accounts (other account types are
+  ///   managed by their sync adapters and may reject third-party calendars)
+  final bool supportsCalendarCreation;
+
   const CalendarSource({
     required this.id,
     required this.accountName,
     required this.accountType,
     required this.type,
+    required this.supportsCalendarCreation,
   });
 
   factory CalendarSource.fromMap(Map<String, dynamic> map) {
@@ -87,6 +95,8 @@ class CalendarSource {
       accountName: map['accountName'] as String,
       accountType: map['accountType'] as String,
       type: CalendarSourceType.fromName(map['type'] as String? ?? 'other'),
+      supportsCalendarCreation:
+          map['supportsCalendarCreation'] as bool? ?? false,
     );
   }
 
@@ -96,6 +106,7 @@ class CalendarSource {
       'accountName': accountName,
       'accountType': accountType,
       'type': type.name,
+      'supportsCalendarCreation': supportsCalendarCreation,
     };
   }
 
@@ -106,11 +117,13 @@ class CalendarSource {
         other.id == id &&
         other.accountName == accountName &&
         other.accountType == accountType &&
-        other.type == type;
+        other.type == type &&
+        other.supportsCalendarCreation == supportsCalendarCreation;
   }
 
   @override
-  int get hashCode => Object.hash(id, accountName, accountType, type);
+  int get hashCode =>
+      Object.hash(id, accountName, accountType, type, supportsCalendarCreation);
 
   @override
   String toString() =>

--- a/packages/device_calendar_plus/lib/src/calendar_source.dart
+++ b/packages/device_calendar_plus/lib/src/calendar_source.dart
@@ -50,9 +50,9 @@ class CalendarSource {
   /// Stable identifier for this source.
   ///
   /// - **iOS**: `EKSource.sourceIdentifier` — use with [CreateCalendarOptionsIos]
-  /// - **Android**: Synthetic `"accountName|accountType"` — informational only,
-  ///   not used for creation. Use [accountName] + [accountType] with
-  ///   [CreateCalendarOptionsAndroid] instead.
+  /// - **Android**: Synthetic `"encodedAccountName:encodedAccountType"` (URI-encoded)
+  ///   — informational only, not used for creation. Use [accountName] + [accountType]
+  ///   with [CreateCalendarOptionsAndroid] instead.
   final String id;
 
   /// Display name or account identifier for this source.

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -115,6 +115,12 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
   }
 
   @override
+  Future<List<Map<String, dynamic>>> listSources() async {
+    if (_exceptionToThrow != null) throw _exceptionToThrow!;
+    return [];
+  }
+
+  @override
   Future<String> createCalendar(
     String name,
     String? colorHex,

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
@@ -116,6 +116,7 @@ class CalendarService(private val activity: Activity) {
                             "accountName" to accountName,
                             "accountType" to accountType,
                             "type" to accountTypeToSourceType(accountType),
+                            "supportsCalendarCreation" to (accountType == CalendarContract.ACCOUNT_TYPE_LOCAL),
                         ))
                     }
                 }

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
@@ -89,7 +89,60 @@ class CalendarService(private val activity: Activity) {
         return Result.success(calendars)
     }
     
-    fun createCalendar(name: String, colorHex: String?, accountNameParam: String?): Result<String> {
+    fun listSources(): Result<List<Map<String, Any>>> {
+        val sources = mutableListOf<Map<String, Any>>()
+        val seen = mutableSetOf<String>()
+
+        try {
+            activity.contentResolver.query(
+                CalendarContract.Calendars.CONTENT_URI,
+                arrayOf(
+                    CalendarContract.Calendars.ACCOUNT_NAME,
+                    CalendarContract.Calendars.ACCOUNT_TYPE,
+                ),
+                null, null, null
+            )?.use { cursor ->
+                val nameIdx = cursor.getColumnIndexOrThrow(CalendarContract.Calendars.ACCOUNT_NAME)
+                val typeIdx = cursor.getColumnIndexOrThrow(CalendarContract.Calendars.ACCOUNT_TYPE)
+
+                while (cursor.moveToNext()) {
+                    val accountName = cursor.getString(nameIdx) ?: continue
+                    val accountType = cursor.getString(typeIdx) ?: continue
+                    val key = "$accountName|$accountType"
+
+                    if (seen.add(key)) {
+                        sources.add(mapOf(
+                            "id" to key,
+                            "accountName" to accountName,
+                            "accountType" to accountType,
+                            "type" to accountTypeToSourceType(accountType),
+                        ))
+                    }
+                }
+            }
+        } catch (e: SecurityException) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.PERMISSION_DENIED,
+                    "Calendar permission denied: ${e.message}"
+                )
+            )
+        }
+
+        return Result.success(sources)
+    }
+
+    private fun accountTypeToSourceType(accountType: String): String {
+        return when (accountType) {
+            CalendarContract.ACCOUNT_TYPE_LOCAL -> "local"
+            "com.google" -> "calDav"
+            "com.android.exchange" -> "exchange"
+            "com.samsung.android.exchange" -> "exchange"
+            else -> "other"
+        }
+    }
+
+    fun createCalendar(name: String, colorHex: String?, accountNameParam: String?, accountTypeParam: String?): Result<String> {
         // Check for write calendar permission
         if (ContextCompat.checkSelfPermission(activity, Manifest.permission.WRITE_CALENDAR) 
             != PackageManager.PERMISSION_GRANTED) {
@@ -102,7 +155,7 @@ class CalendarService(private val activity: Activity) {
         }
         
         val accountName = accountNameParam ?: "local"
-        val accountType = CalendarContract.ACCOUNT_TYPE_LOCAL
+        val accountType = accountTypeParam ?: CalendarContract.ACCOUNT_TYPE_LOCAL
         
         // Android automatically creates the account when inserting the first calendar
         try {

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
@@ -3,6 +3,7 @@ package to.bullet.device_calendar_plus_android
 import android.Manifest
 import android.app.Activity
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.provider.CalendarContract
 import androidx.core.content.ContextCompat
 
@@ -108,7 +109,7 @@ class CalendarService(private val activity: Activity) {
                 while (cursor.moveToNext()) {
                     val accountName = cursor.getString(nameIdx) ?: continue
                     val accountType = cursor.getString(typeIdx) ?: continue
-                    val key = "$accountName|$accountType"
+                    val key = "${Uri.encode(accountName)}:${Uri.encode(accountType)}"
 
                     if (seen.add(key)) {
                         sources.add(mapOf(

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
@@ -42,6 +42,7 @@ class DeviceCalendarPlusAndroidPlugin :
             "hasPermissions" -> handleHasPermissions(result)
             "openAppSettings" -> handleOpenAppSettings(result)
             "listCalendars" -> handleListCalendars(result)
+            "listSources" -> handleListSources(result)
             "createCalendar" -> handleCreateCalendar(call, result)
             "updateCalendar" -> handleUpdateCalendar(call, result)
             "deleteCalendar" -> handleDeleteCalendar(call, result)
@@ -133,13 +134,30 @@ class DeviceCalendarPlusAndroidPlugin :
         )
     }
     
+    private fun handleListSources(result: Result) {
+        val service = calendarService!!
+
+        val serviceResult = service.listSources()
+        serviceResult.fold(
+            onSuccess = { sources -> result.success(sources) },
+            onFailure = { error ->
+                if (error is CalendarException) {
+                    result.error(error.code, error.message, null)
+                } else {
+                    result.error(PlatformExceptionCodes.UNKNOWN_ERROR, error.message, null)
+                }
+            }
+        )
+    }
+
     private fun handleCreateCalendar(call: MethodCall, result: Result) {
         val service = calendarService ?: error("CalendarService not initialized - plugin lifecycle error")
-        
+
         // Parse arguments
         val name = call.argument<String>("name")
         val colorHex = call.argument<String>("colorHex")
         val accountName = call.argument<String>("accountName")
+        val accountType = call.argument<String>("accountType")
         
         if (name == null) {
             result.error(
@@ -150,7 +168,7 @@ class DeviceCalendarPlusAndroidPlugin :
             return
         }
         
-        val serviceResult = service.createCalendar(name, colorHex, accountName)
+        val serviceResult = service.createCalendar(name, colorHex, accountName, accountType)
         serviceResult.fold(
             onSuccess = { calendarId -> result.success(calendarId) },
             onFailure = { error ->

--- a/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
+++ b/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
@@ -55,8 +55,10 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
     CreateCalendarPlatformOptions? platformOptions,
   ) async {
     String? accountName;
+    String? accountType;
     if (platformOptions is CreateCalendarOptionsAndroid) {
       accountName = platformOptions.accountName;
+      accountType = platformOptions.accountType;
     }
 
     final result = await methodChannel.invokeMethod<String>(
@@ -65,6 +67,7 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
         'name': name,
         'colorHex': colorHex,
         'accountName': accountName,
+        'accountType': accountType,
       },
     );
     return result!;

--- a/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
+++ b/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
@@ -41,6 +41,14 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
   }
 
   @override
+  Future<List<Map<String, dynamic>>> listSources() async {
+    final result =
+        await methodChannel.invokeMethod<List<dynamic>>('listSources');
+    return result?.map((e) => Map<String, dynamic>.from(e as Map)).toList() ??
+        [];
+  }
+
+  @override
   Future<String> createCalendar(
     String name,
     String? colorHex,

--- a/packages/device_calendar_plus_android/lib/src/create_calendar_options_android.dart
+++ b/packages/device_calendar_plus_android/lib/src/create_calendar_options_android.dart
@@ -14,17 +14,27 @@ import 'package:device_calendar_plus_platform_interface/device_calendar_plus_pla
 /// );
 /// ```
 class CreateCalendarOptionsAndroid extends CreateCalendarPlatformOptions {
-  /// The account name for the local calendar.
+  /// The account name for the calendar.
   ///
   /// Calendars with the same account name will be grouped together
   /// in the device's calendar app.
   /// Defaults to "local" if not specified via platform options.
   final String accountName;
 
+  /// The account type for the calendar (e.g. "com.google", "LOCAL").
+  ///
+  /// Use values from [CalendarSource.accountType] returned by
+  /// [DeviceCalendar.listSources].
+  ///
+  /// If not provided, defaults to `ACCOUNT_TYPE_LOCAL`.
+  final String? accountType;
+
   /// Creates Android-specific calendar creation options.
   ///
-  /// [accountName] is the account name for the local calendar.
+  /// [accountName] is the account name for the calendar.
+  /// [accountType] is optional — defaults to LOCAL if omitted.
   const CreateCalendarOptionsAndroid({
     required this.accountName,
+    this.accountType,
   });
 }

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/CalendarService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/CalendarService.swift
@@ -209,6 +209,7 @@ class CalendarService {
         "accountName": source.title,
         "accountType": sourceTypeToString(sourceType: source.sourceType),
         "type": sourceTypeToCalendarSourceType(source.sourceType),
+        "supportsCalendarCreation": sourceSupportsCreation(source.sourceType),
       ]
     }
 
@@ -223,6 +224,13 @@ class CalendarService {
     case .subscribed: return "subscribed"
     case .birthdays: return "birthdays"
     default: return "other"
+    }
+  }
+
+  private func sourceSupportsCreation(_ type: EKSourceType) -> Bool {
+    switch type {
+    case .local, .calDAV, .exchange: return true
+    default: return false
     }
   }
 

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/CalendarService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/CalendarService.swift
@@ -55,7 +55,7 @@ class CalendarService {
     completion(.success(calendarMaps))
   }
   
-  func createCalendar(name: String, colorHex: String?, completion: @escaping (Result<String, CalendarError>) -> Void) {
+  func createCalendar(name: String, colorHex: String?, sourceId: String?, completion: @escaping (Result<String, CalendarError>) -> Void) {
     // Check current permission status - creating calendars requires full access (writing)
     guard permissionService.hasPermission(for: .full) else {
       completion(.failure(CalendarError(
@@ -64,20 +64,31 @@ class CalendarService {
       )))
       return
     }
-    
-    // Use the best available writable source:
-    // 1. Default calendar's source (usually iCloud on most devices)
-    // 2. First CalDAV source (iCloud, Google, etc.)
-    // 3. Local source (simulator or devices with no cloud accounts)
-    guard let source = eventStore.defaultCalendarForNewEvents?.source
-        ?? eventStore.sources.first(where: { $0.sourceType == .calDAV })
-        ?? eventStore.sources.first(where: { $0.sourceType == .local })
-    else {
-      completion(.failure(CalendarError(
-        code: PlatformExceptionCodes.calendarUnavailable,
-        message: "Could not find a writable calendar source"
-      )))
-      return
+
+    let source: EKSource
+    if let sourceId = sourceId {
+      // Find source by identifier
+      guard let found = eventStore.sources.first(where: { $0.sourceIdentifier == sourceId }) else {
+        completion(.failure(CalendarError(
+          code: PlatformExceptionCodes.notFound,
+          message: "Source not found with identifier: \(sourceId)"
+        )))
+        return
+      }
+      source = found
+    } else {
+      // Use the best available writable source (tiered fallback)
+      guard let fallback = eventStore.defaultCalendarForNewEvents?.source
+          ?? eventStore.sources.first(where: { $0.sourceType == .calDAV })
+          ?? eventStore.sources.first(where: { $0.sourceType == .local })
+      else {
+        completion(.failure(CalendarError(
+          code: PlatformExceptionCodes.calendarUnavailable,
+          message: "Could not find a writable calendar source"
+        )))
+        return
+      }
+      source = fallback
     }
 
     // Create a new calendar
@@ -183,6 +194,38 @@ class CalendarService {
     }
   }
   
+  func listSources(completion: @escaping (Result<[[String: Any]], CalendarError>) -> Void) {
+    guard permissionService.hasPermission(for: .full) else {
+      completion(.failure(CalendarError(
+        code: PlatformExceptionCodes.permissionDenied,
+        message: "Calendar permission denied. Call requestPermissions() first."
+      )))
+      return
+    }
+
+    let sources = eventStore.sources.map { source -> [String: Any] in
+      return [
+        "id": source.sourceIdentifier,
+        "accountName": source.title,
+        "accountType": sourceTypeToString(sourceType: source.sourceType),
+        "type": sourceTypeToCalendarSourceType(source.sourceType),
+      ]
+    }
+
+    completion(.success(sources))
+  }
+
+  private func sourceTypeToCalendarSourceType(_ type: EKSourceType) -> String {
+    switch type {
+    case .local: return "local"
+    case .calDAV: return "calDav"
+    case .exchange: return "exchange"
+    case .subscribed: return "subscribed"
+    case .birthdays: return "birthdays"
+    default: return "other"
+    }
+  }
+
   private func sourceTypeToString(sourceType: EKSourceType) -> String {
     switch sourceType {
     case .local:

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
@@ -27,6 +27,8 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
       handleOpenAppSettings(result: result)
     case "listCalendars":
       handleListCalendars(result: result)
+    case "listSources":
+      handleListSources(result: result)
     case "createCalendar":
       handleCreateCalendar(call: call, result: result)
     case "updateCalendar":
@@ -119,6 +121,19 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     }
   }
   
+  private func handleListSources(result: @escaping FlutterResult) {
+    calendarService.listSources { serviceResult in
+      DispatchQueue.main.async {
+        switch serviceResult {
+        case .success(let sources):
+          result(sources)
+        case .failure(let error):
+          result(FlutterError(code: error.code, message: error.message, details: nil))
+        }
+      }
+    }
+  }
+
   private func handleCreateCalendar(call: FlutterMethodCall, result: @escaping FlutterResult) {
     guard let args = call.arguments as? [String: Any] else {
       result(FlutterError(
@@ -128,7 +143,7 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
       ))
       return
     }
-    
+
     // Parse name (required)
     guard let name = args["name"] as? String else {
       result(FlutterError(
@@ -138,11 +153,14 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
       ))
       return
     }
-    
+
     // Parse colorHex (optional)
     let colorHex = args["colorHex"] as? String
-    
-    calendarService.createCalendar(name: name, colorHex: colorHex) { serviceResult in
+
+    // Parse sourceId (optional — if nil, uses tiered fallback)
+    let sourceId = args["sourceId"] as? String
+
+    calendarService.createCalendar(name: name, colorHex: colorHex, sourceId: sourceId) { serviceResult in
       DispatchQueue.main.async {
         switch serviceResult {
         case .success(let calendarId):

--- a/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
+++ b/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
@@ -37,6 +37,14 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
   }
 
   @override
+  Future<List<Map<String, dynamic>>> listSources() async {
+    final result =
+        await methodChannel.invokeMethod<List<dynamic>>('listSources');
+    return result?.map((e) => Map<String, dynamic>.from(e as Map)).toList() ??
+        [];
+  }
+
+  @override
   Future<String> createCalendar(
     String name,
     String? colorHex,

--- a/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
+++ b/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
@@ -2,6 +2,9 @@ import 'package:device_calendar_plus_platform_interface/device_calendar_plus_pla
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+import 'src/create_calendar_options_ios.dart';
+export 'src/create_calendar_options_ios.dart';
+
 /// The iOS implementation of [DeviceCalendarPlusPlatform].
 class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
   /// The method channel used to interact with the native platform.
@@ -50,13 +53,17 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
     String? colorHex,
     CreateCalendarPlatformOptions? platformOptions,
   ) async {
-    // iOS does not support platform-specific options for calendar creation
-    // platformOptions is ignored
+    String? sourceId;
+    if (platformOptions is CreateCalendarOptionsIos) {
+      sourceId = platformOptions.sourceId;
+    }
+
     final result = await methodChannel.invokeMethod<String>(
       'createCalendar',
       <String, dynamic>{
         'name': name,
         'colorHex': colorHex,
+        'sourceId': sourceId,
       },
     );
     return result!;

--- a/packages/device_calendar_plus_ios/lib/src/create_calendar_options_ios.dart
+++ b/packages/device_calendar_plus_ios/lib/src/create_calendar_options_ios.dart
@@ -1,0 +1,34 @@
+import 'package:device_calendar_plus_platform_interface/device_calendar_plus_platform_interface.dart';
+
+/// iOS-specific options for creating a calendar.
+///
+/// Use this class to specify which source (account) the calendar should be
+/// created under. Pass the [CalendarSource.id] from [DeviceCalendar.listSources].
+///
+/// If [platformOptions] is omitted from [DeviceCalendar.createCalendar], the
+/// default tiered fallback is used (default calendar's source → first CalDAV → local).
+///
+/// Example:
+/// ```dart
+/// final sources = await plugin.listSources();
+/// final icloud = sources.firstWhere((s) => s.accountName == 'iCloud');
+///
+/// await plugin.createCalendar(
+///   name: 'Work Calendar',
+///   platformOptions: CreateCalendarOptionsIos(sourceId: icloud.id),
+/// );
+/// ```
+class CreateCalendarOptionsIos extends CreateCalendarPlatformOptions {
+  /// The source identifier to create the calendar under.
+  ///
+  /// This is the [CalendarSource.id] value, which corresponds to
+  /// `EKSource.sourceIdentifier` on iOS.
+  final String sourceId;
+
+  /// Creates iOS-specific calendar creation options.
+  ///
+  /// [sourceId] is the source identifier from [CalendarSource.id].
+  const CreateCalendarOptionsIos({
+    required this.sourceId,
+  });
+}

--- a/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
+++ b/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
@@ -91,6 +91,12 @@ abstract class DeviceCalendarPlusPlatform extends PlatformInterface {
     CreateCalendarPlatformOptions? platformOptions,
   );
 
+  /// Lists available calendar sources/accounts on the device.
+  ///
+  /// Returns a list of maps with keys: id, accountName, accountType, type.
+  /// Requires calendar read permissions.
+  Future<List<Map<String, dynamic>>> listSources();
+
   /// Updates an existing calendar on the device.
   ///
   /// [calendarId] is the ID of the calendar to update.

--- a/packages/device_calendar_plus_platform_interface/test/device_calendar_plus_platform_interface_test.dart
+++ b/packages/device_calendar_plus_platform_interface/test/device_calendar_plus_platform_interface_test.dart
@@ -17,6 +17,9 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
   Future<List<Map<String, dynamic>>> listCalendars() async => [];
 
   @override
+  Future<List<Map<String, dynamic>>> listSources() async => [];
+
+  @override
   Future<String> createCalendar(
     String name,
     String? colorHex,


### PR DESCRIPTION
## Summary
- Add `listSources()` to discover available calendar sources/accounts
- Add `CreateCalendarOptionsIos` with `sourceId` for iOS source selection
- Add optional `accountType` to `CreateCalendarOptionsAndroid`
- Default fallback behavior unchanged when no source specified

## Changes
- `CalendarSource` model with id, accountName, accountType, type enum
- `CalendarSourceType` enum (local, calDav, exchange, subscribed, birthdays, other)
- iOS: maps `eventStore.sources`, finds source by `sourceIdentifier` for createCalendar
- Android: queries distinct sources from Calendars table, passes accountType to ContentValues
- Integration tests for both platforms

## Platform Notes
- iOS `id` is `EKSource.sourceIdentifier` (stable, used for creation)
- Android `id` is synthetic `"accountName|accountType"` (informational only)
- Android only lists sources that already have calendars (documented limitation)

## Testing
- Integration tests pass on both Android emulator and iOS simulator
- Tests verify listSources returns data, and explicit source creation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)