### PR TITLE
docs: close project to outside pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,12 @@
 # Contributing to device_calendar_plus
 
-Contributions are welcome!
+**This project is closed to outside pull requests.**
 
-**Bug fixes** that don't change the public API can go straight to a PR.
+Bug reports and feature requests are welcome - please open an issue. I'll handle the implementation myself to keep the API surface and platform-parity decisions consistent.
 
-**New features or API changes** — please open an issue first. The maintainer defines the API surface to ensure cross-platform consistency, so PRs that add new methods, parameters, or models without prior discussion will likely need significant rework. An issue lets us align on the design before you write code.
+If you've already started on a fix, share your approach in the issue. It's useful context and I'll credit you in the changelog when the fix ships.
+
+The rest of this document describes the design philosophy and conventions that guide implementation decisions. It's still worth reading if you want to understand why the API looks the way it does.
 
 ## Design Philosophy
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ flutter devices
 
 ## 🤝 Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, design philosophy, and development workflow.
+This project is closed to outside pull requests. Bug reports and feature requests are welcome - please open an issue. See [CONTRIBUTING.md](CONTRIBUTING.md) for the design philosophy and conventions.
 
 ## 📄 License
 

--- a/packages/device_calendar_plus/README.md
+++ b/packages/device_calendar_plus/README.md
@@ -509,14 +509,7 @@ await plugin.deleteEvent(event.instanceId);
 
 ## 🤝 Contributing
 
-Contributions, PRs and issue reports welcome.
-Open an issue first for larger features or breaking changes.
-
-- Code style: `dart format .`
-- Run tests: `flutter test`
-- Federated layout: platform code lives in
-  `/packages/device_calendar_plus_android` and `/packages/device_calendar_plus_ios`;
-  shared contracts in `/packages/device_calendar_plus_platform_interface`.
+This project is closed to outside pull requests. Bug reports and feature requests are welcome - please open an issue. The maintainer handles implementation to keep the API surface and platform-parity decisions consistent.
 
 ## 🧪 Testing Status
 


### PR DESCRIPTION
## Summary
- Rewrite CONTRIBUTING.md intro to make it explicit that outside PRs are no longer accepted; issues remain welcome and contributor code/approach gets credited in the changelog when shipped.
- Update both READMEs (root + package) so their Contributing sections match.
- Keep design philosophy, conventions, and DateTime rules intact - those still apply to maintainer work.

## Test plan
- [ ] Skim rendered CONTRIBUTING.md and both README files on GitHub to confirm the new wording reads well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)