### PR TITLE
chore(example): commit iOS example Podfile + xcconfig CocoaPods includes

### DIFF
--- a/packages/device_calendar_plus/example/ios/Flutter/Debug.xcconfig
+++ b/packages/device_calendar_plus/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/device_calendar_plus/example/ios/Flutter/Release.xcconfig
+++ b/packages/device_calendar_plus/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/packages/device_calendar_plus/example/ios/Podfile
+++ b/packages/device_calendar_plus/example/ios/Podfile
@@ -1,0 +1,43 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '13.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+  target 'RunnerTests' do
+    inherit! :search_paths
+  end
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end


### PR DESCRIPTION
## Summary

The example app's iOS Podfile was never committed (43-line standard Flutter Podfile that defines Pod dependencies), and the Debug/Release xcconfigs were missing the `#include?` directive for the Pods-Runner xcconfigs that CocoaPods injects when you run `pod install`. Without these, anyone cloning the repo can't build the iOS example.

`Pods/` stays gitignored as it's regenerable from the Podfile.

## Test plan
- [ ] `cd packages/device_calendar_plus/example/ios && pod install` regenerates Pods/ successfully
- [ ] Example app builds on iOS