### PR TITLE
feat: add Color getter on Calendar

### DIFF
--- a/packages/device_calendar_plus/lib/src/calendar.dart
+++ b/packages/device_calendar_plus/lib/src/calendar.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show Color;
+
 /// Represents a user's calendar
 class Calendar {
   /// Identifier returned by the platform (Android `Calendars._ID`, iOS `EKCalendar.calendarIdentifier`).
@@ -8,6 +10,16 @@ class Calendar {
 
   /// Calendar color as a hex string in `#RRGGBB` format, if provided by the OS.
   final String? colorHex;
+
+  /// Parsed [colorHex] as a Flutter [Color], or `null` if absent or unparseable.
+  Color? get color {
+    final hex = colorHex;
+    if (hex == null) return null;
+    final cleaned = hex.startsWith('#') ? hex.substring(1) : hex;
+    final value = int.tryParse(cleaned, radix: 16);
+    if (value == null) return null;
+    return Color(cleaned.length == 6 ? value | 0xFF000000 : value);
+  }
 
   /// Whether edits are disallowed (subscribed/shared calendars, server-managed feeds, etc.).
   final bool readOnly;

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show Color;
+
 import 'package:device_calendar_plus/device_calendar_plus.dart';
 import 'package:device_calendar_plus_platform_interface/device_calendar_plus_platform_interface.dart';
 import 'package:flutter/services.dart';
@@ -1130,7 +1132,6 @@ void main() {
         expect(capturedTimestamp, 1700000000000);
         expect(capturedSpan, 'thisAndFollowing');
       });
-
     });
 
     group('deleteEvent', () {
@@ -1206,6 +1207,35 @@ void main() {
           ),
         );
       });
+    });
+  });
+
+  group('Calendar.color', () {
+    Calendar cal({String? colorHex}) => Calendar(
+          id: '1',
+          name: 'Test',
+          colorHex: colorHex,
+          readOnly: false,
+        );
+
+    test('parses 6-digit hex with # prefix', () {
+      expect(cal(colorHex: '#FF0000').color, const Color(0xFFFF0000));
+    });
+
+    test('parses 8-digit hex with alpha', () {
+      expect(cal(colorHex: '#80FF0000').color, const Color(0x80FF0000));
+    });
+
+    test('parses without # prefix', () {
+      expect(cal(colorHex: '00FF00').color, const Color(0xFF00FF00));
+    });
+
+    test('returns null when colorHex is null', () {
+      expect(cal().color, isNull);
+    });
+
+    test('returns null for unparseable string', () {
+      expect(cal(colorHex: 'notacolor').color, isNull);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Add `Color? get color` on `Calendar` that parses `colorHex` into a `dart:ui` Color
- Handles 6-digit (`#RRGGBB`) and 8-digit (`#AARRGGBB`) hex, with or without `#` prefix
- Returns `null` for absent or unparseable values

Closes #46

## Test plan
- [x] 5 unit tests covering: 6-digit hex, 8-digit with alpha, no prefix, null, unparseable

🤖 Generated with [Claude Code](https://claude.com/claude-code)