### PR TITLE
fix(android): use sync-adapter context for event deletion

### DIFF
--- a/packages/device_calendar_plus/example/integration_test/recurrence_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/recurrence_test.dart
@@ -427,13 +427,16 @@ void main() {
       expect(updated.recurrenceRule, isNull);
     });
 
+    // Known failure on Android emulator: the emulator's Calendar Provider
+    // doesn't propagate the title change to the anchor occurrence after a
+    // thisAndFollowing split. Passes on real Android devices.
     test('thisAndFollowing splits so the anchor occurrence carries the change',
         () async {
       expect(calendarId, isNotNull, reason: 'setUpAll must create a calendar');
       final series = await createDailySeries(plugin, calendarId!, count: 10);
 
-      final occurrences =
-          await occurrencesOf(plugin, calendarId!, series.eventId, series.start);
+      final occurrences = await occurrencesOf(
+          plugin, calendarId!, series.eventId, series.start);
       expect(occurrences.length, greaterThanOrEqualTo(6),
           reason: 'the daily series should have expanded into occurrences');
       final splitPoint = occurrences[4];
@@ -448,8 +451,8 @@ void main() {
       // The original master series is now truncated — only occurrences
       // before the split point should remain under its eventId, and none
       // of them are touched.
-      final remainingMaster =
-          await occurrencesOf(plugin, calendarId!, series.eventId, series.start);
+      final remainingMaster = await occurrencesOf(
+          plugin, calendarId!, series.eventId, series.start);
       expect(remainingMaster, isNotEmpty,
           reason: 'occurrences before the split must survive');
       expect(
@@ -462,13 +465,14 @@ void main() {
           reason: 'occurrences before the split must keep the original title');
 
       // The new series starts at the split point and carries the new title.
-      final newSeriesOccurrences = await occurrencesOf(
-          plugin, calendarId!, newSeriesId, series.start);
+      final newSeriesOccurrences =
+          await occurrencesOf(plugin, calendarId!, newSeriesId, series.start);
       final atSplit = newSeriesOccurrences
           .where((e) => e.startDate.millisecondsSinceEpoch == splitMillis)
           .toList();
       expect(atSplit, isNotEmpty,
-          reason: 'the new series should have an occurrence at the split point');
+          reason:
+              'the new series should have an occurrence at the split point');
       expect(atSplit.first.title, 'Split Tail',
           reason: 'the anchor occurrence must receive the change');
     });
@@ -478,8 +482,8 @@ void main() {
       expect(calendarId, isNotNull, reason: 'setUpAll must create a calendar');
       final series = await createDailySeries(plugin, calendarId!, count: 10);
 
-      final occurrences =
-          await occurrencesOf(plugin, calendarId!, series.eventId, series.start);
+      final occurrences = await occurrencesOf(
+          plugin, calendarId!, series.eventId, series.start);
       expect(occurrences.length, greaterThanOrEqualTo(6));
       final splitPoint = occurrences[4];
       final splitMillis = splitPoint.startDate.millisecondsSinceEpoch;
@@ -516,8 +520,8 @@ void main() {
       expect(calendarId, isNotNull, reason: 'setUpAll must create a calendar');
       final series = await createDailySeries(plugin, calendarId!, count: 10);
 
-      final occurrences =
-          await occurrencesOf(plugin, calendarId!, series.eventId, series.start);
+      final occurrences = await occurrencesOf(
+          plugin, calendarId!, series.eventId, series.start);
       expect(occurrences.length, greaterThanOrEqualTo(6));
       final target = occurrences[4];
       final targetMillis = target.startDate.millisecondsSinceEpoch;
@@ -585,8 +589,8 @@ void main() {
         title: 'Legacy Updated',
       );
 
-      final occurrences =
-          await occurrencesOf(plugin, calendarId!, series.eventId, series.start);
+      final occurrences = await occurrencesOf(
+          plugin, calendarId!, series.eventId, series.start);
       expect(occurrences, isNotEmpty);
       expect(occurrences.every((e) => e.title == 'Legacy Updated'), isTrue,
           reason: 'every occurrence of the series must reflect the update');
@@ -618,14 +622,14 @@ void main() {
       final series = await createDailySeries(plugin, calendarId!);
 
       // The series should have expanded into occurrences first.
-      final before =
-          await occurrencesOf(plugin, calendarId!, series.eventId, series.start);
+      final before = await occurrencesOf(
+          plugin, calendarId!, series.eventId, series.start);
       expect(before, isNotEmpty);
 
       await plugin.deleteRecurring(series.eventId, EventSpan.allEvents);
 
-      final after =
-          await occurrencesOf(plugin, calendarId!, series.eventId, series.start);
+      final after = await occurrencesOf(
+          plugin, calendarId!, series.eventId, series.start);
       expect(after, isEmpty, reason: 'the whole series should be gone');
       expect(await plugin.getEvent(series.eventId), isNull);
     });
@@ -635,8 +639,8 @@ void main() {
       expect(calendarId, isNotNull, reason: 'setUpAll must create a calendar');
       final series = await createDailySeries(plugin, calendarId!, count: 10);
 
-      final occurrences =
-          await occurrencesOf(plugin, calendarId!, series.eventId, series.start);
+      final occurrences = await occurrencesOf(
+          plugin, calendarId!, series.eventId, series.start);
       expect(occurrences.length, greaterThanOrEqualTo(6));
       final anchor = occurrences[4];
       final anchorMillis = anchor.startDate.millisecondsSinceEpoch;
@@ -646,8 +650,8 @@ void main() {
         EventSpan.thisAndFollowing,
       );
 
-      final after =
-          await occurrencesOf(plugin, calendarId!, series.eventId, series.start);
+      final after = await occurrencesOf(
+          plugin, calendarId!, series.eventId, series.start);
 
       // The anchor and everything after it are gone.
       expect(
@@ -672,8 +676,8 @@ void main() {
       expect(calendarId, isNotNull, reason: 'setUpAll must create a calendar');
       final series = await createDailySeries(plugin, calendarId!, count: 10);
 
-      final occurrences =
-          await occurrencesOf(plugin, calendarId!, series.eventId, series.start);
+      final occurrences = await occurrencesOf(
+          plugin, calendarId!, series.eventId, series.start);
       expect(occurrences.length, greaterThanOrEqualTo(6));
       final initialCount = occurrences.length;
       final target = occurrences[4];
@@ -681,8 +685,8 @@ void main() {
 
       await plugin.deleteRecurring(target.instanceId, EventSpan.thisInstance);
 
-      final after =
-          await occurrencesOf(plugin, calendarId!, series.eventId, series.start);
+      final after = await occurrencesOf(
+          plugin, calendarId!, series.eventId, series.start);
 
       // The targeted occurrence is gone.
       expect(
@@ -704,14 +708,14 @@ void main() {
       expect(calendarId, isNotNull, reason: 'setUpAll must create a calendar');
       final series = await createDailySeries(plugin, calendarId!);
 
-      final before =
-          await occurrencesOf(plugin, calendarId!, series.eventId, series.start);
+      final before = await occurrencesOf(
+          plugin, calendarId!, series.eventId, series.start);
       expect(before, isNotEmpty);
 
       await plugin.deleteEvent(eventId: series.eventId);
 
-      final after =
-          await occurrencesOf(plugin, calendarId!, series.eventId, series.start);
+      final after = await occurrencesOf(
+          plugin, calendarId!, series.eventId, series.start);
       expect(after, isEmpty, reason: 'the whole series should be gone');
       expect(await plugin.getEvent(series.eventId), isNull);
     });

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -773,15 +773,19 @@ class EventsService(private val context: Context) {
                 )
             )
         }
-        
+
         try {
-            // Delete the event (entire series for recurring events)
+            // Use sync-adapter context so the Calendar Provider physically
+            // removes the row instead of just setting DELETED=1. Without
+            // this, the event survives deletion on real devices (where a
+            // sync adapter is present) and getEvent still returns it.
+            val uri = buildDeleteUri(eventId)
             val deletedRows = context.contentResolver.delete(
-                CalendarContract.Events.CONTENT_URI,
+                uri,
                 "${CalendarContract.Events._ID} = ?",
                 arrayOf(eventId)
             )
-            
+
             if (deletedRows == 0) {
                 return Result.failure(
                     CalendarException(
@@ -790,7 +794,7 @@ class EventsService(private val context: Context) {
                     )
                 )
             }
-            
+
             return Result.success(Unit)
         } catch (e: SecurityException) {
             return Result.failure(
@@ -1866,5 +1870,36 @@ class EventsService(private val context: Context) {
             "${CalendarContract.Events._ID} = ?",
             arrayOf(eventId)
         )
+    }
+
+    /**
+     * Builds a delete URI with sync-adapter context for the given event.
+     * Without CALLER_IS_SYNCADAPTER, the Calendar Provider on real devices
+     * only marks the row as DELETED=1 (for sync propagation) instead of
+     * physically removing it. Falls back to the plain URI if the calendar
+     * account can't be read.
+     */
+    private fun buildDeleteUri(eventId: String): android.net.Uri {
+        // Look up the event's calendar ID so we can get the account.
+        val calendarId = context.contentResolver.query(
+            CalendarContract.Events.CONTENT_URI,
+            arrayOf(CalendarContract.Events.CALENDAR_ID),
+            "${CalendarContract.Events._ID} = ?",
+            arrayOf(eventId),
+            null
+        )?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                cursor.getString(cursor.getColumnIndexOrThrow(CalendarContract.Events.CALENDAR_ID))
+            } else null
+        } ?: return CalendarContract.Events.CONTENT_URI
+
+        val account = readCalendarAccount(calendarId)
+            ?: return CalendarContract.Events.CONTENT_URI
+
+        return CalendarContract.Events.CONTENT_URI.buildUpon()
+            .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
+            .appendQueryParameter(CalendarContract.Events.ACCOUNT_NAME, account.first)
+            .appendQueryParameter(CalendarContract.Events.ACCOUNT_TYPE, account.second)
+            .build()
     }
 }


### PR DESCRIPTION
## Summary
- Use `CALLER_IS_SYNCADAPTER` when deleting events on Android so the Calendar Provider physically removes rows instead of just marking them `DELETED=1`
- Fixes `deleteEvent` and `deleteRecurring(allEvents)` silently failing on real devices (event survived deletion)
- Adds comment noting `thisAndFollowing` anchor test is a known emulator-only failure

Closes #58 items 1 (delete tests) and partially addresses item 3 (emulator vs real device divergence).

## Test plan
- [x] All 66 integration tests pass across 3 timezones on real Android device (Samsung, API 34)
- [x] `allEvents deletes the whole series` — now passes on real device
- [x] `deleteEvent on a recurring eventId removes the whole series` — now passes on real device

🤖 Generated with [Claude Code](https://claude.com/claude-code)