### PR TITLE
chore(release): 0.5.1

### DIFF
--- a/packages/device_calendar_plus/CHANGELOG.md
+++ b/packages/device_calendar_plus/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.5.1 - 2026-06-15
+
+### Fixed
+- iOS: `showEventModal(edit: true)` no longer crashes (#77) — see the
+  `device_calendar_plus_ios` 0.5.1 changelog
+
+### Docs
+- Clarified `showEventModal` docs: the view modal (`edit: false`) is **not**
+  read-only — on both iOS and Android the native screen lets the user edit the
+  event, and those edits are saved directly by the OS
+
 ## 0.5.0 - 2026-06-11
 
 ### Changed

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -505,18 +505,26 @@ class DeviceCalendar {
   /// - **Event ID**: Shows the master event definition (for recurring events)
   /// - **Instance ID**: Shows a specific occurrence (for recurring events)
   ///
-  /// When [edit] is `true`, opens the native editor directly instead of the
-  /// read-only view. Useful when the user has already expressed intent to edit.
+  /// When [edit] is `true`, opens the native editor directly. When `false`
+  /// (the default), opens the native view screen — but note this is **not
+  /// read-only**: on both platforms the native screen exposes an Edit affordance
+  /// that lets the user modify the event from there. `edit` only controls
+  /// whether the modal *starts* in the editor; it cannot prevent editing.
+  ///
+  /// Either way, edits made by the user are saved to the device calendar
+  /// directly by the OS. This method completes when the modal is dismissed and
+  /// does not report back whether (or what) the user changed.
   ///
   /// **Platform Differences:**
-  /// - **iOS**: Presents `EKEventViewController` (view) or
+  /// - **iOS**: Presents `EKEventViewController` (view, with `allowsEditing`) or
   ///   `EKEventEditViewController` (edit) in a native modal.
-  /// - **Android**: Fires `ACTION_VIEW` or `ACTION_EDIT`.
+  /// - **Android**: Fires `ACTION_VIEW` or `ACTION_EDIT`; the system calendar
+  ///   app renders the screen, and its view screen offers an edit button.
   ///
   /// Example:
   /// ```dart
   /// final plugin = DeviceCalendar.instance;
-  /// // View an event (read-only, user can tap Edit)
+  /// // Open the view screen (the user can still tap Edit from here)
   /// await plugin.showEventModal(event.instanceId);
   ///
   /// // Open directly in the editor

--- a/packages/device_calendar_plus/pubspec.yaml
+++ b/packages/device_calendar_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus
 description: A modern, maintained Flutter plugin for reading and writing device calendar events on Android and iOS.
-version: 0.5.0
+version: 0.5.1
 repository: https://github.com/bullet-to/device_calendar_plus
 issue_tracker: https://github.com/bullet-to/device_calendar_plus/issues
 
@@ -20,9 +20,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  device_calendar_plus_platform_interface: ^0.5.0
-  device_calendar_plus_android: ^0.5.0
-  device_calendar_plus_ios: ^0.5.0
+  device_calendar_plus_platform_interface: ^0.5.1
+  device_calendar_plus_android: ^0.5.1
+  device_calendar_plus_ios: ^0.5.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/device_calendar_plus_android/CHANGELOG.md
+++ b/packages/device_calendar_plus_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.1 - 2026-06-15
+
+- No functional changes; version aligned with the rest of the suite for the
+  0.5.1 release
+
 ## 0.5.0 - 2026-06-11
 
 ### Changed

--- a/packages/device_calendar_plus_android/pubspec.yaml
+++ b/packages/device_calendar_plus_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus_android
 description: Android implementation of the device_calendar_plus plugin.
-version: 0.5.0
+version: 0.5.1
 repository: https://github.com/bullet-to/device_calendar_plus
 
 resolution: workspace
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  device_calendar_plus_platform_interface: ^0.5.0
+  device_calendar_plus_platform_interface: ^0.5.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/device_calendar_plus_ios/CHANGELOG.md
+++ b/packages/device_calendar_plus_ios/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.5.1 - 2026-06-15
+
+### Fixed
+- `showEventModal(edit: true)` no longer crashes with `NSInvalidArgumentException`
+  ("Pushing a navigation controller is not supported"). `EKEventEditViewController`
+  is a `UINavigationController` subclass and is now presented directly instead of
+  being wrapped in another navigation controller (#77)
+
 ## 0.5.0 - 2026-06-11
 
 ### Changed

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
@@ -376,10 +376,18 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
 
             self.eventModalResult = result
 
-            let navigationController = UINavigationController(rootViewController: viewController)
-            navigationController.modalPresentationStyle = .pageSheet
+            // EKEventEditViewController is itself a UINavigationController subclass,
+            // so present it directly. EKEventViewController needs wrapping in a
+            // navigation controller for its action buttons and dismissal to work.
+            let presentedViewController: UIViewController
+            if let navigationController = viewController as? UINavigationController {
+              presentedViewController = navigationController
+            } else {
+              presentedViewController = UINavigationController(rootViewController: viewController)
+            }
+            presentedViewController.modalPresentationStyle = .pageSheet
 
-            rootViewController.present(navigationController, animated: true, completion: nil)
+            rootViewController.present(presentedViewController, animated: true, completion: nil)
           } else {
             result(nil)
           }

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -352,6 +352,8 @@ class EventsService {
     } else {
       let eventViewController = EKEventViewController()
       eventViewController.event = foundEvent
+      // Keep the Edit button: Android's ACTION_VIEW screen also lets the user
+      // edit from the view, so allowing it here preserves cross-platform parity.
       eventViewController.allowsEditing = true
       eventViewController.allowsCalendarPreview = true
       completion(.success(eventViewController))

--- a/packages/device_calendar_plus_ios/pubspec.yaml
+++ b/packages/device_calendar_plus_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus_ios
 description: iOS implementation of the device_calendar_plus plugin.
-version: 0.5.0
+version: 0.5.1
 repository: https://github.com/bullet-to/device_calendar_plus
 
 resolution: workspace
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  device_calendar_plus_platform_interface: ^0.5.0
+  device_calendar_plus_platform_interface: ^0.5.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/device_calendar_plus_platform_interface/CHANGELOG.md
+++ b/packages/device_calendar_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.5.1 - 2026-06-15
+
+### Docs
+- Clarified `showEventModal` docs: the `edit` flag only sets the modal's
+  starting mode; the native view screen still lets the user edit on both
+  platforms
+
 ## 0.5.0 - 2026-06-11
 
 ### Changed

--- a/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
+++ b/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
@@ -142,7 +142,9 @@ abstract class DeviceCalendarPlusPlatform extends PlatformInterface {
   ///
   /// [eventId] is the event identifier.
   /// [timestamp] is the occurrence timestamp in milliseconds for recurring events.
-  /// [edit] opens the native editor directly instead of the read-only view.
+  /// [edit] opens the native editor directly. When `false`, opens the native
+  /// view screen, which is still not read-only: on both platforms the user can
+  /// edit the event from there. `edit` only controls the modal's starting mode.
   ///
   /// On iOS, presents EKEventViewController (view) or EKEventEditViewController (edit).
   /// On Android, fires ACTION_VIEW or ACTION_EDIT.

--- a/packages/device_calendar_plus_platform_interface/pubspec.yaml
+++ b/packages/device_calendar_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus_platform_interface
 description: Platform interface for device_calendar_plus plugin.
-version: 0.5.0
+version: 0.5.1
 repository: https://github.com/bullet-to/device_calendar_plus
 
 resolution: workspace


### PR DESCRIPTION
Patch release. Fixes the iOS crash in #77 plus a docs cleanup.

## What's in it
- **iOS crash fix (#77):** `showEventModal(edit: true)` crashed with `NSInvalidArgumentException` ("Pushing a navigation controller is not supported"). `EKEventEditViewController` is itself a `UINavigationController` subclass, and we were wrapping it in another nav controller. Now presented directly; plain `EKEventViewController` still gets wrapped.
- **Docs:** clarified `showEventModal` — `edit: false` is *not* read-only. On both iOS and Android the native view screen lets the user edit, and edits are saved by the OS. Android (`ACTION_VIEW`) and iOS (`allowsEditing`) behave the same here, so no behavior change.
- All 4 packages bumped 0.5.0 → 0.5.1 in lockstep + changelogs.

## Notes
- Android needed no code change — `ACTION_EDIT` vs `ACTION_VIEW` was already correct.
- The iOS crash fix is native UI; couldn't exercise it in CI. Worth a quick simulator check (open a modal with `edit: true` → no crash) before publishing to pub.dev.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)