### PR TITLE
feat: add edit flag to showEventModal

### DIFF
--- a/packages/device_calendar_plus/CHANGELOG.md
+++ b/packages/device_calendar_plus/CHANGELOG.md
@@ -18,6 +18,9 @@
 - `EventSpan` enum for choosing the scope of a recurring-event operation,
   shared by `updateRecurring()` and `deleteRecurring()`
 - `url` parameter on `updateEvent()` — based on @SuperKrallan (#38)
+- `edit` parameter on `showEventModal()` — when `true`, opens the native editor
+  directly (`EKEventEditViewController` on iOS, `ACTION_EDIT` on Android)
+  instead of the read-only viewer. Based on @xonaman (#45)
 
 ### Changed
 - **Breaking:** `updateEvent()` `description`, `location` and `url` now take a

--- a/packages/device_calendar_plus/README.md
+++ b/packages/device_calendar_plus/README.md
@@ -279,6 +279,9 @@ await plugin.showEventModal(event.instanceId);
 
 // For recurring events, show the master event
 await plugin.showEventModal(event.eventId);
+
+// Open the native editor directly (skip the read-only viewer)
+await plugin.showEventModal(event.instanceId, edit: true);
 ```
 
 ### Create Event via Native Editor

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -504,31 +504,31 @@ class DeviceCalendar {
   /// - **Event ID**: Shows the master event definition (for recurring events)
   /// - **Instance ID**: Shows a specific occurrence (for recurring events)
   ///
+  /// When [edit] is `true`, opens the native editor directly instead of the
+  /// read-only view. Useful when the user has already expressed intent to edit.
   ///
   /// **Platform Differences:**
-  /// - **iOS**: Presents the event in a native modal using EventKit's
-  ///   `EKEventViewController`. The user can view and edit the event without
-  ///   leaving your app. Requires your app to be in the foreground.
-  /// - **Android**: Opens the event using an Intent with `ACTION_VIEW`.
-  ///   The system handles the presentation based on device and app configuration.
+  /// - **iOS**: Presents `EKEventViewController` (view) or
+  ///   `EKEventEditViewController` (edit) in a native modal.
+  /// - **Android**: Fires `ACTION_VIEW` or `ACTION_EDIT`.
   ///
   /// Example:
   /// ```dart
   /// final plugin = DeviceCalendar.instance;
-  /// // Show specific instance of a recurring event
+  /// // View an event (read-only, user can tap Edit)
   /// await plugin.showEventModal(event.instanceId);
   ///
-  /// // Show master event definition
-  /// await plugin.showEventModal(event.eventId);
+  /// // Open directly in the editor
+  /// await plugin.showEventModal(event.instanceId, edit: true);
   /// ```
-  Future<void> showEventModal(String id) async {
+  Future<void> showEventModal(String id, {bool edit = false}) async {
     try {
-      // Parse the ID to extract eventId and optional timestamp
       final parsed = InstanceIdParser.parse(id);
 
       await DeviceCalendarPlusPlatform.instance.showEventModal(
         parsed.eventId,
         parsed.timestamp,
+        edit: edit,
       );
     } on PlatformException catch (e, stackTrace) {
       final convertedException =

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -216,7 +216,8 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
   }
 
   @override
-  Future<void> showEventModal(String eventId, int? timestamp) async {
+  Future<void> showEventModal(String eventId, int? timestamp,
+      {bool edit = false}) async {
     if (_exceptionToThrow != null) throw _exceptionToThrow!;
   }
 
@@ -1130,7 +1131,6 @@ void main() {
         expect(capturedTimestamp, 1700000000000);
         expect(capturedSpan, 'thisAndFollowing');
       });
-
     });
 
     group('deleteEvent', () {

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
@@ -318,7 +318,8 @@ class DeviceCalendarPlusAndroidPlugin :
         // Parse arguments
         val eventId = call.argument<String>("eventId")
         val timestamp = call.argument<Long>("timestamp")
-        
+        val edit = call.argument<Boolean>("edit") ?: false
+
         if (eventId == null) {
             result.error(
                 PlatformExceptionCodes.INVALID_ARGUMENTS,
@@ -327,11 +328,11 @@ class DeviceCalendarPlusAndroidPlugin :
             )
             return
         }
-        
+
         // Store the result callback to call when activity returns
         showEventModalResult = result
-        
-        val serviceResult = service.showEvent(currentActivity, eventId, timestamp, SHOW_EVENT_REQUEST_CODE)
+
+        val serviceResult = service.showEvent(currentActivity, eventId, timestamp, edit, SHOW_EVENT_REQUEST_CODE)
         serviceResult.fold(
             onSuccess = { /* Result will be sent in onActivityResult */ },
             onFailure = { error ->

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -459,7 +459,7 @@ class EventsService(private val context: Context) {
     /**
      * Shows a calendar event in a modal dialog.
      */
-    fun showEvent(activityContext: Activity, eventId: String, timestamp: Long?, requestCode: Int): Result<Unit> {
+    fun showEvent(activityContext: Activity, eventId: String, timestamp: Long?, edit: Boolean, requestCode: Int): Result<Unit> {
         return try {
             // Validate permissions
             if (android.content.pm.PackageManager.PERMISSION_GRANTED !=
@@ -471,8 +471,8 @@ class EventsService(private val context: Context) {
                     )
                 )
             }
-            
-            val intent = Intent(Intent.ACTION_VIEW)
+
+            val intent = Intent(if (edit) Intent.ACTION_EDIT else Intent.ACTION_VIEW)
             
             // Build event URI
             val eventUri = android.content.ContentUris.withAppendedId(

--- a/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
+++ b/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
@@ -125,12 +125,14 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
   }
 
   @override
-  Future<void> showEventModal(String eventId, int? timestamp) async {
+  Future<void> showEventModal(String eventId, int? timestamp,
+      {bool edit = false}) async {
     await methodChannel.invokeMethod<void>(
       'showEventModal',
       <String, dynamic>{
         'eventId': eventId,
         'timestamp': timestamp,
+        'edit': edit,
       },
     );
   }

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
@@ -356,31 +356,31 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     
     // Parse timestamp (optional, for recurring events)
     let timestamp = args["timestamp"] as? Int64
-    
-    eventsService.showEvent(eventId: eventId, timestamp: timestamp) { serviceResult in
+    let edit = args["edit"] as? Bool ?? false
+
+    eventsService.showEvent(eventId: eventId, timestamp: timestamp, edit: edit) { serviceResult in
       DispatchQueue.main.async {
         switch serviceResult {
         case .success(let viewController):
-          // If we have a view controller (modal mode), present it
           if let viewController = viewController {
-            // Get the root view controller
             guard let rootViewController = self.getRootViewController() else {
               fatalError("Failed to get root view controller - plugin lifecycle error")
             }
-            
-            // Set the delegate
-            viewController.delegate = self
-            
-            // Store the result callback to call it when modal is dismissed
+
+            // Set the appropriate delegate based on view controller type
+            if let editVC = viewController as? EKEventEditViewController {
+              editVC.editViewDelegate = self
+            } else if let viewVC = viewController as? EKEventViewController {
+              viewVC.delegate = self
+            }
+
             self.eventModalResult = result
-            
-            // Wrap in navigation controller for proper dismissal
+
             let navigationController = UINavigationController(rootViewController: viewController)
             navigationController.modalPresentationStyle = .pageSheet
-            
+
             rootViewController.present(navigationController, animated: true, completion: nil)
           } else {
-            // Calendar app was opened
             result(nil)
           }
         case .failure(let error):
@@ -727,8 +727,14 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
 
   public func eventEditViewController(_ controller: EKEventEditViewController, didCompleteWith action: EKEventEditViewAction) {
     controller.dismiss(animated: true) {
-      self.createEventModalResult?(nil)
-      self.createEventModalResult = nil
+      // Resolve whichever result callback is active (create modal or edit modal)
+      if self.createEventModalResult != nil {
+        self.createEventModalResult?(nil)
+        self.createEventModalResult = nil
+      } else {
+        self.eventModalResult?(nil)
+        self.eventModalResult = nil
+      }
     }
   }
 

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -287,7 +287,8 @@ class EventsService {
   func showEvent(
     eventId: String,
     timestamp: Int64?,
-    completion: @escaping (Result<EKEventViewController?, CalendarError>) -> Void
+    edit: Bool = false,
+    completion: @escaping (Result<UIViewController?, CalendarError>) -> Void
   ) {
     // Check permission
     guard permissionService.hasPermission(for: .full) else {
@@ -339,13 +340,18 @@ class EventsService {
       return
     }
     
-    // Create event view controller
-    let eventViewController = EKEventViewController()
-    eventViewController.event = foundEvent
-    eventViewController.allowsEditing = true
-    eventViewController.allowsCalendarPreview = true
-    
-    completion(.success(eventViewController))
+    if edit {
+      let editViewController = EKEventEditViewController()
+      editViewController.eventStore = eventStore
+      editViewController.event = foundEvent
+      completion(.success(editViewController))
+    } else {
+      let eventViewController = EKEventViewController()
+      eventViewController.event = foundEvent
+      eventViewController.allowsEditing = true
+      eventViewController.allowsCalendarPreview = true
+      completion(.success(eventViewController))
+    }
   }
   
   func createEvent(

--- a/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
+++ b/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
@@ -121,12 +121,14 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
   }
 
   @override
-  Future<void> showEventModal(String eventId, int? timestamp) async {
+  Future<void> showEventModal(String eventId, int? timestamp,
+      {bool edit = false}) async {
     await methodChannel.invokeMethod<void>(
       'showEventModal',
       <String, dynamic>{
         'eventId': eventId,
         'timestamp': timestamp,
+        'edit': edit,
       },
     );
   }

--- a/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
+++ b/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
@@ -140,10 +140,12 @@ abstract class DeviceCalendarPlusPlatform extends PlatformInterface {
   ///
   /// [eventId] is the event identifier.
   /// [timestamp] is the occurrence timestamp in milliseconds for recurring events.
+  /// [edit] opens the native editor directly instead of the read-only view.
   ///
-  /// On iOS, presents the event in a modal using EKEventViewController.
-  /// On Android, opens the event using an Intent with ACTION_VIEW.
-  Future<void> showEventModal(String eventId, int? timestamp);
+  /// On iOS, presents EKEventViewController (view) or EKEventEditViewController (edit).
+  /// On Android, fires ACTION_VIEW or ACTION_EDIT.
+  Future<void> showEventModal(String eventId, int? timestamp,
+      {bool edit = false});
 
   /// Creates a new event in the specified calendar.
   ///

--- a/packages/device_calendar_plus_platform_interface/test/device_calendar_plus_platform_interface_test.dart
+++ b/packages/device_calendar_plus_platform_interface/test/device_calendar_plus_platform_interface_test.dart
@@ -48,7 +48,8 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
       null;
 
   @override
-  Future<void> showEventModal(String eventId, int? timestamp) async {}
+  Future<void> showEventModal(String eventId, int? timestamp,
+      {bool edit = false}) async {}
 
   @override
   Future<String> createEvent(


### PR DESCRIPTION
## Summary
- Add `edit` parameter to `showEventModal` that opens the native editor directly
- iOS: presents `EKEventEditViewController` instead of `EKEventViewController`
- Android: fires `ACTION_EDIT` instead of `ACTION_VIEW`

```dart
// Read-only view (existing behaviour)
await plugin.showEventModal(event.instanceId);

// Open editor directly
await plugin.showEventModal(event.instanceId, edit: true);
```

Closes #45

## Test plan
- [x] All unit tests pass (platform interface, plugin, mocks updated)
- [ ] Manual test on iOS device
- [ ] Manual test on Android device

🤖 Generated with [Claude Code](https://claude.com/claude-code)