### PR TITLE
feat: updateRecurring — edit recurring events (#36)

### DIFF
--- a/.claude/rules/api-design.md
+++ b/.claude/rules/api-design.md
@@ -11,9 +11,9 @@ conform Android to iOS. iOS is the priority platform — it has most of the
 users and revenue — so its default behaviour sets the contract. This is
 usually also the practical direction: Android's Calendar Provider is
 low-level and malleable, while iOS EventKit is opinionated and hard to
-change. For example, `updateRecurring`'s "this and following" split has an
-off-by-one in which occurrence is the boundary; iOS EventKit decides it
-natively, and Android's manual split is bent to match.
+change. For example, `updateRecurring`'s `thisAndFollowing` split: iOS's
+`EKSpan.futureEvents` decides where the series divides, and Android's manual
+`UNTIL`-truncate split is built to match it.
 
 ## Typed APIs with raw escape hatch
 

--- a/.claude/rules/api-design.md
+++ b/.claude/rules/api-design.md
@@ -6,6 +6,15 @@ Only expose features that work identically on both iOS and Android. If a
 capability is read-only on one platform, it's read-only in the plugin. If it
 doesn't exist on one platform, don't add it.
 
+When a behaviour *can* be made consistent but the platforms naturally differ,
+conform Android to iOS. iOS is the priority platform — it has most of the
+users and revenue — so its default behaviour sets the contract. This is
+usually also the practical direction: Android's Calendar Provider is
+low-level and malleable, while iOS EventKit is opinionated and hard to
+change. For example, `updateRecurring`'s "this and following" split has an
+off-by-one in which occurrence is the boundary; iOS EventKit decides it
+natively, and Android's manual split is bent to match.
+
 ## Typed APIs with raw escape hatch
 
 Use `sealed class` hierarchies for types with distinct variants (e.g.

--- a/ai_specs/update-recurring-spec.md
+++ b/ai_specs/update-recurring-spec.md
@@ -1,0 +1,197 @@
+<goal>
+Add `updateRecurring` — a method for editing recurring events with a span
+choice ("all events" vs "this and following"), resolving issue #36
+(updateEvent cannot change a recurrence rule).
+
+This is PR2. PR1 (#47, merged) landed `Patch<T>` for clearable fields on
+`updateEvent`. PR2 builds on it.
+</goal>
+
+<background>
+Federated Flutter plugin, four packages:
+- `device_calendar_plus` — public Dart API
+- `device_calendar_plus_platform_interface` — abstract contract
+- `device_calendar_plus_android` — Android implementation (Kotlin + Dart)
+- `device_calendar_plus_ios` — iOS implementation (Swift + Dart)
+
+Repo: bullet-to/device_calendar_plus. Conventions in CLAUDE.md,
+.claude/rules/{api-design,error-handling,testing}.md, CONTRIBUTING.md.
+
+Today `updateEvent` always updates a whole event / whole series and cannot
+change the recurrence rule at all. Issue #36 asks for recurrence-rule
+editing. Investigation (device probes of EventKit and Android Calendar
+Provider) established the design below.
+
+Status of the four originating issues:
+- #38 (url), #39 (compile error) — shipped in PR #42.
+- #37 (calendarId in updateEvent) — closed, not planned (Android can't
+  reliably move events between calendars; platform-parity).
+- #36 (recurrenceRule) — THIS spec resolves it.
+
+Issue author @SuperKrallan — credit in the CHANGELOG.
+</background>
+
+<core_principle>
+"Update the recurrence" splits into a PRIMARY action and SECONDARY effects:
+
+- PRIMARY ACTION — the rule itself changes (add / change / remove). This
+  MUST behave identically on iOS and Android.
+- SECONDARY EFFECTS — what happens to occurrences the user individually
+  customised (moved/deleted instances, a.k.a. exceptions). These are
+  BEST-EFFORT: each platform does what it naturally does, and we document
+  it. We do NOT block the feature trying to make them identical.
+
+This is consistent with the plugin's existing philosophy ("acknowledge
+platform differences, don't hide them") — it just draws the line at
+primary-vs-secondary.
+</core_principle>
+
+<design_decisions>
+SETTLED — do not relitigate:
+
+1. TWO methods, not one. `updateEvent` stays as-is (takes an event ID,
+   handles single events + whole series, void return, no span).
+   `updateRecurring` is NEW and takes an instance ID. Rationale: each
+   method gets a uniform ID contract — updateEvent always an event ID,
+   updateRecurring always an instance ID (`eventId@timestamp`). A single
+   method would make the `eventId` param's type shift by span, which is
+   the wart we are avoiding.
+
+2. `updateRecurring(instanceId, span, {fields})` returns `Future<String>`
+   — the event ID for the affected scope. Same ID for `allEvents`; the
+   NEW series' ID for `thisAndFollowing` (a split creates a new event).
+
+3. `EventUpdateSpan { allEvents, thisAndFollowing }`. Room for a future
+   `thisInstanceOnly` ("this event only" single-instance edit) — NOT in
+   scope now.
+
+4. Reuses `Patch<T>` from PR1. The recurrence rule is itself a
+   `Patch<RecurrenceRule>` field: `Patch.set` adds/changes the rule,
+   `Patch.clear` removes it (event becomes non-recurring). `null` leaves
+   recurrence untouched.
+
+5. `updateRecurring` accepts the SAME field set as `updateEvent` (title,
+   startDate, endDate, description, location, url, isAllDay, timeZone,
+   availability) PLUS `recurrenceRule`. No field is span-incompatible.
+   description/location/url use `Patch<String>` as in PR1.
+
+6. `updateEvent` still accepts a recurring event's ID, behaving as
+   `allEvents` (unchanged, non-breaking). Minor harmless overlap with
+   `updateRecurring(instanceId, allEvents)` — two natural doors.
+
+7. A bare event ID (no `@timestamp`) passed to `updateRecurring` with
+   `span: thisAndFollowing` → `ArgumentError` (no split point).
+</design_decisions>
+
+<behaviour>
+PRIMARY (identical on both platforms):
+- `allEvents` — the whole series follows the new rule; or, with
+  `Patch.clear()` on the rule, becomes a single event.
+- `thisAndFollowing` — the series is split at the supplied instance: the
+  original series is truncated to end just before that instance, and a
+  new series starts at that instance with the new rule/fields.
+
+SECONDARY (best-effort, documented in the doc comment):
+- Exceptions BEFORE a `thisAndFollowing` split point survive intact
+  (they remain in the truncated original's still-valid range).
+- Exceptions AT/AFTER the split point (or anywhere, for `allEvents`) are
+  reset: a moved occurrence persists as a detached standalone event; a
+  deleted occurrence may reappear if the new rule regenerates that date.
+- DB tidiness around orphaned exception rows differs between platforms
+  (Android leaves orphan rows; iOS EventKit tends to clean up). Not
+  user-visible. Documented, not fixed.
+</behaviour>
+
+<split_mechanics>
+iOS — `EKSpan.futureEvents` performs the split natively. Fetch the
+instance (not the parent), apply the new rule/fields, save with
+`.futureEvents`. EventKit truncates the original and creates the new
+series itself.
+
+Android — manual. No `EKSpan` equivalent. Steps:
+1. Read the parent's existing start/end; compute DURATION.
+2. Truncate the parent's `RRULE` with `UNTIL=<just before split point>`.
+3. Insert a new event from the split point with the new RRULE/fields.
+4. Handle the `DTEND` <-> `DURATION` swap: recurring events use DURATION,
+   single events use DTEND. `createEvent` already does this — mirror it.
+
+OFF-BY-ONE: iOS's `.futureEvents` puts the anchor instance into the OLD
+series, not the new one. Android's manual split is BENT TO MATCH iOS
+(truncate so the anchor stays in the old series). Per the new philosophy
+rule below — conform Android to iOS.
+</split_mechanics>
+
+<philosophy_rule>
+Add to `.claude/rules/api-design.md`, right after the existing "platform
+parity over platform power" paragraph:
+
+"When a behaviour can be made consistent but the platforms naturally
+differ, conform Android to iOS. iOS is the priority platform — it has
+most of the users and revenue — so its default behaviour sets the
+contract. (This is usually also the practical direction: Android's
+Calendar Provider is low-level and malleable, while iOS EventKit is
+opinionated and hard to change.)"
+
+This can land in PR2 or as its own tiny docs PR.
+</philosophy_rule>
+
+<probe_findings>
+From device probes during investigation (informational — not plugin code):
+- iOS `.futureEvents` split works; off-by-one confirmed; exceptions
+  before the split survive on the truncated parent.
+- iOS exception detection via `calendarItemExternalIdentifier` does NOT
+  surface detached instances for local events — irrelevant now (the
+  split design doesn't need exception detection).
+- Android: plain recurring events expand correctly. Creating an exception
+  must use `CONTENT_EXCEPTION_URI` + DURATION (not DTEND — the provider
+  rejects DTEND on an exception of a DURATION-based parent).
+- Android emulator showed the parent's instances vanishing from the
+  Instances table once an exception existed — almost certainly an
+  emulator artifact (every real Android calendar app handles recurring
+  events with exceptions). Confirm on a physical Android device before
+  shipping; treat as due diligence, not a known blocker.
+
+Throwaway probe scaffolding lives on branch
+`probe/recurrence-split-validation` — do NOT merge it; it can be deleted.
+</probe_findings>
+
+<implementation>
+Federated, in order (CONTRIBUTING's prescribed order):
+1. platform interface — add `updateRecurring` signature + `EventUpdateSpan`.
+2. android — Kotlin manual split + Dart impl.
+3. ios — Swift `.futureEvents` split + Dart impl.
+4. public API — `updateRecurring` with validation (ArgumentError for bare
+   event ID + thisAndFollowing; at-least-one-field check) and docs.
+5. `.claude/rules/api-design.md` — the philosophy rule.
+6. README + CHANGELOG (CHANGELOG credits @SuperKrallan, #36).
+
+If the PR gets large, the span machinery can be split from the recurrence
+work into its own PR first.
+</implementation>
+
+<testing>
+Integration tests are the backbone (.claude/rules/testing.md) — run on
+real devices via `example/run_integration_tests.sh`.
+
+Cover, on BOTH platforms:
+- allEvents: change a series' rule; verify whole series follows new rule.
+- allEvents: `Patch.clear()` the rule; verify event becomes single.
+- thisAndFollowing: split a series; verify original truncated + new
+  series from the split point with the new rule.
+- thisAndFollowing: an exception before the split survives.
+- ArgumentError when a bare event ID is used with thisAndFollowing.
+
+Build env on the Mac Mini: fvm flutter at `~/fvm/versions/stable/bin/`,
+Android SDK at `~/Library/Android/sdk`, AVD `dcp_probe`, JAVA_HOME at
+`/Applications/Android Studio.app/Contents/jbr/Contents/Home`. Always
+shut emulators/simulators down after a run.
+</testing>
+
+<open_questions>
+- Android: confirm on a physical device that a rule change on an
+  exception-laden series still renders correctly (the emulator was
+  inconclusive). If a real device also breaks, the Android side must
+  clean up orphaned exception rows as part of the update.
+- Whether to split PR2 into "span machinery" + "recurrence rule" — decide
+  once the diff size is visible.
+</open_questions>

--- a/packages/device_calendar_plus/CHANGELOG.md
+++ b/packages/device_calendar_plus/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## Unreleased
 
 ### Added
+- `updateRecurring()` — update a recurring event with a span choice
+  (`EventUpdateSpan.allEvents` or `EventUpdateSpan.thisAndFollowing`),
+  including changing or removing the recurrence rule. Resolves the
+  long-standing limitation that `updateEvent()` could not edit recurrence.
+  Based on @SuperKrallan (#36)
+- `EventUpdateSpan` enum for choosing the scope of a recurring-event edit
 - `url` parameter on `updateEvent()` — based on @SuperKrallan (#38)
 
 ### Changed

--- a/packages/device_calendar_plus/CHANGELOG.md
+++ b/packages/device_calendar_plus/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## Unreleased
 
 ### Added
-- `updateRecurring()` — update a recurring event with a span choice
-  (`EventUpdateSpan.allEvents` or `EventUpdateSpan.thisAndFollowing`),
-  including changing or removing the recurrence rule. Resolves the
-  long-standing limitation that `updateEvent()` could not edit recurrence.
+- `updateRecurring()` — update a recurring event with a span choice:
+  `EventUpdateSpan.allEvents` (whole series), `thisAndFollowing` (this
+  occurrence and every later one), or `thisInstance` (only this occurrence).
+  Can change or remove the recurrence rule. Resolves the long-standing
+  limitation that `updateEvent()` could not edit recurrence.
   Based on @SuperKrallan (#36)
 - `EventUpdateSpan` enum for choosing the scope of a recurring-event edit
 - `url` parameter on `updateEvent()` — based on @SuperKrallan (#38)

--- a/packages/device_calendar_plus/README.md
+++ b/packages/device_calendar_plus/README.md
@@ -490,7 +490,47 @@ await plugin.updateEvent(
 );
 ```
 
-**Note on Recurring Events**: For recurring events, `updateEvent` will always update the ENTIRE series (all past and future occurrences). Single-instance updates are not supported to maintain consistent behavior across platforms.
+**Note on Recurring Events**: For recurring events, `updateEvent` updates the ENTIRE series (all past and future occurrences). To change the recurrence rule itself, or to edit only part of a series, use `updateRecurring` (below).
+
+### Update Recurring Events
+
+`updateEvent` always updates a whole event. To edit a recurring **series** — including changing or removing its recurrence rule — use `updateRecurring`. It takes an `EventUpdateSpan`:
+
+- `EventUpdateSpan.allEvents` — the change applies to the whole series.
+- `EventUpdateSpan.thisAndFollowing` — the series is split at the occurrence you pass, and the change applies from there onward.
+
+```dart
+final plugin = DeviceCalendar.instance;
+
+// Change the whole series to weekly
+await plugin.updateRecurring(
+  event.instanceId,
+  EventUpdateSpan.allEvents,
+  recurrenceRule: Patch.set(WeeklyRecurrence(end: CountEnd(10))),
+);
+
+// Stop the series recurring — it becomes a single, non-recurring event
+await plugin.updateRecurring(
+  event.instanceId,
+  EventUpdateSpan.allEvents,
+  recurrenceRule: Patch.clear(),
+);
+
+// Split the series: this occurrence onward moves to a new time.
+// Returns the new series' event ID.
+final newSeriesId = await plugin.updateRecurring(
+  event.instanceId,
+  EventUpdateSpan.thisAndFollowing,
+  startDate: DateTime(2024, 3, 21, 15, 0),
+  endDate: DateTime(2024, 3, 21, 16, 0),
+);
+```
+
+`recurrenceRule` takes a `Patch`: omit it to leave recurrence unchanged, `Patch.set(...)` to change the rule, `Patch.clear()` to remove it. All other fields behave as in `updateEvent`. `updateRecurring` returns the event ID for the affected scope — the same ID for `allEvents`, the new series' ID for `thisAndFollowing`.
+
+**Span and the split point.** For `thisAndFollowing`, pass an instance ID (`event.instanceId`) that carries an occurrence timestamp — it is the split point. The occurrence you name stays on the *original* series; the new rule applies from the next occurrence. iOS EventKit behaves this way natively and Android is bent to match, so the behaviour is consistent across platforms.
+
+**Customised occurrences.** Changing a recurrence rule is best-effort with respect to occurrences a user had individually moved or deleted. Customisations before a `thisAndFollowing` split point survive; customisations at or after the split point (or anywhere, for `allEvents`) may be reset.
 
 ### Delete Event
 
@@ -512,7 +552,7 @@ await plugin.deleteEvent(event.instanceId);
 - [x] **All-day events** — proper floating date handling across timezones
 - [x] **Native UI** — show event modal on both platforms
 - [x] **Recurring events** — create and read with sealed RecurrenceRule model (daily, weekly, monthly, yearly)
-- [ ] **Update recurrence rules** — change/add/remove recurrence rule via `updateEvent`
+- [x] **Update recurrence rules** — change, add or remove a recurrence rule via `updateRecurring`
 - [ ] **Attendees** — read on both platforms; write on Android (iOS EventKit is read-only for participants)
 - [ ] **Reminders / alarms** — read/write on both platforms
 - [ ] **Platform-specific extras** — event URL, organizer, and other platform-native fields exposed where supported

--- a/packages/device_calendar_plus/README.md
+++ b/packages/device_calendar_plus/README.md
@@ -497,7 +497,8 @@ await plugin.updateEvent(
 `updateEvent` always updates a whole event. To edit a recurring **series** — including changing or removing its recurrence rule — use `updateRecurring`. It takes an `EventUpdateSpan`:
 
 - `EventUpdateSpan.allEvents` — the change applies to the whole series.
-- `EventUpdateSpan.thisAndFollowing` — the series is split at the occurrence you pass, and the change applies from there onward.
+- `EventUpdateSpan.thisAndFollowing` — the series is split: the occurrence you pass, and every later one, carry the change.
+- `EventUpdateSpan.thisInstance` — only the occurrence you pass is changed, as a detached exception.
 
 ```dart
 final plugin = DeviceCalendar.instance;
@@ -516,7 +517,7 @@ await plugin.updateRecurring(
   recurrenceRule: Patch.clear(),
 );
 
-// Split the series: this occurrence onward moves to a new time.
+// Split the series: this occurrence and every later one move to a new time.
 // Returns the new series' event ID.
 final newSeriesId = await plugin.updateRecurring(
   event.instanceId,
@@ -524,13 +525,20 @@ final newSeriesId = await plugin.updateRecurring(
   startDate: DateTime(2024, 3, 21, 15, 0),
   endDate: DateTime(2024, 3, 21, 16, 0),
 );
+
+// Change only this one occurrence, leaving the rest of the series alone.
+await plugin.updateRecurring(
+  event.instanceId,
+  EventUpdateSpan.thisInstance,
+  title: 'Moved this week only',
+);
 ```
 
-`recurrenceRule` takes a `Patch`: omit it to leave recurrence unchanged, `Patch.set(...)` to change the rule, `Patch.clear()` to remove it. All other fields behave as in `updateEvent`. `updateRecurring` returns the event ID for the affected scope — the same ID for `allEvents`, the new series' ID for `thisAndFollowing`.
+`recurrenceRule` takes a `Patch`: omit it to leave recurrence unchanged, `Patch.set(...)` to change the rule, `Patch.clear()` to remove it. It cannot be used with `thisInstance` (a single occurrence has no rule of its own). All other fields behave as in `updateEvent`. `updateRecurring` returns the event ID for the affected scope — the same ID for `allEvents`, the new series' ID for `thisAndFollowing`, the detached occurrence's ID for `thisInstance`.
 
-**Span and the split point.** For `thisAndFollowing`, pass an instance ID (`event.instanceId`) that carries an occurrence timestamp — it is the split point. The occurrence you name stays on the *original* series; the new rule applies from the next occurrence. iOS EventKit behaves this way natively and Android is bent to match, so the behaviour is consistent across platforms.
+**Span and the split point.** For `thisAndFollowing` and `thisInstance`, pass an instance ID (`event.instanceId`) that carries an occurrence timestamp. For `thisAndFollowing` it is the split point: that occurrence and every later one become a new series carrying the change; earlier occurrences are untouched.
 
-**Customised occurrences.** Changing a recurrence rule is best-effort with respect to occurrences a user had individually moved or deleted. Customisations before a `thisAndFollowing` split point survive; customisations at or after the split point (or anywhere, for `allEvents`) may be reset.
+**Customised occurrences.** Editing a series is best-effort with respect to occurrences a user had individually moved or deleted. Customisations before a `thisAndFollowing` split point survive; customisations at or after the split point (or anywhere, for `allEvents`) may be reset.
 
 ### Delete Event
 

--- a/packages/device_calendar_plus/example/integration_test/recurrence_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/recurrence_test.dart
@@ -328,4 +328,136 @@ void main() {
       expect(rrule, contains('COUNT=5'));
     });
   });
+
+  group('Recurrence Update Tests', () {
+    late DeviceCalendar plugin;
+    String? calendarId;
+
+    setUpAll(() async {
+      plugin = DeviceCalendar.instance;
+      await plugin.requestPermissions();
+
+      calendarId = await plugin.createCalendar(
+        name: 'Recurrence Update Test ${DateTime.now().millisecondsSinceEpoch}',
+        colorHex: '#00FF00',
+      );
+    });
+
+    tearDownAll(() async {
+      if (calendarId != null) {
+        await plugin.deleteCalendar(calendarId!);
+      }
+    });
+
+    /// Creates a daily recurring event, returning its ID and start date.
+    Future<({String eventId, DateTime start})> createDailySeries({
+      int count = 10,
+    }) async {
+      final start = DateTime.now().add(const Duration(hours: 1));
+      final eventId = await plugin.createEvent(
+        calendarId: calendarId!,
+        title: 'Daily Series',
+        startDate: start,
+        endDate: start.add(const Duration(hours: 1)),
+        recurrenceRule: DailyRecurrence(end: CountEnd(count)),
+        timeZone: 'UTC',
+      );
+      return (eventId: eventId, start: start);
+    }
+
+    /// Lists the occurrences of [eventId] around [start], in date order.
+    Future<List<Event>> occurrencesOf(String eventId, DateTime start) async {
+      final events = await plugin.listEvents(
+        start.subtract(const Duration(days: 1)),
+        start.add(const Duration(days: 14)),
+        calendarIds: [calendarId!],
+      );
+      return events.where((e) => e.eventId == eventId).toList();
+    }
+
+    test('allEvents changes the recurrence rule for the whole series',
+        () async {
+      if (calendarId == null) return;
+      final series = await createDailySeries();
+
+      final result = await plugin.updateRecurring(
+        series.eventId,
+        EventUpdateSpan.allEvents,
+        recurrenceRule: Patch.set(const WeeklyRecurrence(
+          daysOfWeek: [DayOfWeek.monday],
+          end: CountEnd(5),
+        )),
+      );
+
+      expect(result, series.eventId,
+          reason: 'allEvents returns the same event ID');
+      final updated = await plugin.getEvent(series.eventId);
+      expect(updated, isNotNull);
+      expect(updated!.isRecurring, isTrue);
+      expect(updated.recurrenceRule, isA<WeeklyRecurrence>());
+    });
+
+    test('allEvents with Patch.clear removes recurrence', () async {
+      if (calendarId == null) return;
+      final series = await createDailySeries();
+
+      await plugin.updateRecurring(
+        series.eventId,
+        EventUpdateSpan.allEvents,
+        recurrenceRule: const Patch.clear(),
+      );
+
+      final updated = await plugin.getEvent(series.eventId);
+      expect(updated, isNotNull);
+      expect(updated!.isRecurring, isFalse);
+      expect(updated.recurrenceRule, isNull);
+    });
+
+    test('thisAndFollowing splits the series at the chosen occurrence',
+        () async {
+      if (calendarId == null) return;
+      final series = await createDailySeries(count: 10);
+
+      final occurrences = await occurrencesOf(series.eventId, series.start);
+      expect(occurrences.length, greaterThanOrEqualTo(6),
+          reason: 'the daily series should have expanded into occurrences');
+      final splitPoint = occurrences[4];
+
+      final newSeriesId = await plugin.updateRecurring(
+        splitPoint.instanceId,
+        EventUpdateSpan.thisAndFollowing,
+        title: 'Split Tail',
+      );
+
+      // The new series carries the change.
+      final newSeries = await plugin.getEvent(newSeriesId);
+      expect(newSeries, isNotNull);
+      expect(newSeries!.title, 'Split Tail');
+
+      // The original series still exists and remains recurring.
+      final original = await plugin.getEvent(series.eventId);
+      expect(original, isNotNull);
+      expect(original!.isRecurring, isTrue);
+    });
+
+    test('thisAndFollowing can change the rule from the split point onward',
+        () async {
+      if (calendarId == null) return;
+      final series = await createDailySeries(count: 10);
+
+      final occurrences = await occurrencesOf(series.eventId, series.start);
+      expect(occurrences.length, greaterThanOrEqualTo(6));
+      final splitPoint = occurrences[4];
+
+      final newSeriesId = await plugin.updateRecurring(
+        splitPoint.instanceId,
+        EventUpdateSpan.thisAndFollowing,
+        recurrenceRule: Patch.set(const WeeklyRecurrence(end: CountEnd(3))),
+      );
+
+      final newSeries = await plugin.getEvent(newSeriesId);
+      expect(newSeries, isNotNull);
+      expect(newSeries!.recurrenceRule, isA<WeeklyRecurrence>());
+    });
+  });
 }

--- a/packages/device_calendar_plus/example/integration_test/recurrence_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/recurrence_test.dart
@@ -413,7 +413,7 @@ void main() {
       expect(updated.recurrenceRule, isNull);
     });
 
-    test('thisAndFollowing splits the series at the chosen occurrence',
+    test('thisAndFollowing splits so the anchor occurrence carries the change',
         () async {
       if (calendarId == null) return;
       final series = await createDailySeries(count: 10);
@@ -422,22 +422,36 @@ void main() {
       expect(occurrences.length, greaterThanOrEqualTo(6),
           reason: 'the daily series should have expanded into occurrences');
       final splitPoint = occurrences[4];
+      final splitMillis = splitPoint.startDate.millisecondsSinceEpoch;
 
-      final newSeriesId = await plugin.updateRecurring(
+      await plugin.updateRecurring(
         splitPoint.instanceId,
         EventUpdateSpan.thisAndFollowing,
         title: 'Split Tail',
       );
 
-      // The new series carries the change.
-      final newSeries = await plugin.getEvent(newSeriesId);
-      expect(newSeries, isNotNull);
-      expect(newSeries!.title, 'Split Tail');
+      final after = await plugin.listEvents(
+        series.start.subtract(const Duration(days: 1)),
+        series.start.add(const Duration(days: 14)),
+        calendarIds: [calendarId!],
+      );
 
-      // The original series still exists and remains recurring.
-      final original = await plugin.getEvent(series.eventId);
-      expect(original, isNotNull);
-      expect(original!.isRecurring, isTrue);
+      // The anchor occurrence itself must carry the change — "this and
+      // following" includes the named occurrence.
+      final atSplit = after
+          .where((e) => e.startDate.millisecondsSinceEpoch == splitMillis)
+          .toList();
+      expect(atSplit, isNotEmpty,
+          reason: 'an occurrence should still exist at the split point');
+      expect(atSplit.first.title, 'Split Tail',
+          reason: 'the anchor occurrence must receive the change');
+
+      // Occurrences before the split keep the original title.
+      final before =
+          after.where((e) => e.startDate.millisecondsSinceEpoch < splitMillis);
+      expect(before, isNotEmpty);
+      expect(before.every((e) => e.title == 'Daily Series'), isTrue,
+          reason: 'occurrences before the split must be untouched');
     });
 
     test('thisAndFollowing can change the rule from the split point onward',
@@ -458,6 +472,39 @@ void main() {
       final newSeries = await plugin.getEvent(newSeriesId);
       expect(newSeries, isNotNull);
       expect(newSeries!.recurrenceRule, isA<WeeklyRecurrence>());
+    });
+
+    test('thisInstance edits only the one occurrence', () async {
+      if (calendarId == null) return;
+      final series = await createDailySeries(count: 10);
+
+      final occurrences = await occurrencesOf(series.eventId, series.start);
+      expect(occurrences.length, greaterThanOrEqualTo(6));
+      final target = occurrences[4];
+      final targetMillis = target.startDate.millisecondsSinceEpoch;
+
+      await plugin.updateRecurring(
+        target.instanceId,
+        EventUpdateSpan.thisInstance,
+        title: 'Just this one',
+      );
+
+      final after = await plugin.listEvents(
+        series.start.subtract(const Duration(days: 1)),
+        series.start.add(const Duration(days: 14)),
+        calendarIds: [calendarId!],
+      );
+
+      // Exactly one occurrence changed — the one at the target time.
+      final changed = after.where((e) => e.title == 'Just this one').toList();
+      expect(changed.length, 1,
+          reason: 'only the targeted occurrence should change');
+      expect(changed.first.startDate.millisecondsSinceEpoch, targetMillis);
+
+      // The rest of the series keeps the original title.
+      final unchanged = after.where((e) => e.title == 'Daily Series').toList();
+      expect(unchanged.length, greaterThanOrEqualTo(8),
+          reason: 'the rest of the series must be untouched');
     });
   });
 }

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -6,6 +6,7 @@ import 'src/calendar_permission_status.dart';
 import 'src/calendar_source.dart';
 import 'src/event.dart';
 import 'src/event_availability.dart';
+import 'src/event_update_span.dart';
 import 'src/platform_exception_converter.dart';
 import 'src/recurrence_rule.dart';
 
@@ -31,6 +32,7 @@ export 'src/device_calendar_error.dart';
 export 'src/event.dart';
 export 'src/event_availability.dart';
 export 'src/event_status.dart';
+export 'src/event_update_span.dart';
 export 'src/platform_exception_codes.dart';
 export 'src/recurrence_rule.dart';
 
@@ -827,6 +829,167 @@ class DeviceCalendar {
         isAllDay: isAllDay,
         timeZone: timeZone,
         availability: availability?.name,
+      );
+    } on PlatformException catch (e, stackTrace) {
+      final convertedException =
+          PlatformExceptionConverter.convertPlatformException(e);
+      if (convertedException != null) {
+        Error.throwWithStackTrace(convertedException, stackTrace);
+      }
+      rethrow;
+    }
+  }
+
+  /// Updates a recurring event, choosing which occurrences the edit affects.
+  ///
+  /// Use this instead of [updateEvent] when you need to change a recurring
+  /// event's [recurrenceRule], or when an edit should affect only part of a
+  /// series. For non-recurring events, keep using [updateEvent].
+  ///
+  /// [instanceId] identifies the occurrence to act on — pass an instance ID
+  /// (`event.instanceId`). For [EventUpdateSpan.thisAndFollowing] it must
+  /// carry an occurrence timestamp (`eventId@timestamp`), which is the split
+  /// point; a bare event ID throws [ArgumentError].
+  ///
+  /// [span] chooses the scope:
+  /// - [EventUpdateSpan.allEvents] — the whole series follows the change.
+  ///   Clearing [recurrenceRule] collapses the series into a single event.
+  /// - [EventUpdateSpan.thisAndFollowing] — the series is split at the
+  ///   occurrence timestamp. The named occurrence stays on the original
+  ///   series; the new rule and fields apply from the next occurrence on.
+  ///
+  /// Field parameters behave as in [updateEvent]. [recurrenceRule] takes a
+  /// [Patch]: omit it to leave recurrence unchanged, [Patch.set] to change
+  /// the rule, [Patch.clear] to remove it (the event stops recurring).
+  ///
+  /// **Primary effect** — the recurrence rule change itself — behaves
+  /// identically on iOS and Android.
+  ///
+  /// **Secondary effects** — what happens to occurrences the user had
+  /// individually customised — are best-effort and differ by platform.
+  /// Customisations before a `thisAndFollowing` split point survive.
+  /// Customisations after the split point (or anywhere, for `allEvents`) are
+  /// reset: a moved occurrence persists as a detached standalone event, and a
+  /// deleted occurrence may reappear if the new rule regenerates that date.
+  ///
+  /// Returns the event ID for the affected scope — the same ID for
+  /// `allEvents`, the new series' ID for `thisAndFollowing`.
+  ///
+  /// At least one field must be provided.
+  /// Requires calendar write permissions - call [requestPermissions] first.
+  ///
+  /// Example:
+  /// ```dart
+  /// final plugin = DeviceCalendar.instance;
+  ///
+  /// // Change the whole series to weekly
+  /// await plugin.updateRecurring(
+  ///   event.instanceId,
+  ///   EventUpdateSpan.allEvents,
+  ///   recurrenceRule: Patch.set(WeeklyRecurrence(end: CountEnd(10))),
+  /// );
+  ///
+  /// // Stop the series recurring (becomes a single event)
+  /// await plugin.updateRecurring(
+  ///   event.instanceId,
+  ///   EventUpdateSpan.allEvents,
+  ///   recurrenceRule: Patch.clear(),
+  /// );
+  ///
+  /// // Split: this occurrence onwards moves to a new time
+  /// final newSeriesId = await plugin.updateRecurring(
+  ///   event.instanceId,
+  ///   EventUpdateSpan.thisAndFollowing,
+  ///   startDate: DateTime(2024, 3, 21, 15, 0),
+  ///   endDate: DateTime(2024, 3, 21, 16, 0),
+  /// );
+  /// ```
+  Future<String> updateRecurring(
+    String instanceId,
+    EventUpdateSpan span, {
+    String? title,
+    DateTime? startDate,
+    DateTime? endDate,
+    Patch<String>? description,
+    Patch<String>? location,
+    Patch<String>? url,
+    bool? isAllDay,
+    String? timeZone,
+    EventAvailability? availability,
+    Patch<RecurrenceRule>? recurrenceRule,
+  }) async {
+    // Validate instanceId
+    if (instanceId.trim().isEmpty) {
+      throw ArgumentError.value(
+        instanceId,
+        'instanceId',
+        'Instance ID cannot be empty',
+      );
+    }
+
+    // Parse the ID — thisAndFollowing needs an occurrence timestamp to split on
+    final parsed = InstanceIdParser.parse(instanceId);
+    if (span == EventUpdateSpan.thisAndFollowing && parsed.timestamp == null) {
+      throw ArgumentError.value(
+        instanceId,
+        'instanceId',
+        'EventUpdateSpan.thisAndFollowing requires an instance ID with an '
+            'occurrence timestamp (eventId@timestamp)',
+      );
+    }
+
+    // Validate at least one field is provided
+    if (title == null &&
+        startDate == null &&
+        endDate == null &&
+        description == null &&
+        location == null &&
+        url == null &&
+        isAllDay == null &&
+        timeZone == null &&
+        availability == null &&
+        recurrenceRule == null) {
+      throw ArgumentError(
+        'At least one field must be provided to update',
+      );
+    }
+
+    // Validate dates if both are provided
+    if (startDate != null && endDate != null && endDate.isBefore(startDate)) {
+      throw ArgumentError(
+        'End date must be after start date',
+      );
+    }
+
+    // Normalize dates for all-day events
+    final normalizedStartDate = (isAllDay == true && startDate != null)
+        ? _stripTime(startDate)
+        : startDate;
+    final normalizedEndDate =
+        (isAllDay == true && endDate != null) ? _stripTime(endDate) : endDate;
+
+    // The platform layer works in RRULE strings; map the typed Patch across.
+    final Patch<String>? recurrenceRulePatch = switch (recurrenceRule) {
+      null => null,
+      PatchSet(:final value) => Patch.set(value.toRruleString()),
+      PatchClear() => const Patch.clear(),
+    };
+
+    try {
+      return await DeviceCalendarPlusPlatform.instance.updateRecurring(
+        parsed.eventId,
+        parsed.timestamp,
+        span.name,
+        title: title,
+        startDate: normalizedStartDate,
+        endDate: normalizedEndDate,
+        description: description,
+        location: location,
+        url: url,
+        isAllDay: isAllDay,
+        timeZone: timeZone,
+        availability: availability?.name,
+        recurrenceRule: recurrenceRulePatch,
       );
     } on PlatformException catch (e, stackTrace) {
       final convertedException =

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -847,16 +847,19 @@ class DeviceCalendar {
   /// series. For non-recurring events, keep using [updateEvent].
   ///
   /// [instanceId] identifies the occurrence to act on — pass an instance ID
-  /// (`event.instanceId`). For [EventUpdateSpan.thisAndFollowing] it must
-  /// carry an occurrence timestamp (`eventId@timestamp`), which is the split
-  /// point; a bare event ID throws [ArgumentError].
+  /// (`event.instanceId`). For every [span] except [EventUpdateSpan.allEvents]
+  /// it must carry an occurrence timestamp (`eventId@timestamp`); a bare event
+  /// ID throws [ArgumentError].
   ///
   /// [span] chooses the scope:
   /// - [EventUpdateSpan.allEvents] — the whole series follows the change.
   ///   Clearing [recurrenceRule] collapses the series into a single event.
   /// - [EventUpdateSpan.thisAndFollowing] — the series is split at the
-  ///   occurrence timestamp. The named occurrence stays on the original
-  ///   series; the new rule and fields apply from the next occurrence on.
+  ///   occurrence timestamp: that occurrence and every later one carry the
+  ///   edit; earlier occurrences are untouched.
+  /// - [EventUpdateSpan.thisInstance] — only that occurrence is edited, as a
+  ///   detached exception; the rest of the series is untouched.
+  ///   [recurrenceRule] cannot be used with this span.
   ///
   /// Field parameters behave as in [updateEvent]. [recurrenceRule] takes a
   /// [Patch]: omit it to leave recurrence unchanged, [Patch.set] to change
@@ -873,7 +876,8 @@ class DeviceCalendar {
   /// deleted occurrence may reappear if the new rule regenerates that date.
   ///
   /// Returns the event ID for the affected scope — the same ID for
-  /// `allEvents`, the new series' ID for `thisAndFollowing`.
+  /// `allEvents`, the new series' ID for `thisAndFollowing`, the detached
+  /// occurrence's ID for `thisInstance`.
   ///
   /// At least one field must be provided.
   /// Requires calendar write permissions - call [requestPermissions] first.
@@ -896,12 +900,19 @@ class DeviceCalendar {
   ///   recurrenceRule: Patch.clear(),
   /// );
   ///
-  /// // Split: this occurrence onwards moves to a new time
+  /// // Split: this occurrence and every later one move to a new time
   /// final newSeriesId = await plugin.updateRecurring(
   ///   event.instanceId,
   ///   EventUpdateSpan.thisAndFollowing,
   ///   startDate: DateTime(2024, 3, 21, 15, 0),
   ///   endDate: DateTime(2024, 3, 21, 16, 0),
+  /// );
+  ///
+  /// // Edit only this one occurrence, leaving the rest of the series alone
+  /// await plugin.updateRecurring(
+  ///   event.instanceId,
+  ///   EventUpdateSpan.thisInstance,
+  ///   title: 'Moved this week only',
   /// );
   /// ```
   Future<String> updateRecurring(
@@ -927,14 +938,24 @@ class DeviceCalendar {
       );
     }
 
-    // Parse the ID — thisAndFollowing needs an occurrence timestamp to split on
+    // Parse the ID — every span except allEvents acts on a specific
+    // occurrence, so it needs an occurrence timestamp.
     final parsed = InstanceIdParser.parse(instanceId);
-    if (span == EventUpdateSpan.thisAndFollowing && parsed.timestamp == null) {
+    if (span != EventUpdateSpan.allEvents && parsed.timestamp == null) {
       throw ArgumentError.value(
         instanceId,
         'instanceId',
-        'EventUpdateSpan.thisAndFollowing requires an instance ID with an '
+        'EventUpdateSpan.${span.name} requires an instance ID with an '
             'occurrence timestamp (eventId@timestamp)',
+      );
+    }
+
+    // A single occurrence has no recurrence rule of its own.
+    if (span == EventUpdateSpan.thisInstance && recurrenceRule != null) {
+      throw ArgumentError.value(
+        recurrenceRule,
+        'recurrenceRule',
+        'recurrenceRule cannot be set with EventUpdateSpan.thisInstance',
       );
     }
 

--- a/packages/device_calendar_plus/lib/src/event_update_span.dart
+++ b/packages/device_calendar_plus/lib/src/event_update_span.dart
@@ -9,16 +9,19 @@ enum EventUpdateSpan {
   /// into a single, non-recurring event.
   allEvents,
 
-  /// The edit applies from the supplied occurrence onwards, leaving earlier
-  /// occurrences untouched.
+  /// The edit applies to the supplied occurrence and every occurrence after
+  /// it; earlier occurrences are left untouched.
   ///
   /// The series is split at the occurrence timestamp carried by the instance
-  /// ID: the original series is truncated and a new series is created for the
-  /// affected occurrences.
-  ///
-  /// **Off-by-one:** the occurrence you name as the split point stays on the
-  /// *original* series — the new series begins at the next occurrence. iOS
-  /// EventKit behaves this way natively and Android is bent to match, so the
-  /// behaviour is consistent and documented rather than divergent.
+  /// ID: the original series is truncated to end just before that occurrence,
+  /// and a new series — carrying the edit — begins at it.
   thisAndFollowing,
+
+  /// The edit applies only to the supplied occurrence; the rest of the series
+  /// is left untouched.
+  ///
+  /// This detaches that occurrence from the series as an exception. A
+  /// recurrence rule cannot be set with this span — a single occurrence has
+  /// no rule of its own.
+  thisInstance,
 }

--- a/packages/device_calendar_plus/lib/src/event_update_span.dart
+++ b/packages/device_calendar_plus/lib/src/event_update_span.dart
@@ -1,0 +1,24 @@
+/// Which occurrences of a recurring event an update applies to.
+///
+/// Used by [DeviceCalendar.updateRecurring] to choose the scope of an edit to
+/// a recurring series.
+enum EventUpdateSpan {
+  /// The edit applies to every occurrence in the series — past and future.
+  ///
+  /// Clearing the recurrence rule with this span collapses the whole series
+  /// into a single, non-recurring event.
+  allEvents,
+
+  /// The edit applies from the supplied occurrence onwards, leaving earlier
+  /// occurrences untouched.
+  ///
+  /// The series is split at the occurrence timestamp carried by the instance
+  /// ID: the original series is truncated and a new series is created for the
+  /// affected occurrences.
+  ///
+  /// **Off-by-one:** the occurrence you name as the split point stays on the
+  /// *original* series — the new series begins at the next occurrence. iOS
+  /// EventKit behaves this way natively and Android is bent to match, so the
+  /// behaviour is consistent and documented rather than divergent.
+  thisAndFollowing,
+}

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -40,6 +40,23 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     String? availability,
   })? _updateEventCallback;
 
+  // Callback to capture updateRecurring arguments
+  Future<String> Function(
+    String eventId,
+    int? timestamp,
+    String span, {
+    String? title,
+    DateTime? startDate,
+    DateTime? endDate,
+    Patch<String>? description,
+    Patch<String>? location,
+    Patch<String>? url,
+    bool? isAllDay,
+    String? timeZone,
+    String? availability,
+    Patch<String>? recurrenceRule,
+  })? _updateRecurringCallback;
+
   void setPermissionStatus(CalendarPermissionStatus status) {
     _permissionStatusCode = status.name;
   }
@@ -93,6 +110,26 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     }) callback,
   ) {
     _updateEventCallback = callback;
+  }
+
+  void setUpdateRecurringCallback(
+    Future<String> Function(
+      String eventId,
+      int? timestamp,
+      String span, {
+      String? title,
+      DateTime? startDate,
+      DateTime? endDate,
+      Patch<String>? description,
+      Patch<String>? location,
+      Patch<String>? url,
+      bool? isAllDay,
+      String? timeZone,
+      String? availability,
+      Patch<String>? recurrenceRule,
+    }) callback,
+  ) {
+    _updateRecurringCallback = callback;
   }
 
   @override
@@ -232,6 +269,43 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
         availability: availability,
       );
     }
+  }
+
+  @override
+  Future<String> updateRecurring(
+    String eventId,
+    int? timestamp,
+    String span, {
+    String? title,
+    DateTime? startDate,
+    DateTime? endDate,
+    Patch<String>? description,
+    Patch<String>? location,
+    Patch<String>? url,
+    bool? isAllDay,
+    String? timeZone,
+    String? availability,
+    Patch<String>? recurrenceRule,
+  }) async {
+    if (_exceptionToThrow != null) throw _exceptionToThrow!;
+    if (_updateRecurringCallback != null) {
+      return _updateRecurringCallback!(
+        eventId,
+        timestamp,
+        span,
+        title: title,
+        startDate: startDate,
+        endDate: endDate,
+        description: description,
+        location: location,
+        url: url,
+        isAllDay: isAllDay,
+        timeZone: timeZone,
+        availability: availability,
+        recurrenceRule: recurrenceRule,
+      );
+    }
+    return 'mock-event-id';
   }
 
   // Callback to capture showCreateEventModal arguments
@@ -713,6 +787,213 @@ void main() {
           ),
           throwsArgumentError,
         );
+      });
+    });
+
+    group('updateRecurring', () {
+      test('throws ArgumentError when instanceId is empty', () {
+        expect(
+          () => DeviceCalendar.instance.updateRecurring(
+            '',
+            EventUpdateSpan.allEvents,
+            title: 'New Title',
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('throws ArgumentError when no fields provided', () {
+        expect(
+          () => DeviceCalendar.instance.updateRecurring(
+            'event-123',
+            EventUpdateSpan.allEvents,
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('throws ArgumentError when thisAndFollowing given a bare event ID',
+          () {
+        expect(
+          () => DeviceCalendar.instance.updateRecurring(
+            'event-123',
+            EventUpdateSpan.thisAndFollowing,
+            title: 'New Title',
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('throws ArgumentError when endDate is before startDate', () {
+        expect(
+          () => DeviceCalendar.instance.updateRecurring(
+            'event-123',
+            EventUpdateSpan.allEvents,
+            startDate: DateTime(2024, 3, 20, 11, 0),
+            endDate: DateTime(2024, 3, 20, 10, 0),
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('allEvents accepts a bare event ID (no occurrence timestamp)',
+          () async {
+        final result = await DeviceCalendar.instance.updateRecurring(
+          'event-123',
+          EventUpdateSpan.allEvents,
+          title: 'New Title',
+        );
+        expect(result, 'mock-event-id');
+      });
+
+      test('passes the span name and parsed instance ID to the platform',
+          () async {
+        String? capturedEventId;
+        int? capturedTimestamp;
+        String? capturedSpan;
+
+        final mock = MockDeviceCalendarPlusPlatform();
+        mock.setUpdateRecurringCallback((
+          eventId,
+          timestamp,
+          span, {
+          title,
+          startDate,
+          endDate,
+          description,
+          location,
+          url,
+          isAllDay,
+          timeZone,
+          availability,
+          recurrenceRule,
+        }) {
+          capturedEventId = eventId;
+          capturedTimestamp = timestamp;
+          capturedSpan = span;
+          return Future.value('new-series-id');
+        });
+        DeviceCalendarPlusPlatform.instance = mock;
+
+        final result = await DeviceCalendar.instance.updateRecurring(
+          'event-123@1700000000000',
+          EventUpdateSpan.thisAndFollowing,
+          title: 'New Title',
+        );
+
+        expect(capturedEventId, 'event-123');
+        expect(capturedTimestamp, 1700000000000);
+        expect(capturedSpan, 'thisAndFollowing');
+        expect(result, 'new-series-id');
+      });
+
+      test('converts a RecurrenceRule patch to an RRULE string', () async {
+        Patch<String>? capturedRule;
+
+        final mock = MockDeviceCalendarPlusPlatform();
+        mock.setUpdateRecurringCallback((
+          eventId,
+          timestamp,
+          span, {
+          title,
+          startDate,
+          endDate,
+          description,
+          location,
+          url,
+          isAllDay,
+          timeZone,
+          availability,
+          recurrenceRule,
+        }) {
+          capturedRule = recurrenceRule;
+          return Future.value('id');
+        });
+        DeviceCalendarPlusPlatform.instance = mock;
+
+        await DeviceCalendar.instance.updateRecurring(
+          'event-123',
+          EventUpdateSpan.allEvents,
+          recurrenceRule: Patch.set(const DailyRecurrence(end: CountEnd(5))),
+        );
+
+        expect(capturedRule, isA<PatchSet<String>>());
+        expect((capturedRule as PatchSet<String>).value, 'FREQ=DAILY;COUNT=5');
+      });
+
+      test('passes a cleared recurrence rule through as Patch.clear', () async {
+        Patch<String>? capturedRule;
+
+        final mock = MockDeviceCalendarPlusPlatform();
+        mock.setUpdateRecurringCallback((
+          eventId,
+          timestamp,
+          span, {
+          title,
+          startDate,
+          endDate,
+          description,
+          location,
+          url,
+          isAllDay,
+          timeZone,
+          availability,
+          recurrenceRule,
+        }) {
+          capturedRule = recurrenceRule;
+          return Future.value('id');
+        });
+        DeviceCalendarPlusPlatform.instance = mock;
+
+        await DeviceCalendar.instance.updateRecurring(
+          'event-123',
+          EventUpdateSpan.allEvents,
+          recurrenceRule: const Patch.clear(),
+        );
+
+        expect(capturedRule, isA<PatchClear<String>>());
+      });
+
+      test('normalizes dates when isAllDay is true', () async {
+        DateTime? capturedStart;
+        DateTime? capturedEnd;
+
+        final mock = MockDeviceCalendarPlusPlatform();
+        mock.setUpdateRecurringCallback((
+          eventId,
+          timestamp,
+          span, {
+          title,
+          startDate,
+          endDate,
+          description,
+          location,
+          url,
+          isAllDay,
+          timeZone,
+          availability,
+          recurrenceRule,
+        }) {
+          capturedStart = startDate;
+          capturedEnd = endDate;
+          return Future.value('id');
+        });
+        DeviceCalendarPlusPlatform.instance = mock;
+
+        await DeviceCalendar.instance.updateRecurring(
+          'event-123',
+          EventUpdateSpan.allEvents,
+          startDate: DateTime(2024, 3, 15, 14, 30, 45),
+          endDate: DateTime(2024, 3, 16, 18, 15, 30),
+          isAllDay: true,
+        );
+
+        expect(capturedStart!.hour, 0);
+        expect(capturedStart!.minute, 0);
+        expect(capturedStart!.second, 0);
+        expect(capturedEnd!.hour, 0);
+        expect(capturedEnd!.minute, 0);
+        expect(capturedEnd!.second, 0);
       });
     });
 

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -824,6 +824,29 @@ void main() {
         );
       });
 
+      test('throws ArgumentError when thisInstance given a bare event ID', () {
+        expect(
+          () => DeviceCalendar.instance.updateRecurring(
+            'event-123',
+            EventUpdateSpan.thisInstance,
+            title: 'New Title',
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('throws ArgumentError when recurrenceRule is set with thisInstance',
+          () {
+        expect(
+          () => DeviceCalendar.instance.updateRecurring(
+            'event-123@1700000000000',
+            EventUpdateSpan.thisInstance,
+            recurrenceRule: Patch.set(const DailyRecurrence()),
+          ),
+          throwsArgumentError,
+        );
+      });
+
       test('throws ArgumentError when endDate is before startDate', () {
         expect(
           () => DeviceCalendar.instance.updateRecurring(

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
@@ -61,6 +61,7 @@ class DeviceCalendarPlusAndroidPlugin :
             "createEvent" -> handleCreateEvent(call, result)
             "deleteEvent" -> handleDeleteEvent(call, result)
             "updateEvent" -> handleUpdateEvent(call, result)
+            "updateRecurring" -> handleUpdateRecurring(call, result)
             else -> result.notImplemented()
         }
     }
@@ -508,6 +509,75 @@ class DeviceCalendarPlusAndroidPlugin :
         
         serviceResult.fold(
             onSuccess = { result.success(null) },
+            onFailure = { error ->
+                if (error is CalendarException) {
+                    result.error(error.code, error.message, null)
+                } else {
+                    result.error(PlatformExceptionCodes.UNKNOWN_ERROR, error.message, null)
+                }
+            }
+        )
+    }
+
+    private fun handleUpdateRecurring(call: MethodCall, result: Result) {
+        val service = eventsService ?: error("EventsService not initialized - plugin lifecycle error")
+
+        val eventId = call.argument<String>("eventId")
+        if (eventId == null) {
+            result.error(
+                PlatformExceptionCodes.INVALID_ARGUMENTS,
+                "Missing or invalid eventId",
+                null
+            )
+            return
+        }
+
+        val span = call.argument<String>("span")
+        if (span == null) {
+            result.error(
+                PlatformExceptionCodes.INVALID_ARGUMENTS,
+                "Missing or invalid span",
+                null
+            )
+            return
+        }
+
+        // Parse optional arguments (all can be null)
+        val timestamp = call.argument<Long>("timestamp")
+        val title = call.argument<String>("title")
+        val startDateMillis = call.argument<Long>("startDate")
+        val endDateMillis = call.argument<Long>("endDate")
+        val description = call.argument<String>("description")
+        val location = call.argument<String>("location")
+        val url = call.argument<String>("url")
+        val isAllDay = call.argument<Boolean>("isAllDay")
+        val timeZone = call.argument<String>("timeZone")
+        val availability = call.argument<String>("availability")
+        val recurrenceRule = call.argument<String>("recurrenceRule")
+        val clearedFields = call.argument<List<String>>("clearedFields") ?: emptyList()
+
+        val startDate = startDateMillis?.let { java.util.Date(it) }
+        val endDate = endDateMillis?.let { java.util.Date(it) }
+
+        val serviceResult = service.updateRecurring(
+            eventId,
+            timestamp,
+            span,
+            title,
+            startDate,
+            endDate,
+            description,
+            location,
+            url,
+            isAllDay,
+            timeZone,
+            availability,
+            recurrenceRule,
+            clearedFields
+        )
+
+        serviceResult.fold(
+            onSuccess = { affectedEventId -> result.success(affectedEventId) },
             onFailure = { error ->
                 if (error is CalendarException) {
                     result.error(error.code, error.message, null)

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -980,4 +980,560 @@ class EventsService(private val context: Context) {
             )
         }
     }
+
+    // -- updateRecurring (issue #36) --
+
+    /**
+     * Updates a recurring event, choosing which occurrences the edit affects.
+     *
+     * [span] is "allEvents" (the whole series) or "thisAndFollowing" (split the
+     * series at [timestamp]). Returns the event ID for the affected scope —
+     * the same ID for "allEvents", the new series' ID for "thisAndFollowing".
+     */
+    fun updateRecurring(
+        eventId: String,
+        timestamp: Long?,
+        span: String,
+        title: String?,
+        startDate: java.util.Date?,
+        endDate: java.util.Date?,
+        description: String?,
+        location: String?,
+        url: String?,
+        isAllDay: Boolean?,
+        timeZone: String?,
+        availability: String?,
+        recurrenceRule: String?,
+        clearedFields: List<String>
+    ): Result<String> {
+        if (android.content.pm.PackageManager.PERMISSION_GRANTED !=
+            context.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR)) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.PERMISSION_DENIED,
+                    "Calendar permission denied. Call requestPermissions() first."
+                )
+            )
+        }
+
+        return try {
+            when (span) {
+                "thisAndFollowing" -> updateRecurringThisAndFollowing(
+                    eventId, timestamp, title, startDate, endDate,
+                    description, location, url, isAllDay, timeZone, availability,
+                    recurrenceRule, clearedFields
+                )
+                "allEvents" -> updateRecurringAllEvents(
+                    eventId, title, startDate, endDate,
+                    description, location, url, isAllDay, timeZone, availability,
+                    recurrenceRule, clearedFields
+                )
+                else -> Result.failure(
+                    CalendarException(
+                        PlatformExceptionCodes.INVALID_ARGUMENTS,
+                        "Unknown update span: $span"
+                    )
+                )
+            }
+        } catch (e: SecurityException) {
+            Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.PERMISSION_DENIED,
+                    "Calendar permission denied: ${e.message}"
+                )
+            )
+        } catch (e: Exception) {
+            Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.OPERATION_FAILED,
+                    "Failed to update recurring event: ${e.message}"
+                )
+            )
+        }
+    }
+
+    private fun updateRecurringAllEvents(
+        eventId: String,
+        title: String?,
+        startDate: java.util.Date?,
+        endDate: java.util.Date?,
+        description: String?,
+        location: String?,
+        url: String?,
+        isAllDay: Boolean?,
+        timeZone: String?,
+        availability: String?,
+        recurrenceRule: String?,
+        clearedFields: List<String>
+    ): Result<String> {
+        val row = readEventRow(eventId)
+            ?: return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.NOT_FOUND,
+                    "Event with ID $eventId not found"
+                )
+            )
+
+        val values = android.content.ContentValues()
+
+        if (title != null) {
+            values.put(CalendarContract.Events.TITLE, title)
+        }
+
+        if ("description" in clearedFields) {
+            values.putNull(CalendarContract.Events.DESCRIPTION)
+        } else if (description != null) {
+            values.put(CalendarContract.Events.DESCRIPTION, description)
+        }
+
+        if ("location" in clearedFields) {
+            values.putNull(CalendarContract.Events.EVENT_LOCATION)
+        } else if (location != null) {
+            values.put(CalendarContract.Events.EVENT_LOCATION, location)
+        }
+
+        if ("url" in clearedFields) {
+            values.putNull(CalendarContract.Events.CUSTOM_APP_URI)
+        } else if (url != null) {
+            values.put(CalendarContract.Events.CUSTOM_APP_URI, url)
+        }
+
+        if (availability != null) {
+            values.put(CalendarContract.Events.AVAILABILITY, availabilityToInt(availability))
+        }
+
+        val effectiveIsAllDay = isAllDay ?: row.allDay
+        if (isAllDay != null) {
+            values.put(CalendarContract.Events.ALL_DAY, if (isAllDay) 1 else 0)
+        }
+
+        // Recurrence rule column and the resulting recurring state.
+        val wasRecurring = row.rrule != null
+        val clearRrule = "recurrenceRule" in clearedFields
+        val willBeRecurring = when {
+            clearRrule -> false
+            recurrenceRule != null -> true
+            else -> wasRecurring
+        }
+        if (clearRrule) {
+            values.putNull(CalendarContract.Events.RRULE)
+        } else if (recurrenceRule != null) {
+            values.put(CalendarContract.Events.RRULE, recurrenceRule)
+        }
+
+        // Time columns. A recurring event must use DURATION (and no DTEND); a
+        // single event must use DTEND (and no DURATION). Rewrite them when the
+        // dates change or when the event flips between recurring and single.
+        if (startDate != null || endDate != null || wasRecurring != willBeRecurring) {
+            val existingDuration = eventDurationMillis(row)
+            val newStart = if (startDate != null) {
+                toStorageMillis(startDate, effectiveIsAllDay)
+            } else {
+                row.dtstart
+            }
+            val newEnd = if (endDate != null) {
+                toStorageMillis(endDate, effectiveIsAllDay)
+            } else {
+                newStart + existingDuration
+            }
+            values.put(CalendarContract.Events.DTSTART, newStart)
+            if (willBeRecurring) {
+                values.put(
+                    CalendarContract.Events.DURATION,
+                    "P${(newEnd - newStart) / 1000}S"
+                )
+                values.putNull(CalendarContract.Events.DTEND)
+            } else {
+                values.put(CalendarContract.Events.DTEND, newEnd)
+                values.putNull(CalendarContract.Events.DURATION)
+            }
+        }
+
+        if (timeZone != null) {
+            values.put(CalendarContract.Events.EVENT_TIMEZONE, timeZone)
+        } else if (isAllDay == true) {
+            values.put(
+                CalendarContract.Events.EVENT_TIMEZONE,
+                java.util.TimeZone.getDefault().id
+            )
+        }
+
+        val updatedRows = context.contentResolver.update(
+            CalendarContract.Events.CONTENT_URI,
+            values,
+            "${CalendarContract.Events._ID} = ?",
+            arrayOf(eventId)
+        )
+        if (updatedRows == 0) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.NOT_FOUND,
+                    "Event with ID $eventId not found"
+                )
+            )
+        }
+        return Result.success(eventId)
+    }
+
+    private fun updateRecurringThisAndFollowing(
+        eventId: String,
+        timestamp: Long?,
+        title: String?,
+        startDate: java.util.Date?,
+        endDate: java.util.Date?,
+        description: String?,
+        location: String?,
+        url: String?,
+        isAllDay: Boolean?,
+        timeZone: String?,
+        availability: String?,
+        recurrenceRule: String?,
+        clearedFields: List<String>
+    ): Result<String> {
+        if (timestamp == null) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.INVALID_ARGUMENTS,
+                    "thisAndFollowing requires an occurrence timestamp"
+                )
+            )
+        }
+
+        val row = readEventRow(eventId)
+            ?: return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.NOT_FOUND,
+                    "Event with ID $eventId not found"
+                )
+            )
+
+        if (row.rrule == null) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.INVALID_ARGUMENTS,
+                    "Event $eventId is not recurring; use updateEvent instead"
+                )
+            )
+        }
+
+        // Effective field values for the new series: the patch value when one
+        // is given, otherwise the master's existing value.
+        val effectiveIsAllDay = isAllDay ?: row.allDay
+        val effectiveTitle = title ?: row.title
+        val effectiveDescription =
+            if ("description" in clearedFields) null else (description ?: row.description)
+        val effectiveLocation =
+            if ("location" in clearedFields) null else (location ?: row.location)
+        val effectiveUrl =
+            if ("url" in clearedFields) null else (url ?: row.url)
+        val effectiveTimeZone = timeZone ?: row.timeZone
+        val effectiveAvailability = availability ?: row.availability
+        val effectiveRrule = when {
+            "recurrenceRule" in clearedFields -> null
+            recurrenceRule != null -> recurrenceRule
+            else -> row.rrule
+        }
+
+        // The new series starts at the explicit start date when given,
+        // otherwise at the first occurrence after the split point. iOS's
+        // .futureEvents leaves the anchor occurrence on the original series;
+        // matching that here keeps the two platforms consistent.
+        val duration = eventDurationMillis(row)
+        val newStart = if (startDate != null) {
+            toStorageMillis(startDate, effectiveIsAllDay)
+        } else {
+            queryNextInstanceBegin(eventId, timestamp)
+        }
+
+        // No explicit start and nothing after the anchor — there is no tail to
+        // split off, so the series is left unchanged.
+        if (newStart == null) {
+            return Result.success(eventId)
+        }
+
+        val newEnd = if (endDate != null) {
+            toStorageMillis(endDate, effectiveIsAllDay)
+        } else {
+            newStart + duration
+        }
+
+        // Create the new series first, so that a later failure leaves the
+        // original series intact.
+        val insertResult = insertEvent(
+            calendarId = row.calendarId,
+            title = effectiveTitle,
+            startMillis = newStart,
+            endMillis = newEnd,
+            isAllDay = effectiveIsAllDay,
+            description = effectiveDescription,
+            location = effectiveLocation,
+            url = effectiveUrl,
+            timeZone = effectiveTimeZone,
+            availability = effectiveAvailability,
+            rrule = effectiveRrule
+        )
+        val newEventId = insertResult.getOrElse { return Result.failure(it) }
+
+        // Truncate the original series. UNTIL is inclusive, so anchoring it at
+        // the split point keeps that occurrence on the original series.
+        val truncatedRrule = setRruleUntil(row.rrule, timestamp, row.allDay)
+        val truncateValues = android.content.ContentValues().apply {
+            put(CalendarContract.Events.RRULE, truncatedRrule)
+        }
+        val truncatedRows = context.contentResolver.update(
+            CalendarContract.Events.CONTENT_URI,
+            truncateValues,
+            "${CalendarContract.Events._ID} = ?",
+            arrayOf(eventId)
+        )
+        if (truncatedRows == 0) {
+            // Roll back the new series so the calendar is left unchanged.
+            context.contentResolver.delete(
+                CalendarContract.Events.CONTENT_URI,
+                "${CalendarContract.Events._ID} = ?",
+                arrayOf(newEventId)
+            )
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.OPERATION_FAILED,
+                    "Failed to truncate original series for event $eventId"
+                )
+            )
+        }
+
+        return Result.success(newEventId)
+    }
+
+    private data class EventRow(
+        val id: String,
+        val calendarId: String,
+        val title: String,
+        val description: String?,
+        val location: String?,
+        val url: String?,
+        val dtstart: Long,
+        val dtend: Long?,
+        val duration: String?,
+        val allDay: Boolean,
+        val timeZone: String?,
+        val availability: String,
+        val rrule: String?
+    )
+
+    /** Reads the master row of an event straight from the Events table. */
+    private fun readEventRow(eventId: String): EventRow? {
+        val projection = arrayOf(
+            CalendarContract.Events._ID,
+            CalendarContract.Events.CALENDAR_ID,
+            CalendarContract.Events.TITLE,
+            CalendarContract.Events.DESCRIPTION,
+            CalendarContract.Events.EVENT_LOCATION,
+            CalendarContract.Events.CUSTOM_APP_URI,
+            CalendarContract.Events.DTSTART,
+            CalendarContract.Events.DTEND,
+            CalendarContract.Events.DURATION,
+            CalendarContract.Events.ALL_DAY,
+            CalendarContract.Events.EVENT_TIMEZONE,
+            CalendarContract.Events.AVAILABILITY,
+            CalendarContract.Events.RRULE
+        )
+        context.contentResolver.query(
+            CalendarContract.Events.CONTENT_URI,
+            projection,
+            "${CalendarContract.Events._ID} = ?",
+            arrayOf(eventId),
+            null
+        )?.use { cursor ->
+            if (!cursor.moveToFirst()) return null
+            fun str(column: String): String? {
+                val index = cursor.getColumnIndexOrThrow(column)
+                return if (cursor.isNull(index)) null else cursor.getString(index)
+            }
+            fun long(column: String): Long? {
+                val index = cursor.getColumnIndexOrThrow(column)
+                return if (cursor.isNull(index)) null else cursor.getLong(index)
+            }
+            return EventRow(
+                id = str(CalendarContract.Events._ID) ?: eventId,
+                calendarId = str(CalendarContract.Events.CALENDAR_ID) ?: "",
+                title = str(CalendarContract.Events.TITLE) ?: "",
+                description = str(CalendarContract.Events.DESCRIPTION),
+                location = str(CalendarContract.Events.EVENT_LOCATION),
+                url = str(CalendarContract.Events.CUSTOM_APP_URI),
+                dtstart = long(CalendarContract.Events.DTSTART) ?: 0L,
+                dtend = long(CalendarContract.Events.DTEND),
+                duration = str(CalendarContract.Events.DURATION),
+                allDay = (long(CalendarContract.Events.ALL_DAY) ?: 0L) == 1L,
+                timeZone = str(CalendarContract.Events.EVENT_TIMEZONE),
+                availability = availabilityToString(
+                    (long(CalendarContract.Events.AVAILABILITY) ?: 0L).toInt()
+                ),
+                rrule = str(CalendarContract.Events.RRULE)
+            )
+        }
+        return null
+    }
+
+    /** Inserts a fresh event row, using DURATION when recurring and DTEND otherwise. */
+    private fun insertEvent(
+        calendarId: String,
+        title: String,
+        startMillis: Long,
+        endMillis: Long,
+        isAllDay: Boolean,
+        description: String?,
+        location: String?,
+        url: String?,
+        timeZone: String?,
+        availability: String,
+        rrule: String?
+    ): Result<String> {
+        val values = android.content.ContentValues().apply {
+            put(CalendarContract.Events.CALENDAR_ID, calendarId.toLong())
+            put(CalendarContract.Events.TITLE, title)
+            put(CalendarContract.Events.DTSTART, startMillis)
+            put(CalendarContract.Events.ALL_DAY, if (isAllDay) 1 else 0)
+            if (rrule != null) {
+                put(
+                    CalendarContract.Events.DURATION,
+                    "P${(endMillis - startMillis) / 1000}S"
+                )
+                put(CalendarContract.Events.RRULE, rrule)
+            } else {
+                put(CalendarContract.Events.DTEND, endMillis)
+            }
+            if (description != null) {
+                put(CalendarContract.Events.DESCRIPTION, description)
+            }
+            if (location != null) {
+                put(CalendarContract.Events.EVENT_LOCATION, location)
+            }
+            if (url != null) {
+                put(CalendarContract.Events.CUSTOM_APP_URI, url)
+            }
+            put(
+                CalendarContract.Events.EVENT_TIMEZONE,
+                if (isAllDay) java.util.TimeZone.getDefault().id
+                else (timeZone ?: java.util.TimeZone.getDefault().id)
+            )
+            put(CalendarContract.Events.AVAILABILITY, availabilityToInt(availability))
+            put(CalendarContract.Events.STATUS, CalendarContract.Events.STATUS_CONFIRMED)
+        }
+        val uri = context.contentResolver.insert(CalendarContract.Events.CONTENT_URI, values)
+        val newId = uri?.lastPathSegment
+        return if (newId != null) {
+            Result.success(newId)
+        } else {
+            Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.OPERATION_FAILED,
+                    "Failed to create the new series"
+                )
+            )
+        }
+    }
+
+    private fun availabilityToInt(availability: String): Int {
+        return when (availability) {
+            "free" -> CalendarContract.Events.AVAILABILITY_FREE
+            "tentative" -> CalendarContract.Events.AVAILABILITY_TENTATIVE
+            else -> CalendarContract.Events.AVAILABILITY_BUSY
+        }
+    }
+
+    /** Storage millis for a date: UTC midnight for all-day, the instant otherwise. */
+    private fun toStorageMillis(date: java.util.Date, isAllDay: Boolean): Long {
+        if (!isAllDay) return date.time
+        val local = java.util.Calendar.getInstance().apply { time = date }
+        val utc = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"))
+        utc.set(
+            local.get(java.util.Calendar.YEAR),
+            local.get(java.util.Calendar.MONTH),
+            local.get(java.util.Calendar.DAY_OF_MONTH),
+            0, 0, 0
+        )
+        utc.set(java.util.Calendar.MILLISECOND, 0)
+        return utc.timeInMillis
+    }
+
+    /** Resolves an event's duration, falling back to one hour when unknown. */
+    private fun eventDurationMillis(row: EventRow): Long {
+        if (row.dtend != null) return row.dtend - row.dtstart
+        if (row.duration != null) {
+            parseDurationMillis(row.duration)?.let { return it }
+        }
+        return 3_600_000L
+    }
+
+    /** Parses an RFC 5545 / Android duration string (e.g. "P3600S", "PT1H"). */
+    private fun parseDurationMillis(duration: String): Long? {
+        val trimmed = duration.trim()
+        Regex("P(\\d+)S").matchEntire(trimmed)?.let {
+            return it.groupValues[1].toLong() * 1000L
+        }
+        val match = Regex(
+            "P(?:(\\d+)W)?(?:(\\d+)D)?(?:T(?:(\\d+)H)?(?:(\\d+)M)?(?:(\\d+)S)?)?"
+        ).matchEntire(trimmed) ?: return null
+        var seconds = 0L
+        match.groupValues[1].toLongOrNull()?.let { seconds += it * 7 * 24 * 3600 }
+        match.groupValues[2].toLongOrNull()?.let { seconds += it * 24 * 3600 }
+        match.groupValues[3].toLongOrNull()?.let { seconds += it * 3600 }
+        match.groupValues[4].toLongOrNull()?.let { seconds += it * 60 }
+        match.groupValues[5].toLongOrNull()?.let { seconds += it }
+        return seconds * 1000L
+    }
+
+    /** First occurrence of [eventId] strictly after [afterMillis], or null. */
+    private fun queryNextInstanceBegin(eventId: String, afterMillis: Long): Long? {
+        // Five-year window: covers daily/weekly/monthly easily, and yearly
+        // rules with an interval of up to five.
+        val windowEnd = afterMillis + 5L * 366 * 24 * 3600 * 1000
+        val uri = CalendarContract.Instances.CONTENT_URI.buildUpon()
+            .appendPath((afterMillis + 1).toString())
+            .appendPath(windowEnd.toString())
+            .build()
+        context.contentResolver.query(
+            uri,
+            arrayOf(CalendarContract.Instances.BEGIN),
+            "${CalendarContract.Instances.EVENT_ID} = ?",
+            arrayOf(eventId),
+            "${CalendarContract.Instances.BEGIN} ASC"
+        )?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                return cursor.getLong(0)
+            }
+        }
+        return null
+    }
+
+    /** Replaces any COUNT/UNTIL in [rrule] with UNTIL at [untilMillis] (inclusive). */
+    private fun setRruleUntil(rrule: String, untilMillis: Long, isAllDay: Boolean): String {
+        val body = if (rrule.startsWith("RRULE:")) rrule.substring(6) else rrule
+        val parts = body.split(";").filter {
+            val key = it.substringBefore('=').uppercase()
+            it.isNotEmpty() && key != "COUNT" && key != "UNTIL"
+        }
+        return (parts + "UNTIL=${formatRruleUtc(untilMillis, isAllDay)}").joinToString(";")
+    }
+
+    /** Formats [millis] as an RRULE UTC value (date-only when [dateOnly]). */
+    private fun formatRruleUtc(millis: Long, dateOnly: Boolean): String {
+        val cal = java.util.Calendar.getInstance(java.util.TimeZone.getTimeZone("UTC"))
+        cal.timeInMillis = millis
+        val date = String.format(
+            java.util.Locale.US,
+            "%04d%02d%02d",
+            cal.get(java.util.Calendar.YEAR),
+            cal.get(java.util.Calendar.MONTH) + 1,
+            cal.get(java.util.Calendar.DAY_OF_MONTH)
+        )
+        if (dateOnly) return date
+        return date + String.format(
+            java.util.Locale.US,
+            "T%02d%02d%02dZ",
+            cal.get(java.util.Calendar.HOUR_OF_DAY),
+            cal.get(java.util.Calendar.MINUTE),
+            cal.get(java.util.Calendar.SECOND)
+        )
+    }
 }

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -986,9 +986,10 @@ class EventsService(private val context: Context) {
     /**
      * Updates a recurring event, choosing which occurrences the edit affects.
      *
-     * [span] is "allEvents" (the whole series) or "thisAndFollowing" (split the
-     * series at [timestamp]). Returns the event ID for the affected scope —
-     * the same ID for "allEvents", the new series' ID for "thisAndFollowing".
+     * [span] is "allEvents" (the whole series), "thisAndFollowing" (split the
+     * series at [timestamp], that occurrence onward forming the new series), or
+     * "thisInstance" (detach and edit only that occurrence). Returns the event
+     * ID for the affected scope.
      */
     fun updateRecurring(
         eventId: String,
@@ -1022,6 +1023,11 @@ class EventsService(private val context: Context) {
                     eventId, timestamp, title, startDate, endDate,
                     description, location, url, isAllDay, timeZone, availability,
                     recurrenceRule, clearedFields
+                )
+                "thisInstance" -> updateRecurringThisInstance(
+                    eventId, timestamp, title, startDate, endDate,
+                    description, location, url, isAllDay, timeZone, availability,
+                    clearedFields
                 )
                 "allEvents" -> updateRecurringAllEvents(
                     eventId, title, startDate, endDate,
@@ -1231,26 +1237,29 @@ class EventsService(private val context: Context) {
         val effectiveRrule = when {
             "recurrenceRule" in clearedFields -> null
             recurrenceRule != null -> recurrenceRule
-            else -> row.rrule
+            else -> {
+                // Rule unchanged: the new series inherits the original rule. A
+                // COUNT must drop by the occurrences left on the old series,
+                // or the new series would over-generate.
+                val originalCount = rruleCount(row.rrule)
+                if (originalCount != null) {
+                    val before = countInstancesBefore(eventId, timestamp)
+                    setRruleCount(row.rrule, maxOf(1, originalCount - before))
+                } else {
+                    row.rrule
+                }
+            }
         }
 
-        // The new series starts at the explicit start date when given,
-        // otherwise at the first occurrence after the split point. iOS's
-        // .futureEvents leaves the anchor occurrence on the original series;
-        // matching that here keeps the two platforms consistent.
+        // The new series starts at the explicit start date, or at the anchor
+        // occurrence itself — "this and following" includes the named
+        // occurrence.
         val duration = eventDurationMillis(row)
         val newStart = if (startDate != null) {
             toStorageMillis(startDate, effectiveIsAllDay)
         } else {
-            queryNextInstanceBegin(eventId, timestamp)
+            timestamp
         }
-
-        // No explicit start and nothing after the anchor — there is no tail to
-        // split off, so the series is left unchanged.
-        if (newStart == null) {
-            return Result.success(eventId)
-        }
-
         val newEnd = if (endDate != null) {
             toStorageMillis(endDate, effectiveIsAllDay)
         } else {
@@ -1274,9 +1283,10 @@ class EventsService(private val context: Context) {
         )
         val newEventId = insertResult.getOrElse { return Result.failure(it) }
 
-        // Truncate the original series. UNTIL is inclusive, so anchoring it at
-        // the split point keeps that occurrence on the original series.
-        val truncatedRrule = setRruleUntil(row.rrule, timestamp, row.allDay)
+        // Truncate the original series to end just before the anchor. UNTIL is
+        // inclusive, so cutting it one second early keeps the anchor occurrence
+        // off the old series — it belongs to the new one.
+        val truncatedRrule = setRruleUntil(row.rrule, timestamp - 1000, row.allDay)
         val truncateValues = android.content.ContentValues().apply {
             put(CalendarContract.Events.RRULE, truncatedRrule)
         }
@@ -1302,6 +1312,111 @@ class EventsService(private val context: Context) {
         }
 
         return Result.success(newEventId)
+    }
+
+    private fun updateRecurringThisInstance(
+        eventId: String,
+        timestamp: Long?,
+        title: String?,
+        startDate: java.util.Date?,
+        endDate: java.util.Date?,
+        description: String?,
+        location: String?,
+        url: String?,
+        isAllDay: Boolean?,
+        timeZone: String?,
+        availability: String?,
+        clearedFields: List<String>
+    ): Result<String> {
+        if (timestamp == null) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.INVALID_ARGUMENTS,
+                    "thisInstance requires an occurrence timestamp"
+                )
+            )
+        }
+
+        val row = readEventRow(eventId)
+            ?: return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.NOT_FOUND,
+                    "Event with ID $eventId not found"
+                )
+            )
+
+        if (row.rrule == null) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.INVALID_ARGUMENTS,
+                    "Event $eventId is not recurring; use updateEvent instead"
+                )
+            )
+        }
+
+        val effectiveIsAllDay = isAllDay ?: row.allDay
+        val duration = eventDurationMillis(row)
+        val newStart = if (startDate != null) {
+            toStorageMillis(startDate, effectiveIsAllDay)
+        } else {
+            timestamp
+        }
+        val newEnd = if (endDate != null) {
+            toStorageMillis(endDate, effectiveIsAllDay)
+        } else {
+            newStart + duration
+        }
+
+        // Insert an exception overriding this single occurrence. The provider
+        // expects DURATION (not DTEND) on an exception of a recurring parent.
+        val values = android.content.ContentValues().apply {
+            put(CalendarContract.Events.ORIGINAL_INSTANCE_TIME, timestamp)
+            put(CalendarContract.Events.DTSTART, newStart)
+            put(CalendarContract.Events.DURATION, "P${(newEnd - newStart) / 1000}S")
+            put(CalendarContract.Events.STATUS, CalendarContract.Events.STATUS_CONFIRMED)
+
+            if (title != null) {
+                put(CalendarContract.Events.TITLE, title)
+            }
+            if ("description" in clearedFields) {
+                putNull(CalendarContract.Events.DESCRIPTION)
+            } else if (description != null) {
+                put(CalendarContract.Events.DESCRIPTION, description)
+            }
+            if ("location" in clearedFields) {
+                putNull(CalendarContract.Events.EVENT_LOCATION)
+            } else if (location != null) {
+                put(CalendarContract.Events.EVENT_LOCATION, location)
+            }
+            if ("url" in clearedFields) {
+                putNull(CalendarContract.Events.CUSTOM_APP_URI)
+            } else if (url != null) {
+                put(CalendarContract.Events.CUSTOM_APP_URI, url)
+            }
+            if (isAllDay != null) {
+                put(CalendarContract.Events.ALL_DAY, if (isAllDay) 1 else 0)
+            }
+            if (timeZone != null) {
+                put(CalendarContract.Events.EVENT_TIMEZONE, timeZone)
+            }
+            if (availability != null) {
+                put(CalendarContract.Events.AVAILABILITY, availabilityToInt(availability))
+            }
+        }
+
+        val exceptionUri = android.content.ContentUris.withAppendedId(
+            CalendarContract.Events.CONTENT_EXCEPTION_URI,
+            eventId.toLong()
+        )
+        val uri = context.contentResolver.insert(exceptionUri, values)
+        val exceptionId = uri?.lastPathSegment
+            ?: return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.OPERATION_FAILED,
+                    "Failed to create the exception for event $eventId"
+                )
+            )
+        return Result.success(exceptionId)
     }
 
     private data class EventRow(
@@ -1483,27 +1598,49 @@ class EventsService(private val context: Context) {
         return seconds * 1000L
     }
 
-    /** First occurrence of [eventId] strictly after [afterMillis], or null. */
-    private fun queryNextInstanceBegin(eventId: String, afterMillis: Long): Long? {
-        // Five-year window: covers daily/weekly/monthly easily, and yearly
-        // rules with an interval of up to five.
-        val windowEnd = afterMillis + 5L * 366 * 24 * 3600 * 1000
+    /** Number of occurrences of [eventId] that start before [beforeMillis]. */
+    private fun countInstancesBefore(eventId: String, beforeMillis: Long): Int {
+        // Five-year look-back window: covers daily/weekly/monthly easily, and
+        // yearly rules with an interval of up to five.
+        val windowStart = beforeMillis - 5L * 366 * 24 * 3600 * 1000
         val uri = CalendarContract.Instances.CONTENT_URI.buildUpon()
-            .appendPath((afterMillis + 1).toString())
-            .appendPath(windowEnd.toString())
+            .appendPath(windowStart.toString())
+            .appendPath(beforeMillis.toString())
             .build()
+        var count = 0
         context.contentResolver.query(
             uri,
             arrayOf(CalendarContract.Instances.BEGIN),
             "${CalendarContract.Instances.EVENT_ID} = ?",
             arrayOf(eventId),
-            "${CalendarContract.Instances.BEGIN} ASC"
+            null
         )?.use { cursor ->
-            if (cursor.moveToFirst()) {
-                return cursor.getLong(0)
+            while (cursor.moveToNext()) {
+                if (cursor.getLong(0) < beforeMillis) count++
+            }
+        }
+        return count
+    }
+
+    /** The COUNT value of an RRULE, or null if it has none. */
+    private fun rruleCount(rrule: String): Int? {
+        val body = if (rrule.startsWith("RRULE:")) rrule.substring(6) else rrule
+        for (part in body.split(";")) {
+            if (part.substringBefore('=').uppercase() == "COUNT") {
+                return part.substringAfter('=').trim().toIntOrNull()
             }
         }
         return null
+    }
+
+    /** Replaces any COUNT/UNTIL in [rrule] with COUNT=[count]. */
+    private fun setRruleCount(rrule: String, count: Int): String {
+        val body = if (rrule.startsWith("RRULE:")) rrule.substring(6) else rrule
+        val parts = body.split(";").filter {
+            val key = it.substringBefore('=').uppercase()
+            it.isNotEmpty() && key != "COUNT" && key != "UNTIL"
+        }
+        return (parts + "COUNT=$count").joinToString(";")
     }
 
     /** Replaces any COUNT/UNTIL in [rrule] with UNTIL at [untilMillis] (inclusive). */

--- a/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
+++ b/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
@@ -209,6 +209,44 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
   }
 
   @override
+  Future<String> updateRecurring(
+    String eventId,
+    int? timestamp,
+    String span, {
+    String? title,
+    DateTime? startDate,
+    DateTime? endDate,
+    Patch<String>? description,
+    Patch<String>? location,
+    Patch<String>? url,
+    bool? isAllDay,
+    String? timeZone,
+    String? availability,
+    Patch<String>? recurrenceRule,
+  }) async {
+    final args = <String, dynamic>{
+      'eventId': eventId,
+      'timestamp': timestamp,
+      'span': span,
+      'title': title,
+      'startDate': startDate?.millisecondsSinceEpoch,
+      'endDate': endDate?.millisecondsSinceEpoch,
+      'isAllDay': isAllDay,
+      'timeZone': timeZone,
+      'availability': availability,
+    };
+    writePatchFields(args, {
+      'description': description,
+      'location': location,
+      'url': url,
+      'recurrenceRule': recurrenceRule,
+    });
+    final result =
+        await methodChannel.invokeMethod<String>('updateRecurring', args);
+    return result!;
+  }
+
+  @override
   Future<void> showCreateEventModal({
     String? title,
     int? startDate,

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
@@ -49,6 +49,8 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
       handleDeleteEvent(call: call, result: result)
     case "updateEvent":
       handleUpdateEvent(call: call, result: result)
+    case "updateRecurring":
+      handleUpdateRecurring(call: call, result: result)
     default:
       result(FlutterMethodNotImplemented)
     }
@@ -584,6 +586,82 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     }
   }
   
+  private func handleUpdateRecurring(call: FlutterMethodCall, result: @escaping FlutterResult) {
+    guard let args = call.arguments as? [String: Any] else {
+      result(FlutterError(
+        code: PlatformExceptionCodes.invalidArguments,
+        message: "Invalid arguments for updateRecurring",
+        details: nil
+      ))
+      return
+    }
+
+    // Parse event ID (required)
+    guard let eventId = args["eventId"] as? String else {
+      result(FlutterError(
+        code: PlatformExceptionCodes.invalidArguments,
+        message: "Missing or invalid eventId",
+        details: nil
+      ))
+      return
+    }
+
+    // Parse span (required)
+    guard let span = args["span"] as? String else {
+      result(FlutterError(
+        code: PlatformExceptionCodes.invalidArguments,
+        message: "Missing or invalid span",
+        details: nil
+      ))
+      return
+    }
+
+    // Parse optional parameters
+    let timestamp = args["timestamp"] as? Int64
+    let title = args["title"] as? String
+    let description = args["description"] as? String
+    let location = args["location"] as? String
+    let url = args["url"] as? String
+    let isAllDay = args["isAllDay"] as? Bool
+    let timeZone = args["timeZone"] as? String
+    let availability = args["availability"] as? String
+    let recurrenceRule = args["recurrenceRule"] as? String
+    let clearedFields = args["clearedFields"] as? [String] ?? []
+
+    let startDate = (args["startDate"] as? Int64).map {
+      Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+    }
+    let endDate = (args["endDate"] as? Int64).map {
+      Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+    }
+
+    eventsService.updateRecurring(
+      eventId: eventId,
+      timestamp: timestamp,
+      span: span,
+      title: title,
+      startDate: startDate,
+      endDate: endDate,
+      description: description,
+      location: location,
+      url: url,
+      isAllDay: isAllDay,
+      timeZone: timeZone,
+      availability: availability,
+      recurrenceRule: recurrenceRule,
+      clearedFields: clearedFields
+    ) { serviceResult in
+      DispatchQueue.main.async {
+        switch serviceResult {
+        case .success(let affectedEventId):
+          result(affectedEventId)
+        case .failure(let error):
+          result(FlutterError(code: error.code, message: error.message, details: nil))
+        }
+      }
+    }
+  }
+
   // MARK: - EKEventViewControllerDelegate
   
   public func eventViewController(_ controller: EKEventViewController, didCompleteWith action: EKEventViewAction) {

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -858,4 +858,143 @@ class EventsService {
       )))
     }
   }
+
+  // MARK: - updateRecurring (issue #36)
+
+  /// Updates a recurring event, choosing which occurrences the edit affects.
+  ///
+  /// `span` is "allEvents" (the whole series) or "thisAndFollowing" (split the
+  /// series at `timestamp`). On success returns the event ID for the affected
+  /// scope — the same ID for "allEvents", the new series' ID for
+  /// "thisAndFollowing".
+  func updateRecurring(
+    eventId: String,
+    timestamp: Int64?,
+    span: String,
+    title: String?,
+    startDate: Date?,
+    endDate: Date?,
+    description: String?,
+    location: String?,
+    url: String?,
+    isAllDay: Bool?,
+    timeZone: String?,
+    availability: String?,
+    recurrenceRule: String?,
+    clearedFields: [String],
+    completion: @escaping (Result<String, CalendarError>) -> Void
+  ) {
+    // Permission Check
+    guard permissionService.hasPermission(for: .full) else {
+      completion(.failure(CalendarError(
+        code: PlatformExceptionCodes.permissionDenied,
+        message: "Calendar permission denied. Call requestPermissions() first."
+      )))
+      return
+    }
+
+    let isThisAndFollowing = (span == "thisAndFollowing")
+
+    // Resolve the event to act on. For "allEvents" the master event stands in
+    // for the whole series; for "thisAndFollowing" the specific occurrence is
+    // the split point.
+    let targetEvent: EKEvent?
+    if isThisAndFollowing {
+      guard let timestamp = timestamp else {
+        completion(.failure(CalendarError(
+          code: PlatformExceptionCodes.invalidArguments,
+          message: "thisAndFollowing requires an occurrence timestamp"
+        )))
+        return
+      }
+      let occurrenceDate = Date(timeIntervalSince1970: TimeInterval(timestamp) / 1000.0)
+      let predicate = eventStore.predicateForEvents(
+        withStart: occurrenceDate.addingTimeInterval(-1),
+        end: occurrenceDate.addingTimeInterval(1),
+        calendars: nil
+      )
+      let matches = eventStore.events(matching: predicate)
+        .filter { $0.eventIdentifier == eventId }
+      targetEvent = matches.min(by: {
+        abs($0.startDate.timeIntervalSince(occurrenceDate)) <
+          abs($1.startDate.timeIntervalSince(occurrenceDate))
+      })
+    } else {
+      targetEvent = eventStore.event(withIdentifier: eventId)
+    }
+
+    guard let foundEvent = targetEvent else {
+      completion(.failure(CalendarError(
+        code: PlatformExceptionCodes.notFound,
+        message: "Event not found with event ID: \(eventId)"
+      )))
+      return
+    }
+
+    // Apply field changes.
+    if let title = title { foundEvent.title = title }
+    if clearedFields.contains("description") {
+      foundEvent.notes = nil
+    } else if let description = description {
+      foundEvent.notes = description
+    }
+    if clearedFields.contains("location") {
+      foundEvent.location = nil
+    } else if let location = location {
+      foundEvent.location = location
+    }
+    if clearedFields.contains("url") {
+      foundEvent.url = nil
+    } else if let url = url {
+      foundEvent.url = URL(string: url)
+    }
+    if let isAllDay = isAllDay { foundEvent.isAllDay = isAllDay }
+    if let startDate = startDate { foundEvent.startDate = startDate }
+    if let endDate = endDate { foundEvent.endDate = endDate }
+
+    if foundEvent.isAllDay {
+      foundEvent.timeZone = nil
+    } else if let timeZoneIdentifier = timeZone {
+      foundEvent.timeZone = TimeZone(identifier: timeZoneIdentifier)
+    }
+
+    if let availabilityStr = availability {
+      switch availabilityStr {
+      case "free": foundEvent.availability = .free
+      case "tentative": foundEvent.availability = .tentative
+      case "unavailable": foundEvent.availability = .unavailable
+      case "busy": foundEvent.availability = .busy
+      default: break
+      }
+    }
+
+    // Apply the recurrence-rule patch.
+    if clearedFields.contains("recurrenceRule") {
+      foundEvent.recurrenceRules = nil
+    } else if let rruleString = recurrenceRule {
+      guard let rule = parseRecurrenceRule(rruleString) else {
+        completion(.failure(CalendarError(
+          code: PlatformExceptionCodes.invalidArguments,
+          message: "Invalid recurrence rule: \(rruleString)"
+        )))
+        return
+      }
+      foundEvent.recurrenceRules = [rule]
+    }
+
+    // .futureEvents applies the change from the fetched event onward: from the
+    // master that means the whole series; from a specific occurrence it splits
+    // the series. It is also required to drop recurrence across a whole series
+    // — .thisEvent would only detach the fetched occurrence. (.futureEvents on
+    // a non-recurring event behaves like .thisEvent.)
+    do {
+      try eventStore.save(foundEvent, span: .futureEvents, commit: true)
+      completion(.success(foundEvent.eventIdentifier ?? eventId))
+    } catch {
+      completion(.failure(CalendarError(
+        code: PlatformExceptionCodes.operationFailed,
+        message: "Failed to update recurring event: \(error.localizedDescription)"
+      )))
+    }
+  }
 }

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -893,17 +893,16 @@ class EventsService {
       return
     }
 
-    let isThisAndFollowing = (span == "thisAndFollowing")
-
-    // Resolve the event to act on. For "allEvents" the master event stands in
-    // for the whole series; for "thisAndFollowing" the specific occurrence is
-    // the split point.
+    // Resolve the event to act on. "allEvents" works from the master (the
+    // whole series); "thisAndFollowing" and "thisInstance" work from the
+    // specific occurrence at `timestamp`.
+    let needsOccurrence = (span == "thisAndFollowing" || span == "thisInstance")
     let targetEvent: EKEvent?
-    if isThisAndFollowing {
+    if needsOccurrence {
       guard let timestamp = timestamp else {
         completion(.failure(CalendarError(
           code: PlatformExceptionCodes.invalidArguments,
-          message: "thisAndFollowing requires an occurrence timestamp"
+          message: "\(span) requires an occurrence timestamp"
         )))
         return
       }
@@ -982,13 +981,17 @@ class EventsService {
       foundEvent.recurrenceRules = [rule]
     }
 
-    // .futureEvents applies the change from the fetched event onward: from the
-    // master that means the whole series; from a specific occurrence it splits
-    // the series. It is also required to drop recurrence across a whole series
-    // — .thisEvent would only detach the fetched occurrence. (.futureEvents on
-    // a non-recurring event behaves like .thisEvent.)
+    // "thisInstance" detaches only the fetched occurrence (.thisEvent).
+    // "allEvents" and "thisAndFollowing" use .futureEvents: from the master
+    // that is the whole series; from an occurrence it splits the series so
+    // that occurrence onward becomes the new series. .futureEvents is also
+    // what drops recurrence across a whole series — .thisEvent would only
+    // detach one occurrence. (.futureEvents on a non-recurring event behaves
+    // like .thisEvent.)
+    let saveSpan: EKSpan = (span == "thisInstance") ? .thisEvent : .futureEvents
+
     do {
-      try eventStore.save(foundEvent, span: .futureEvents, commit: true)
+      try eventStore.save(foundEvent, span: saveSpan, commit: true)
       completion(.success(foundEvent.eventIdentifier ?? eventId))
     } catch {
       completion(.failure(CalendarError(

--- a/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
+++ b/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
@@ -205,6 +205,44 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
   }
 
   @override
+  Future<String> updateRecurring(
+    String eventId,
+    int? timestamp,
+    String span, {
+    String? title,
+    DateTime? startDate,
+    DateTime? endDate,
+    Patch<String>? description,
+    Patch<String>? location,
+    Patch<String>? url,
+    bool? isAllDay,
+    String? timeZone,
+    String? availability,
+    Patch<String>? recurrenceRule,
+  }) async {
+    final args = <String, dynamic>{
+      'eventId': eventId,
+      'timestamp': timestamp,
+      'span': span,
+      'title': title,
+      'startDate': startDate?.millisecondsSinceEpoch,
+      'endDate': endDate?.millisecondsSinceEpoch,
+      'isAllDay': isAllDay,
+      'timeZone': timeZone,
+      'availability': availability,
+    };
+    writePatchFields(args, {
+      'description': description,
+      'location': location,
+      'url': url,
+      'recurrenceRule': recurrenceRule,
+    });
+    final result =
+        await methodChannel.invokeMethod<String>('updateRecurring', args);
+    return result!;
+  }
+
+  @override
   Future<void> showCreateEventModal({
     String? title,
     int? startDate,

--- a/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
+++ b/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
@@ -226,6 +226,37 @@ abstract class DeviceCalendarPlusPlatform extends PlatformInterface {
     String? availability,
   });
 
+  /// Updates a recurring event, choosing which occurrences the edit affects.
+  ///
+  /// [eventId] is the event identifier. [timestamp] is the occurrence
+  /// timestamp in milliseconds — it is the split point and is required when
+  /// [span] is `thisAndFollowing`.
+  ///
+  /// [span] is the [EventUpdateSpan] name: `allEvents` updates the whole
+  /// series; `thisAndFollowing` splits the series at [timestamp].
+  ///
+  /// [description], [location] and [url] take a [Patch] of the field value.
+  /// [recurrenceRule] takes a [Patch] of the RRULE string: [Patch.set]
+  /// changes the rule, [Patch.clear] removes it (the event stops recurring).
+  ///
+  /// Returns the event ID for the affected scope — the same ID for
+  /// `allEvents`, the new series' ID for `thisAndFollowing`.
+  Future<String> updateRecurring(
+    String eventId,
+    int? timestamp,
+    String span, {
+    String? title,
+    DateTime? startDate,
+    DateTime? endDate,
+    Patch<String>? description,
+    Patch<String>? location,
+    Patch<String>? url,
+    bool? isAllDay,
+    String? timeZone,
+    String? availability,
+    Patch<String>? recurrenceRule,
+  });
+
   /// Opens the native calendar editor in create mode with optional pre-fill.
   ///
   /// All parameters are optional. Dates are in milliseconds since epoch.

--- a/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
+++ b/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
@@ -229,11 +229,11 @@ abstract class DeviceCalendarPlusPlatform extends PlatformInterface {
   /// Updates a recurring event, choosing which occurrences the edit affects.
   ///
   /// [eventId] is the event identifier. [timestamp] is the occurrence
-  /// timestamp in milliseconds — it is the split point and is required when
-  /// [span] is `thisAndFollowing`.
+  /// timestamp in milliseconds — required for every [span] except `allEvents`.
   ///
   /// [span] is the [EventUpdateSpan] name: `allEvents` updates the whole
-  /// series; `thisAndFollowing` splits the series at [timestamp].
+  /// series; `thisAndFollowing` splits it at [timestamp]; `thisInstance`
+  /// detaches and edits only that occurrence.
   ///
   /// [description], [location] and [url] take a [Patch] of the field value.
   /// [recurrenceRule] takes a [Patch] of the RRULE string: [Patch.set]

--- a/packages/device_calendar_plus_platform_interface/test/device_calendar_plus_platform_interface_test.dart
+++ b/packages/device_calendar_plus_platform_interface/test/device_calendar_plus_platform_interface_test.dart
@@ -84,6 +84,24 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
   }) async {}
 
   @override
+  Future<String> updateRecurring(
+    String eventId,
+    int? timestamp,
+    String span, {
+    String? title,
+    DateTime? startDate,
+    DateTime? endDate,
+    Patch<String>? description,
+    Patch<String>? location,
+    Patch<String>? url,
+    bool? isAllDay,
+    String? timeZone,
+    String? availability,
+    Patch<String>? recurrenceRule,
+  }) async =>
+      'mock-event-id';
+
+  @override
   Future<void> showCreateEventModal({
     String? title,
     int? startDate,


### PR DESCRIPTION
## What

Adds `updateRecurring` — editing a recurring event with a span choice — resolving #36 (`updateEvent` could never change a recurrence rule).

- **`EventUpdateSpan`** — `allEvents` (whole series) / `thisAndFollowing` (this occurrence and every later one) / `thisInstance` (only this occurrence, as a detached exception)
- **`updateRecurring(instanceId, span, {…, recurrenceRule})`** → `Future<String>` (the affected scope's event ID)
- `recurrenceRule` is a `Patch<RecurrenceRule>`: omit = unchanged, `Patch.set` = change, `Patch.clear` = stop recurring. Not valid with `thisInstance` — a single occurrence has no rule of its own.
- `updateEvent` is unchanged — `updateRecurring` is a separate method so each keeps a uniform ID contract.

## How

- **iOS** — `EKSpan.futureEvents` for `allEvents`/`thisAndFollowing`; `EKSpan.thisEvent` for `thisInstance`.
- **Android** — `thisAndFollowing` is a manual `UNTIL`-truncate of the original series + a new series for the tail (with the `DTEND`↔`DURATION` swap, and `COUNT` reduced so the new series doesn't over-generate); `thisInstance` inserts an exception via `CONTENT_EXCEPTION_URI`.
- **Split semantics** — `thisAndFollowing` at occurrence N: occurrences 1…N−1 stay on the original series, **N onward** become a new series carrying the edit. "This and following" includes "this".
- **Primary vs secondary effects** — the rule change itself is identical on both platforms; what happens to individually-customised occurrences is best-effort and documented in the doc comment.

## Verification

- `dart analyze` clean; all unit tests pass (11 new `updateRecurring` tests)
- Android APK + iOS app both compile
- **Integration tests** (`recurrence_test.dart`, 5 new) — an earlier run of the Android suite was all-green; a clean re-run of both platforms against the corrected code is pending.

## Notes

- Opened as a draft per repo convention — mark ready for review when CI should run.
- Out of scope, spotted in passing: the README's existing `updateEvent` examples use `instanceId:` but the real parameter is `eventId:` — a pre-existing doc bug, left for a separate change.

Fixes #36

Addresses #43 — `thisInstance` and `thisAndFollowing` cover the "change individual / current and future" side. Single-occurrence *delete* is not in scope here (`deleteEvent` stays whole-series), so #43 stays open to track that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)