### PR TITLE
feat(android): implement EventSpan.thisInstance via EXDATE on master

### DIFF
--- a/packages/device_calendar_plus/CHANGELOG.md
+++ b/packages/device_calendar_plus/CHANGELOG.md
@@ -10,10 +10,9 @@
 - `deleteRecurring()` — delete part of a recurring event with a span choice:
   `EventSpan.allEvents` (whole series), `thisAndFollowing` (this occurrence
   and every later one), or `thisInstance` (only this occurrence). Completes
-  the single-occurrence support that `updateRecurring()` started.
-  Note: `EventSpan.thisInstance` is iOS-only at the moment — Android throws
-  "not yet supported"; a follow-up will land Android support (likely via
-  EXDATE on the master rather than the exception-event path).
+  the single-occurrence support that `updateRecurring()` started. On Android
+  `thisInstance` appends the occurrence to the master's `EXDATE`; on iOS it
+  uses EventKit's `remove(span: .thisEvent)`.
   Based on @SuperKrallan (#43)
 - `EventSpan` enum for choosing the scope of a recurring-event operation,
   shared by `updateRecurring()` and `deleteRecurring()`

--- a/packages/device_calendar_plus/README.md
+++ b/packages/device_calendar_plus/README.md
@@ -558,7 +558,7 @@ await plugin.deleteEvent(event.instanceId);
 
 - `EventSpan.allEvents` — the whole series is deleted (the same as `deleteEvent`).
 - `EventSpan.thisAndFollowing` — the occurrence you pass, and every later one, are removed; the series is truncated to end before it.
-- `EventSpan.thisInstance` — only the occurrence you pass is removed, as a cancelled exception. **iOS only at the moment** — Android throws "not yet supported"; use `thisAndFollowing` or `allEvents` instead, or call from iOS.
+- `EventSpan.thisInstance` — only the occurrence you pass is removed. On iOS this is a cancelled exception via EventKit; on Android the occurrence is appended to the master's `EXDATE`.
 
 ```dart
 final plugin = DeviceCalendar.instance;
@@ -569,7 +569,7 @@ await plugin.deleteRecurring(event.instanceId, EventSpan.allEvents);
 // Delete this occurrence and every later one
 await plugin.deleteRecurring(event.instanceId, EventSpan.thisAndFollowing);
 
-// Delete only this one occurrence, leaving the rest of the series alone (iOS only)
+// Delete only this one occurrence, leaving the rest of the series alone
 await plugin.deleteRecurring(event.instanceId, EventSpan.thisInstance);
 ```
 

--- a/packages/device_calendar_plus/example/integration_test/recurrence_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/recurrence_test.dart
@@ -597,15 +597,7 @@ void main() {
           reason: 'occurrences before the anchor must survive');
     });
 
-    test('thisInstance removes only the one occurrence',
-        // iOS works (EventKit's remove with .thisEvent). Android currently
-        // throws "not yet supported" — both the minimal CONTENT_EXCEPTION_URI
-        // insert and the DTSTART+DURATION variant cause the provider to
-        // cancel the whole series rather than just one instance. Re-enable
-        // when Android lands a working implementation (likely via EXDATE
-        // on the master).
-        skip: 'TODO: enable when Android thisInstance is implemented',
-        () async {
+    test('thisInstance removes only the one occurrence', () async {
       if (calendarId == null) return;
       final series = await createDailySeries(count: 10);
 

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -1426,19 +1426,18 @@ class EventsService(private val context: Context) {
     /**
      * Deletes a recurring event, choosing which occurrences are removed.
      *
-     * [span] is "allEvents" (the whole series) or "thisAndFollowing" (the
-     * occurrence at [timestamp] and every later one). "thisInstance" is
-     * accepted by the public API but currently rejected here — see below.
+     * [span] is "allEvents" (the whole series), "thisAndFollowing" (the
+     * occurrence at [timestamp] and every later one), or "thisInstance"
+     * (only the occurrence at [timestamp]).
      *
-     * iOS supports all three spans via EventKit's `remove(span:)`. On
-     * Android, "thisInstance" needs to insert a cancelled exception via
-     * `CONTENT_EXCEPTION_URI`. The straightforward implementations of that
-     * insert (`ORIGINAL_INSTANCE_TIME + STATUS_CANCELED` and the same plus
-     * explicit `DTSTART + DURATION`) both cause the provider to cancel
-     * every generated instance of the master rather than just the targeted
-     * one. Rather than ship that silent data-loss bug, this returns a
-     * clear error until a correct implementation lands (likely via
-     * `EXDATE` on the master rather than the exception pattern).
+     * "thisInstance" is implemented by appending the occurrence to the
+     * master's `EXDATE` column rather than inserting a cancelled exception
+     * via `CONTENT_EXCEPTION_URI`. The exception-insert path looks correct
+     * on paper but in practice (AOSP CalendarProvider2) cancels every
+     * generated instance of the master rather than just the targeted one —
+     * even when DTSTART/DURATION are supplied explicitly. EXDATE on the
+     * master is the same shape the provider uses internally for ICS-imported
+     * exclusions, and it cleanly drops only the matching occurrence.
      */
     fun deleteRecurring(
         eventId: String,
@@ -1460,14 +1459,7 @@ class EventsService(private val context: Context) {
                 // The whole series — exactly what deleteEvent already does.
                 "allEvents" -> deleteEvent(eventId)
                 "thisAndFollowing" -> deleteRecurringThisAndFollowing(eventId, timestamp)
-                "thisInstance" -> Result.failure(
-                    CalendarException(
-                        PlatformExceptionCodes.OPERATION_FAILED,
-                        "deleteRecurring with EventSpan.thisInstance is not yet " +
-                        "supported on Android. Use EventSpan.allEvents or " +
-                        "EventSpan.thisAndFollowing, or call deleteRecurring on iOS."
-                    )
-                )
+                "thisInstance" -> deleteRecurringThisInstance(eventId, timestamp)
                 else -> Result.failure(
                     CalendarException(
                         PlatformExceptionCodes.INVALID_ARGUMENTS,
@@ -1552,6 +1544,60 @@ class EventsService(private val context: Context) {
         return Result.success(Unit)
     }
 
+    private fun deleteRecurringThisInstance(
+        eventId: String,
+        timestamp: Long?
+    ): Result<Unit> {
+        if (timestamp == null) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.INVALID_ARGUMENTS,
+                    "thisInstance requires an occurrence timestamp"
+                )
+            )
+        }
+
+        val row = readEventRow(eventId)
+            ?: return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.NOT_FOUND,
+                    "Event with ID $eventId not found"
+                )
+            )
+
+        if (row.rrule == null) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.INVALID_ARGUMENTS,
+                    "Event $eventId is not recurring; use deleteEvent instead"
+                )
+            )
+        }
+
+        // Append the occurrence to the master's EXDATE. Same multi-field
+        // touch (DTSTART + DURATION) as the thisAndFollowing path — the
+        // provider doesn't always invalidate the Instances cache when a
+        // single recurrence-related column changes in isolation.
+        val nextExdate = appendExdate(row.exdate, timestamp, row.allDay)
+        val values = android.content.ContentValues().apply {
+            put(CalendarContract.Events.EXDATE, nextExdate)
+            put(CalendarContract.Events.DTSTART, row.dtstart)
+            if (row.duration != null) {
+                put(CalendarContract.Events.DURATION, row.duration)
+            }
+        }
+        val updatedRows = updateEventAsSyncAdapter(eventId, row.calendarId, values)
+        if (updatedRows == 0) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.NOT_FOUND,
+                    "Event with ID $eventId not found"
+                )
+            )
+        }
+        return Result.success(Unit)
+    }
+
     private data class EventRow(
         val id: String,
         val calendarId: String,
@@ -1565,7 +1611,8 @@ class EventsService(private val context: Context) {
         val allDay: Boolean,
         val timeZone: String?,
         val availability: String,
-        val rrule: String?
+        val rrule: String?,
+        val exdate: String?
     )
 
     /** Reads the master row of an event straight from the Events table. */
@@ -1583,7 +1630,8 @@ class EventsService(private val context: Context) {
             CalendarContract.Events.ALL_DAY,
             CalendarContract.Events.EVENT_TIMEZONE,
             CalendarContract.Events.AVAILABILITY,
-            CalendarContract.Events.RRULE
+            CalendarContract.Events.RRULE,
+            CalendarContract.Events.EXDATE
         )
         context.contentResolver.query(
             CalendarContract.Events.CONTENT_URI,
@@ -1616,7 +1664,8 @@ class EventsService(private val context: Context) {
                 availability = availabilityToString(
                     (long(CalendarContract.Events.AVAILABILITY) ?: 0L).toInt()
                 ),
-                rrule = str(CalendarContract.Events.RRULE)
+                rrule = str(CalendarContract.Events.RRULE),
+                exdate = str(CalendarContract.Events.EXDATE)
             )
         }
         return null
@@ -1774,6 +1823,22 @@ class EventsService(private val context: Context) {
             it.isNotEmpty() && key != "COUNT" && key != "UNTIL"
         }
         return (parts + "COUNT=$count").joinToString(";")
+    }
+
+    /**
+     * Appends [instanceMillis] (formatted as a UTC RRULE date or date-time)
+     * to an existing EXDATE string. Multiple exclusions are comma-separated
+     * within a single Events.EXDATE column — CalendarProvider2 parses this
+     * format and drops matching occurrences from the expansion.
+     */
+    private fun appendExdate(
+        existing: String?,
+        instanceMillis: Long,
+        isAllDay: Boolean
+    ): String {
+        val value = formatRruleUtc(instanceMillis, isAllDay)
+        val trimmed = existing?.trim().orEmpty()
+        return if (trimmed.isEmpty()) value else "$trimmed,$value"
     }
 
     /** Replaces any COUNT/UNTIL in [rrule] with UNTIL at [untilMillis] (inclusive). */


### PR DESCRIPTION
## Summary
- Replaces the `not yet supported` stub for `deleteRecurring(..., EventSpan.thisInstance)` on Android with an EXDATE append on the master event
- Drops the iOS-only caveat from README + CHANGELOG; iOS already worked via EventKit's `remove(span: .thisEvent)`
- Unskips the `thisInstance removes only the one occurrence` integration test

## Why EXDATE
The straightforward `CONTENT_EXCEPTION_URI` insert (the path most plugins reach for) cancels *every* generated instance of the master under AOSP's CalendarProvider2 — even when DTSTART/DURATION are supplied explicitly. The EXDATE column on the master is the same shape the provider uses for ICS-imported exclusions and drops only the targeted occurrence.

## Implementation notes
- `appendExdate(existing, instanceMillis, isAllDay)` formats the timestamp via the existing `formatRruleUtc` helper and comma-appends to whatever's already in `Events.EXDATE`
- Writes go through `updateEventAsSyncAdapter` (sync-adapter context is required for protected columns) and re-stamp `DTSTART`/`DURATION` alongside `EXDATE` — same Instances-cache regen-forcing pattern as `deleteRecurringThisAndFollowing`
- `EventRow` gains the `exdate` field so existing exclusions aren't clobbered when a second occurrence is removed

## Stacked on
PR #52 (deleteRecurring). This PR targets `feat/delete-recurring`; GitHub will auto-retarget to `main` when #52 merges.

## Test plan
- [x] `dart analyze` clean
- [x] `flutter test` — 149 unit tests pass
- [x] Android example APK builds
- [ ] Android integration suite — recurrence file in at least one timezone (Sydney/LA/UTC). _Got killed by the bot daemon's stall judge mid-run; needs to be verified before merge_
- [ ] iOS integration suite to confirm I didn't break iOS

Fixes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)