### PR TITLE
chore(release): 0.3.5

### DIFF
--- a/packages/device_calendar_plus/CHANGELOG.md
+++ b/packages/device_calendar_plus/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 0.3.5 - 2026-04-20
+
+### Added
+- `listSources()` to discover calendar accounts/sources — based on @magic-fit (#14)
+- Source selection on `createCalendar` — iOS via `CreateCalendarOptionsIos(sourceId:)`, Android via optional `accountType`
+- `supportsCalendarCreation` on `CalendarSource`
+- `availability` parameter on `updateEvent()` — thanks @SuperKrallan (#29)
+- `url` field on events (iOS: `EKEvent.url`, Android: `CUSTOM_APP_URI`) — thanks @magic-fit (#32)
+- `showCreateEventModal()` with optional pre-fill (title, dates, location, description)
+- Read-only `attendees` on events (name, email, role, status)
+
+### Fixed
+- Android: all-day events appearing in wrong day's query in non-UTC timezones (#20)
+- Android: `hasPermissions()` now works from background services without an Activity (#31)
+- Android: calendar/event queries use application context for background compatibility — thanks @vitalii-vov (#26)
+- Android: `notDetermined` permission status correctly distinguished from `denied` — thanks @Albert221 (#12)
+- iOS: calendar source lookup fallback when default source is unavailable — thanks @zaqwery (#13)
+- iOS: `createCalendar` default fallback now picks iCloud over Gmail CalDAV (#33)
+
 ## 0.3.4 - 2026-02-08
 
 ### Added

--- a/packages/device_calendar_plus/pubspec.yaml
+++ b/packages/device_calendar_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus
 description: A modern, maintained Flutter plugin for reading and writing device calendar events on Android and iOS.
-version: 0.3.4
+version: 0.3.5
 repository: https://github.com/bullet-to/device_calendar_plus
 issue_tracker: https://github.com/bullet-to/device_calendar_plus/issues
 

--- a/packages/device_calendar_plus_android/CHANGELOG.md
+++ b/packages/device_calendar_plus_android/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.5 - 2026-04-20
+
+### Fixed
+- All-day events appearing in wrong day's query in non-UTC timezones (#20)
+- `PermissionService` accepts `Context` — `hasPermissions()` works without an Activity (#31)
+
 ## 0.3.4 - 2026-02-08
 
 Version sync with other packages. No functional changes.

--- a/packages/device_calendar_plus_android/pubspec.yaml
+++ b/packages/device_calendar_plus_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus_android
 description: Android implementation of the device_calendar_plus plugin.
-version: 0.3.4
+version: 0.3.5
 repository: https://github.com/bullet-to/device_calendar_plus
 
 resolution: workspace

--- a/packages/device_calendar_plus_ios/CHANGELOG.md
+++ b/packages/device_calendar_plus_ios/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.5 - 2026-04-20
+
+### Fixed
+- Calendar source lookup fallback when default source is unavailable (#13)
+- `createCalendar` default fallback prefers iCloud over other CalDAV sources (#33)
+
 ## 0.3.4 - 2026-02-08
 
 ### Added

--- a/packages/device_calendar_plus_ios/pubspec.yaml
+++ b/packages/device_calendar_plus_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus_ios
 description: iOS implementation of the device_calendar_plus plugin.
-version: 0.3.4
+version: 0.3.5
 repository: https://github.com/bullet-to/device_calendar_plus
 
 resolution: workspace

--- a/packages/device_calendar_plus_platform_interface/CHANGELOG.md
+++ b/packages/device_calendar_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.5 - 2026-04-20
+
+Version sync with other packages. No functional changes.
+
 ## 0.3.4 - 2026-02-08
 
 Version sync with other packages. No functional changes.

--- a/packages/device_calendar_plus_platform_interface/pubspec.yaml
+++ b/packages/device_calendar_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus_platform_interface
 description: Platform interface for device_calendar_plus plugin.
-version: 0.3.4
+version: 0.3.5
 repository: https://github.com/bullet-to/device_calendar_plus
 
 resolution: workspace


### PR DESCRIPTION
## Release 0.3.5

Version bump + changelogs for all 4 packages.

Depends on PRs #33 and #34 being merged first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)