### PR TITLE
fix(test): iOS createCalendar test picks writable source matching native fallback

### DIFF
--- a/packages/device_calendar_plus/example/integration_test/sources_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/sources_test.dart
@@ -67,12 +67,18 @@ void main() {
     (tester) async {
       final sources = await plugin.listSources();
 
-      // Find a writable source (local or calDav)
-      final source = sources.firstWhere(
+      // Mirror the native fallback: prefer iCloud (calDav with "icloud"
+      // account name), then local. Other calDav sources (e.g. Exchange)
+      // may not allow programmatic calendar creation.
+      final icloud = sources.where(
         (s) =>
-            s.type == CalendarSourceType.local ||
-            s.type == CalendarSourceType.calDav,
+            s.type == CalendarSourceType.calDav &&
+            s.accountName.toLowerCase() == 'icloud',
       );
+      final local = sources.where(
+        (s) => s.type == CalendarSourceType.local,
+      );
+      final source = icloud.followedBy(local).first;
 
       final timestamp = DateTime.now().millisecondsSinceEpoch;
       final calendarId = await plugin.createCalendar(


### PR DESCRIPTION
## Summary
- Mirror the native Swift source selection logic in the iOS createCalendar test: prefer iCloud calDav source, then local
- Previously the test picked the first `local` or `calDav` source — on real iOS devices, non-iCloud calDav sources (e.g. Exchange) reject programmatic calendar creation

## Test plan
- [x] `iOS: createCalendar with explicit sourceId` passes on real iOS device with iCloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)