### PR TITLE
feat(android): implement deleteRecurring(thisInstance)

### DIFF
--- a/packages/device_calendar_plus/example/integration_test/recurrence_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/recurrence_test.dart
@@ -664,15 +664,7 @@ void main() {
           reason: 'occurrences before the anchor must survive');
     });
 
-    test('thisInstance removes only the one occurrence',
-        // iOS works (EventKit's remove with .thisEvent). Android currently
-        // throws "not yet supported" — both the minimal CONTENT_EXCEPTION_URI
-        // insert and the DTSTART+DURATION variant cause the provider to
-        // cancel the whole series rather than just one instance. Re-enable
-        // when Android lands a working implementation (likely via EXDATE
-        // on the master).
-        skip: 'TODO: enable when Android thisInstance is implemented',
-        () async {
+    test('thisInstance removes only the one occurrence', () async {
       expect(calendarId, isNotNull, reason: 'setUpAll must create a calendar');
       final series = await createDailySeries(plugin, calendarId!, count: 10);
 

--- a/packages/device_calendar_plus/example/run_integration_tests.sh
+++ b/packages/device_calendar_plus/example/run_integration_tests.sh
@@ -110,11 +110,19 @@ select_device() {
     echo -e "${GREEN}✓${NC} Selected: ${DEVICE_NAMES[$((SELECTION-1))]}"
 }
 
-# Check if device ID is provided
-if [ -z "$1" ]; then
+# Parse arguments
+SKIP_TZ=false
+DEVICE_ID=""
+for arg in "$@"; do
+    if [ "$arg" == "--no-tz" ]; then
+        SKIP_TZ=true
+    elif [ -z "$DEVICE_ID" ]; then
+        DEVICE_ID="$arg"
+    fi
+done
+
+if [ -z "$DEVICE_ID" ]; then
     select_device
-else
-    DEVICE_ID="$1"
 fi
 
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
@@ -225,7 +233,7 @@ run_tests() {
 # All-day event boundary logic depends on correct UTC date extraction regardless of offset.
 ANDROID_TIMEZONES=("America/Los_Angeles" "UTC" "Australia/Sydney")
 
-if [ "$PLATFORM" == "android" ]; then
+if [ "$PLATFORM" == "android" ] && [ "$SKIP_TZ" == false ]; then
     # Save original timezone
     ORIGINAL_TZ=$(adb -s "$DEVICE_ID" shell getprop persist.sys.timezone | tr -d '\r')
     EXIT_CODE=0

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -1427,23 +1427,7 @@ class EventsService(private val context: Context) {
 
     // -- deleteRecurring (issue #43) --
 
-    /**
-     * Deletes a recurring event, choosing which occurrences are removed.
-     *
-     * [span] is "allEvents" (the whole series) or "thisAndFollowing" (the
-     * occurrence at [timestamp] and every later one). "thisInstance" is
-     * accepted by the public API but currently rejected here — see below.
-     *
-     * iOS supports all three spans via EventKit's `remove(span:)`. On
-     * Android, "thisInstance" needs to insert a cancelled exception via
-     * `CONTENT_EXCEPTION_URI`. The straightforward implementations of that
-     * insert (`ORIGINAL_INSTANCE_TIME + STATUS_CANCELED` and the same plus
-     * explicit `DTSTART + DURATION`) both cause the provider to cancel
-     * every generated instance of the master rather than just the targeted
-     * one. Rather than ship that silent data-loss bug, this returns a
-     * clear error until a correct implementation lands (likely via
-     * `EXDATE` on the master rather than the exception pattern).
-     */
+    /** Deletes a recurring event, choosing which occurrences are removed. */
     fun deleteRecurring(
         eventId: String,
         timestamp: Long?,
@@ -1461,17 +1445,9 @@ class EventsService(private val context: Context) {
 
         return try {
             when (span) {
-                // The whole series — exactly what deleteEvent already does.
                 "allEvents" -> deleteEvent(eventId)
                 "thisAndFollowing" -> deleteRecurringThisAndFollowing(eventId, timestamp)
-                "thisInstance" -> Result.failure(
-                    CalendarException(
-                        PlatformExceptionCodes.OPERATION_FAILED,
-                        "deleteRecurring with EventSpan.thisInstance is not yet " +
-                        "supported on Android. Use EventSpan.allEvents or " +
-                        "EventSpan.thisAndFollowing, or call deleteRecurring on iOS."
-                    )
-                )
+                "thisInstance" -> deleteRecurringThisInstance(eventId, timestamp)
                 else -> Result.failure(
                     CalendarException(
                         PlatformExceptionCodes.INVALID_ARGUMENTS,
@@ -1550,6 +1526,69 @@ class EventsService(private val context: Context) {
                 CalendarException(
                     PlatformExceptionCodes.NOT_FOUND,
                     "Event with ID $eventId not found"
+                )
+            )
+        }
+        return Result.success(Unit)
+    }
+
+    /**
+     * Removes a single occurrence by inserting a cancelled exception event
+     * via CONTENT_EXCEPTION_URI. The Calendar Provider then excludes that
+     * occurrence from the Instances expansion.
+     */
+    private fun deleteRecurringThisInstance(
+        eventId: String,
+        timestamp: Long?
+    ): Result<Unit> {
+        if (timestamp == null) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.INVALID_ARGUMENTS,
+                    "thisInstance requires an occurrence timestamp"
+                )
+            )
+        }
+
+        val row = readEventRow(eventId)
+            ?: return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.NOT_FOUND,
+                    "Event with ID $eventId not found"
+                )
+            )
+
+        if (row.rrule == null) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.INVALID_ARGUMENTS,
+                    "Event $eventId is not recurring; use deleteEvent instead"
+                )
+            )
+        }
+
+        val values = android.content.ContentValues().apply {
+            put(CalendarContract.Events.ORIGINAL_INSTANCE_TIME, timestamp)
+            put(CalendarContract.Events.STATUS, CalendarContract.Events.STATUS_CANCELED)
+        }
+
+        // Build the exception URI with sync-adapter context.
+        val account = readCalendarAccount(row.calendarId)
+        val uriBuilder = CalendarContract.Events.CONTENT_EXCEPTION_URI.buildUpon()
+        if (account != null) {
+            uriBuilder
+                .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
+                .appendQueryParameter(CalendarContract.Events.ACCOUNT_NAME, account.first)
+                .appendQueryParameter(CalendarContract.Events.ACCOUNT_TYPE, account.second)
+        }
+        uriBuilder.appendPath(eventId)
+
+        val exceptionUri = context.contentResolver.insert(uriBuilder.build(), values)
+        if (exceptionUri == null) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.OPERATION_FAILED,
+                    "Failed to create cancellation exception for event $eventId"
                 )
             )
         }


### PR DESCRIPTION
## Summary
- Implement `deleteRecurring(thisInstance)` on Android via `CONTENT_EXCEPTION_URI` with `STATUS_CANCELED` and sync-adapter context
- Un-skip the `thisInstance removes only the one occurrence` integration test
- Add `--no-tz` flag to `run_integration_tests.sh` to skip timezone cycling for faster iteration

Earlier attempts using EXDATE failed — the Calendar Provider's second-level EXDATE format couldn't match DTSTART values with sub-second precision. The cancelled-exception approach avoids this entirely.

Closes #58 item 5.

## Test plan
- [x] `thisInstance removes only the one occurrence` passes on real Android device
- [x] All 67 integration tests pass on real Android device (Samsung, API 34)
- [x] `--no-tz` flag works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)