### PR TITLE
chore(release): prepare 0.4.0

### DIFF
--- a/packages/device_calendar_plus/CHANGELOG.md
+++ b/packages/device_calendar_plus/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.4.0 - 2026-05-25
 
 ### Added
 - `updateRecurring()` — update a recurring event with a span choice:
@@ -9,11 +9,9 @@
   Based on @SuperKrallan (#36)
 - `deleteRecurring()` — delete part of a recurring event with a span choice:
   `EventSpan.allEvents` (whole series), `thisAndFollowing` (this occurrence
-  and every later one), or `thisInstance` (only this occurrence). Completes
-  the single-occurrence support that `updateRecurring()` started.
-  Note: `EventSpan.thisInstance` is iOS-only at the moment — Android throws
-  "not yet supported"; a follow-up will land Android support (likely via
-  EXDATE on the master rather than the exception-event path).
+  and every later one), or `thisInstance` (only this occurrence). Now
+  supported on both iOS and Android (Android uses EXDATE on the master
+  rather than a cancelled exception event).
   Based on @SuperKrallan (#43)
 - `EventSpan` enum for choosing the scope of a recurring-event operation,
   shared by `updateRecurring()` and `deleteRecurring()`
@@ -21,6 +19,8 @@
 - `edit` parameter on `showEventModal()` — when `true`, opens the native editor
   directly (`EKEventEditViewController` on iOS, `ACTION_EDIT` on Android)
   instead of the read-only viewer. Based on @xonaman (#45)
+- `Calendar.color` getter — derived Flutter `Color?` parsed from `colorHex`,
+  saving consumers from writing the same hex-parsing helper. Based on @xonaman (#46)
 
 ### Changed
 - **Breaking:** `updateEvent()` `description`, `location` and `url` now take a

--- a/packages/device_calendar_plus/README.md
+++ b/packages/device_calendar_plus/README.md
@@ -30,12 +30,14 @@ Created by [Bullet](https://bullet.to) — a personal task + notes + calendar ap
 
 - **Permissions**: Request and check calendar permissions
 - **Calendars**: Create, read, update, and delete calendars
+- **Sources/accounts**: List calendar sources (iCloud, Google, local, etc.) and target a specific account when creating calendars
 - **Events**: Create, read, update, and delete events
 - **Query**: Retrieve events by date range or specific event IDs
-- **Native UI**: Open native event modal for viewing/editing in both android and iOS
+- **Native UI**: Open native event modal for viewing or editing (`edit: true`) on both Android and iOS
 - **All-Day Events**: Proper handling of floating calendar dates
 - **Timezones**: Correct timezone behavior for timed events
-- **Recurring Events**: Create, read, and delete recurring events (daily, weekly, monthly, yearly) with full RRULE support
+- **Recurring events**: Create, read, and delete recurring events (daily, weekly, monthly, yearly) with full RRULE support
+- **Edit a recurring series**: `updateRecurring()` and `deleteRecurring()` with `EventSpan` — apply changes to the whole series, this-and-following, or just one occurrence
 
 ## 🧩 Installation
 
@@ -209,8 +211,13 @@ for (final calendar in calendars) {
   if (calendar.isPrimary) {
     print('  ⭐ Primary calendar');
   }
+  // Raw hex string (e.g. "#FF5733")
   if (calendar.colorHex != null) {
     print('  Color: ${calendar.colorHex}');
+  }
+  // Or use the parsed Flutter Color directly for theming
+  if (calendar.color != null) {
+    // e.g. Container(color: calendar.color, ...)
   }
 }
 
@@ -220,6 +227,96 @@ final writableCalendar = calendars.firstWhere(
   orElse: () => calendars.first,
 );
 ```
+
+### List Sources
+
+Sources are the accounts that own calendars (iCloud, Google, local, Exchange, etc.). Use them to discover where a new calendar can live, and to target a specific account when calling `createCalendar`.
+
+```dart
+final plugin = DeviceCalendar.instance;
+final sources = await plugin.listSources();
+
+for (final source in sources) {
+  print('${source.accountName} — ${source.type}');
+  if (source.supportsCalendarCreation) {
+    print('  ✓ can create calendars here');
+  }
+}
+
+// Pick the first source that supports creation
+final writable = sources.firstWhere((s) => s.supportsCalendarCreation);
+
+// iOS: pass the source id via CreateCalendarOptionsIos
+await plugin.createCalendar(
+  name: 'Work',
+  platformOptions: CreateCalendarOptionsIos(sourceId: writable.id),
+);
+
+// Android: pass accountName + accountType via CreateCalendarOptionsAndroid
+await plugin.createCalendar(
+  name: 'Work',
+  platformOptions: CreateCalendarOptionsAndroid(
+    accountName: writable.accountName,
+    accountType: writable.accountType,
+  ),
+);
+```
+
+> **Note on Android**: Only sources that already have at least one calendar are returned. Freshly-added accounts won't appear until their first calendar exists.
+
+### Create Calendar
+
+```dart
+final plugin = DeviceCalendar.instance;
+
+// Simplest case — picks a sensible default source on each platform
+final calendarId = await plugin.createCalendar(name: 'My Calendar');
+
+// With a color
+final colored = await plugin.createCalendar(
+  name: 'Work',
+  colorHex: '#FF5733',
+);
+
+// Target a specific account (see "List Sources" above for full example)
+final scoped = await plugin.createCalendar(
+  name: 'Project Calendar',
+  platformOptions: CreateCalendarOptionsAndroid(accountName: 'MyApp'),
+);
+```
+
+Returns the new calendar's ID. Requires write permission.
+
+### Update Calendar
+
+```dart
+final plugin = DeviceCalendar.instance;
+
+// Rename
+await plugin.updateCalendar(calendarId, name: 'New Name');
+
+// Recolor
+await plugin.updateCalendar(calendarId, colorHex: '#3366FF');
+
+// Both at once
+await plugin.updateCalendar(
+  calendarId,
+  name: 'Q3 Planning',
+  colorHex: '#3366FF',
+);
+```
+
+At least one of `name` or `colorHex` must be provided.
+
+### Delete Calendar
+
+```dart
+final plugin = DeviceCalendar.instance;
+
+await plugin.deleteCalendar(calendarId);
+```
+
+Throws `DeviceCalendarException` with `DeviceCalendarError.readOnly` if the calendar can't be deleted (e.g. a system-managed account calendar).
 
 ### Retrieve Events
 
@@ -561,7 +658,7 @@ await plugin.deleteEvent(event.instanceId);
 
 - `EventSpan.allEvents` — the whole series is deleted (the same as `deleteEvent`).
 - `EventSpan.thisAndFollowing` — the occurrence you pass, and every later one, are removed; the series is truncated to end before it.
-- `EventSpan.thisInstance` — only the occurrence you pass is removed, as a cancelled exception. **iOS only at the moment** — Android throws "not yet supported"; use `thisAndFollowing` or `allEvents` instead, or call from iOS.
+- `EventSpan.thisInstance` — only the occurrence you pass is removed. iOS records this as a cancelled exception; Android appends the occurrence timestamp to the master's `EXDATE` column.
 
 ```dart
 final plugin = DeviceCalendar.instance;
@@ -572,7 +669,7 @@ await plugin.deleteRecurring(event.instanceId, EventSpan.allEvents);
 // Delete this occurrence and every later one
 await plugin.deleteRecurring(event.instanceId, EventSpan.thisAndFollowing);
 
-// Delete only this one occurrence, leaving the rest of the series alone (iOS only)
+// Delete only this one occurrence, leaving the rest of the series alone
 await plugin.deleteRecurring(event.instanceId, EventSpan.thisInstance);
 ```
 
@@ -590,7 +687,7 @@ For `thisAndFollowing` and `thisInstance`, pass an instance ID (`event.instanceI
 - [x] **Delete recurring events** — delete a whole series, this-and-following, or a single occurrence via `deleteRecurring`
 - [ ] **Attendees** — read on both platforms; write on Android (iOS EventKit is read-only for participants)
 - [ ] **Reminders / alarms** — read/write on both platforms
-- [ ] **Platform-specific extras** — event URL, organizer, and other platform-native fields exposed where supported
+- [ ] **Platform-specific extras** — organizer and other platform-native fields exposed where supported (event URL is now supported)
 
 ## 🤝 Contributing
 

--- a/packages/device_calendar_plus/pubspec.yaml
+++ b/packages/device_calendar_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus
 description: A modern, maintained Flutter plugin for reading and writing device calendar events on Android and iOS.
-version: 0.3.5
+version: 0.4.0
 repository: https://github.com/bullet-to/device_calendar_plus
 issue_tracker: https://github.com/bullet-to/device_calendar_plus/issues
 
@@ -20,9 +20,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  device_calendar_plus_platform_interface: ^0.3.4
-  device_calendar_plus_android: ^0.3.4
-  device_calendar_plus_ios: ^0.3.4
+  device_calendar_plus_platform_interface: ^0.4.0
+  device_calendar_plus_android: ^0.4.0
+  device_calendar_plus_ios: ^0.4.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/device_calendar_plus_android/CHANGELOG.md
+++ b/packages/device_calendar_plus_android/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.4.0 - 2026-05-25
+
+### Added
+- `updateRecurring()` — series-level recurring-event edits with `EventSpan` (allEvents / thisAndFollowing / thisInstance). `thisAndFollowing` truncates the master with `UNTIL` and starts a new series; `thisInstance` writes a detached exception event.
+- `deleteRecurring()` — `allEvents` deletes the master; `thisAndFollowing` truncates via `UNTIL`; `thisInstance` appends to the master's `EXDATE` column (no separate exception event needed).
+- `url` field on events via `Events.CUSTOM_APP_URI`
+- `Patch<T>` support in `updateEvent()` — null leaves a field unchanged, `Patch.set` writes, `Patch.clear` writes the empty string to remove
+- `edit` flag on `showEvent()` — fires `Intent.ACTION_EDIT` instead of `ACTION_VIEW`
+
+### Fixed
+- Event deletion now uses sync-adapter context so EventKit-equivalent listEvents calls stop returning the deleted row immediately
+
+### Changed
+- Extracted all-day date-conversion helpers; no behaviour change
+
 ## 0.3.5 - 2026-04-20
 
 ### Fixed

--- a/packages/device_calendar_plus_android/pubspec.yaml
+++ b/packages/device_calendar_plus_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus_android
 description: Android implementation of the device_calendar_plus plugin.
-version: 0.3.5
+version: 0.4.0
 repository: https://github.com/bullet-to/device_calendar_plus
 
 resolution: workspace
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  device_calendar_plus_platform_interface: ^0.3.4
+  device_calendar_plus_platform_interface: ^0.4.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/device_calendar_plus_ios/CHANGELOG.md
+++ b/packages/device_calendar_plus_ios/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.4.0 - 2026-05-25
+
+### Added
+- `updateRecurring()` — series-level recurring-event edits with `EventSpan` (allEvents / thisAndFollowing / thisInstance), backed by `EKSpan.futureEvents` and `EKSpan.thisEvent`
+- `deleteRecurring()` — same `EventSpan` semantics on `EKEventStore.remove`
+- `url` field on events via `EKEvent.url`
+- `Patch<T>` support in `updateEvent()` — null leaves a field unchanged, `Patch.set` writes, `Patch.clear` nils the field on the `EKEvent`
+- `edit` flag on `showEvent()` — presents `EKEventEditViewController` instead of `EKEventViewController`
+
 ## 0.3.5 - 2026-04-20
 
 ### Fixed

--- a/packages/device_calendar_plus_ios/pubspec.yaml
+++ b/packages/device_calendar_plus_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus_ios
 description: iOS implementation of the device_calendar_plus plugin.
-version: 0.3.5
+version: 0.4.0
 repository: https://github.com/bullet-to/device_calendar_plus
 
 resolution: workspace
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  device_calendar_plus_platform_interface: ^0.3.4
+  device_calendar_plus_platform_interface: ^0.4.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/device_calendar_plus_platform_interface/CHANGELOG.md
+++ b/packages/device_calendar_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.4.0 - 2026-05-25
+
+### Added
+- `updateRecurring()` method with `EventSpan` enum (allEvents / thisAndFollowing / thisInstance)
+- `deleteRecurring()` method taking an `EventSpan`
+- `url` parameter on `updateEvent()`
+- `edit` parameter on `showEventModal()`
+- `Patch<T>` sealed type (`Patch.set` / `Patch.clear`) for clearable optional fields
+
+### Changed
+- **Breaking:** `updateEvent()` `description`, `location`, and `url` now take `Patch<String>` instead of `String?`
+
 ## 0.3.5 - 2026-04-20
 
 Version sync with other packages. No functional changes.

--- a/packages/device_calendar_plus_platform_interface/pubspec.yaml
+++ b/packages/device_calendar_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus_platform_interface
 description: Platform interface for device_calendar_plus plugin.
-version: 0.3.5
+version: 0.4.0
 repository: https://github.com/bullet-to/device_calendar_plus
 
 resolution: workspace

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   charcode:
     dependency: transitive
     description:
@@ -238,18 +238,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   melos:
     dependency: "direct dev"
     description:
@@ -403,10 +403,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   typed_data:
     dependency: transitive
     description:
@@ -464,5 +464,5 @@ packages:
     source: hosted
     version: "2.2.2"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
## Summary
- Bumps all four packages to **0.4.0** (main, platform_interface, android, ios)
- Tightens inter-package constraints to `^0.4.0` — this fixes the **downgrade-analysis** failures on pub.dev (`listSources` undefined, `Patch<String>` type mismatch, `updateEvent` arity) caused by the published 0.3.5 main package depending on `^0.3.4` of platform_interface
- Promotes the main CHANGELOG `Unreleased` section to `0.4.0 - 2026-05-25`, adds the missing `Calendar.color` entry, drops the iOS-only caveat on `deleteRecurring(thisInstance)` (now supported on Android via EXDATE)
- Writes proper `0.4.0` CHANGELOG entries for platform_interface, android, and ios — none of them had unreleased content tracked
- README audit: adds **List Sources** and **Create/Update/Delete Calendar** sections (calendar-level CRUD was undocumented despite shipping pre-0.4.0); surfaces `Calendar.color`; lists `updateRecurring`/`deleteRecurring` in the Features and ticks Delete recurring fully on the Roadmap

## Notable in 0.4.0
- **Breaking**: `updateEvent()` `description`, `location`, `url` now take `Patch<String>` instead of `String?`
- `updateRecurring()` + `deleteRecurring()` with `EventSpan`
- `Calendar.color` getter
- `edit` flag on `showEventModal()`
- `url` parameter on `updateEvent()`
- Android `deleteRecurring(thisInstance)` now supported (via EXDATE on the master)

## Test plan
- [x] `flutter analyze` clean across workspace (no new issues)
- [x] All unit tests pass (181 across 4 packages)
- [ ] Manually verify `flutter pub publish --dry-run` reports no errors before publishing
- [ ] Publish order after merge: platform_interface -> android + ios -> main (so resolution always finds the floor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)