### PR TITLE
fix(ios): run EventKit work off the main thread

### DIFF
--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
@@ -15,10 +15,13 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
   /// calling thread (listEvents fans out across the store, create/update/delete
   /// touch the calendar database), and method-channel handlers run on the main
   /// thread, so query-heavy calls jank the UI there (#181). A single serial
-  /// queue keeps operations in call order, serializes EKEventStore access, and
-  /// mirrors the Android plugin's single-thread provider executor. Permission
-  /// and modal handlers stay on the main thread — they're light and must touch
-  /// UIKit.
+  /// queue keeps the data operations in call order and serializes them against
+  /// each other, mirroring the Android plugin's single-thread provider
+  /// executor. The permission and modal handlers deliberately stay on the main
+  /// thread — they're light and must touch UIKit — so the `eventStore` they
+  /// reach is not serialized against this queue. That's the same boundary
+  /// Android draws; in practice those paths are user-driven and don't overlap a
+  /// bulk data operation.
   private let providerQueue = DispatchQueue(label: "to.bullet.device_calendar_plus.provider")
 
   public static func register(with registrar: FlutterPluginRegistrar) {
@@ -67,7 +70,50 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
       result(FlutterMethodNotImplemented)
     }
   }
-  
+
+  /// Runs an EventKit service call on the serial provider queue (off the main
+  /// thread — see `providerQueue`) and delivers its Result back on the main
+  /// thread, mapping `CalendarError` to `FlutterError`. Callers parse and
+  /// validate arguments on the main thread first, then hand the service call
+  /// here so the threading contract lives in exactly one place.
+  private func runOnProvider<T>(
+    _ result: @escaping FlutterResult,
+    _ work: @escaping (@escaping (Result<T, CalendarError>) -> Void) -> Void
+  ) {
+    providerQueue.async {
+      work { serviceResult in
+        DispatchQueue.main.async {
+          switch serviceResult {
+          case .success(let value):
+            result(value)
+          case .failure(let error):
+            result(FlutterError(code: error.code, message: error.message, details: nil))
+          }
+        }
+      }
+    }
+  }
+
+  /// `Void`-success overload of `runOnProvider`. Swift resolves to this for
+  /// `Result<Void, CalendarError>` service calls, replying `nil` on success.
+  private func runOnProvider(
+    _ result: @escaping FlutterResult,
+    _ work: @escaping (@escaping (Result<Void, CalendarError>) -> Void) -> Void
+  ) {
+    providerQueue.async {
+      work { serviceResult in
+        DispatchQueue.main.async {
+          switch serviceResult {
+          case .success:
+            result(nil)
+          case .failure(let error):
+            result(FlutterError(code: error.code, message: error.message, details: nil))
+          }
+        }
+      }
+    }
+  }
+
   private func handleRequestPermissions(result: @escaping FlutterResult) {
     permissionService.requestPermissions { serviceResult in
       DispatchQueue.main.async {
@@ -123,33 +169,11 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
   }
   
   private func handleListCalendars(result: @escaping FlutterResult) {
-    providerQueue.async {
-      self.calendarService.listCalendars { serviceResult in
-        DispatchQueue.main.async {
-          switch serviceResult {
-          case .success(let calendars):
-            result(calendars)
-          case .failure(let error):
-            result(FlutterError(code: error.code, message: error.message, details: nil))
-          }
-        }
-      }
-    }
+    runOnProvider(result) { self.calendarService.listCalendars(completion: $0) }
   }
 
   private func handleListSources(result: @escaping FlutterResult) {
-    providerQueue.async {
-      self.calendarService.listSources { serviceResult in
-        DispatchQueue.main.async {
-          switch serviceResult {
-          case .success(let sources):
-            result(sources)
-          case .failure(let error):
-            result(FlutterError(code: error.code, message: error.message, details: nil))
-          }
-        }
-      }
-    }
+    runOnProvider(result) { self.calendarService.listSources(completion: $0) }
   }
 
   private func handleCreateCalendar(call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -178,17 +202,9 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     // Parse sourceId (optional — if nil, uses tiered fallback)
     let sourceId = args["sourceId"] as? String
 
-    providerQueue.async {
-      self.calendarService.createCalendar(name: name, colorHex: colorHex, sourceId: sourceId) { serviceResult in
-        DispatchQueue.main.async {
-          switch serviceResult {
-          case .success(let calendarId):
-            result(calendarId)
-          case .failure(let error):
-            result(FlutterError(code: error.code, message: error.message, details: nil))
-          }
-        }
-      }
+    runOnProvider(result) {
+      self.calendarService.createCalendar(
+        name: name, colorHex: colorHex, sourceId: sourceId, completion: $0)
     }
   }
   
@@ -218,17 +234,9 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     // Parse colorHex (optional)
     let colorHex = args["colorHex"] as? String
     
-    providerQueue.async {
-      self.calendarService.updateCalendar(calendarId: calendarId, name: name, colorHex: colorHex) { serviceResult in
-        DispatchQueue.main.async {
-          switch serviceResult {
-          case .success:
-            result(nil)
-          case .failure(let error):
-            result(FlutterError(code: error.code, message: error.message, details: nil))
-          }
-        }
-      }
+    runOnProvider(result) {
+      self.calendarService.updateCalendar(
+        calendarId: calendarId, name: name, colorHex: colorHex, completion: $0)
     }
   }
   
@@ -252,17 +260,8 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
       return
     }
     
-    providerQueue.async {
-      self.calendarService.deleteCalendar(calendarId: calendarId) { serviceResult in
-        DispatchQueue.main.async {
-          switch serviceResult {
-          case .success:
-            result(nil)
-          case .failure(let error):
-            result(FlutterError(code: error.code, message: error.message, details: nil))
-          }
-        }
-      }
+    runOnProvider(result) {
+      self.calendarService.deleteCalendar(calendarId: calendarId, completion: $0)
     }
   }
   
@@ -303,21 +302,9 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     // Parse calendar IDs (optional)
     let calendarIds = args["calendarIds"] as? [String]
     
-    providerQueue.async {
+    runOnProvider(result) {
       self.eventsService.retrieveEvents(
-        startDate: startDate,
-        endDate: endDate,
-        calendarIds: calendarIds
-      ) { serviceResult in
-        DispatchQueue.main.async {
-          switch serviceResult {
-          case .success(let events):
-            result(events)
-          case .failure(let error):
-            result(FlutterError(code: error.code, message: error.message, details: nil))
-          }
-        }
-      }
+        startDate: startDate, endDate: endDate, calendarIds: calendarIds, completion: $0)
     }
   }
   
@@ -344,17 +331,8 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     // Parse timestamp (optional, for recurring events)
     let timestamp = args["timestamp"] as? Int64
     
-    providerQueue.async {
-      self.eventsService.getEvent(eventId: eventId, timestamp: timestamp) { serviceResult in
-        DispatchQueue.main.async {
-          switch serviceResult {
-          case .success(let event):
-            result(event)
-          case .failure(let error):
-            result(FlutterError(code: error.code, message: error.message, details: nil))
-          }
-        }
-      }
+    runOnProvider(result) {
+      self.eventsService.getEvent(eventId: eventId, timestamp: timestamp, completion: $0)
     }
   }
   
@@ -493,7 +471,7 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     let startDate = Date(timeIntervalSince1970: TimeInterval(startDateMillis) / 1000.0)
     let endDate = Date(timeIntervalSince1970: TimeInterval(endDateMillis) / 1000.0)
 
-    providerQueue.async {
+    runOnProvider(result) {
       self.eventsService.createEvent(
         calendarId: calendarId,
         title: title,
@@ -505,17 +483,8 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
         url: url,
         timeZone: timeZone,
         availability: availability,
-        recurrenceRule: recurrenceRule
-      ) { serviceResult in
-        DispatchQueue.main.async {
-          switch serviceResult {
-          case .success(let eventId):
-            result(eventId)
-          case .failure(let error):
-            result(FlutterError(code: error.code, message: error.message, details: nil))
-          }
-        }
-      }
+        recurrenceRule: recurrenceRule,
+        completion: $0)
     }
   }
   
@@ -541,20 +510,8 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     
     let timestamp = args["timestamp"] as? Int64
 
-    providerQueue.async {
-      self.eventsService.deleteEvent(
-        eventId: eventId,
-        timestamp: timestamp
-      ) { serviceResult in
-        DispatchQueue.main.async {
-          switch serviceResult {
-          case .success:
-            result(nil)
-          case .failure(let error):
-            result(FlutterError(code: error.code, message: error.message, details: nil))
-          }
-        }
-      }
+    runOnProvider(result) {
+      self.eventsService.deleteEvent(eventId: eventId, timestamp: timestamp, completion: $0)
     }
   }
   
@@ -588,23 +545,14 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     }
 
     let patch = EventFieldPatch(args: args)
-    providerQueue.async {
+    runOnProvider(result) {
       self.eventsService.updateEvent(
         eventId: eventId,
         timestamp: timestamp,
         startDate: startDate,
         endDate: endDate,
-        patch: patch
-      ) { serviceResult in
-        DispatchQueue.main.async {
-          switch serviceResult {
-          case .success:
-            result(nil)
-          case .failure(let error):
-            result(FlutterError(code: error.code, message: error.message, details: nil))
-          }
-        }
-      }
+        patch: patch,
+        completion: $0)
     }
   }
   
@@ -645,7 +593,7 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     let recurrenceRule = args["recurrenceRule"] as? String
 
     let patch = EventFieldPatch(args: args)
-    providerQueue.async {
+    runOnProvider(result) {
       self.eventsService.updateRecurring(
         eventId: eventId,
         timestamp: timestamp,
@@ -653,17 +601,8 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
         startMinuteOfDay: startMinuteOfDay,
         durationMinutes: durationMinutes,
         recurrenceRule: recurrenceRule,
-        patch: patch
-      ) { serviceResult in
-        DispatchQueue.main.async {
-          switch serviceResult {
-          case .success(let affectedEventId):
-            result(affectedEventId)
-          case .failure(let error):
-            result(FlutterError(code: error.code, message: error.message, details: nil))
-          }
-        }
-      }
+        patch: patch,
+        completion: $0)
     }
   }
 
@@ -699,21 +638,9 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
 
     let timestamp = args["timestamp"] as? Int64
 
-    providerQueue.async {
+    runOnProvider(result) {
       self.eventsService.deleteRecurring(
-        eventId: eventId,
-        timestamp: timestamp,
-        span: span
-      ) { serviceResult in
-        DispatchQueue.main.async {
-          switch serviceResult {
-          case .success:
-            result(nil)
-          case .failure(let error):
-            result(FlutterError(code: error.code, message: error.message, details: nil))
-          }
-        }
-      }
+        eventId: eventId, timestamp: timestamp, span: span, completion: $0)
     }
   }
 

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
@@ -10,7 +10,17 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
   private lazy var eventsService = EventsService(eventStore: eventStore, permissionService: permissionService)
   private var eventModalResult: FlutterResult?
   private var createEventModalResult: FlutterResult?
-  
+
+  /// Serial queue for EventKit data operations. EventKit calls block the
+  /// calling thread (listEvents fans out across the store, create/update/delete
+  /// touch the calendar database), and method-channel handlers run on the main
+  /// thread, so query-heavy calls jank the UI there (#181). A single serial
+  /// queue keeps operations in call order, serializes EKEventStore access, and
+  /// mirrors the Android plugin's single-thread provider executor. Permission
+  /// and modal handlers stay on the main thread — they're light and must touch
+  /// UIKit.
+  private let providerQueue = DispatchQueue(label: "to.bullet.device_calendar_plus.provider")
+
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "device_calendar_plus_ios", binaryMessenger: registrar.messenger())
     let instance = DeviceCalendarPlusIosPlugin()
@@ -113,26 +123,30 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
   }
   
   private func handleListCalendars(result: @escaping FlutterResult) {
-    calendarService.listCalendars { serviceResult in
-      DispatchQueue.main.async {
-        switch serviceResult {
-        case .success(let calendars):
-          result(calendars)
-        case .failure(let error):
-          result(FlutterError(code: error.code, message: error.message, details: nil))
+    providerQueue.async {
+      self.calendarService.listCalendars { serviceResult in
+        DispatchQueue.main.async {
+          switch serviceResult {
+          case .success(let calendars):
+            result(calendars)
+          case .failure(let error):
+            result(FlutterError(code: error.code, message: error.message, details: nil))
+          }
         }
       }
     }
   }
-  
+
   private func handleListSources(result: @escaping FlutterResult) {
-    calendarService.listSources { serviceResult in
-      DispatchQueue.main.async {
-        switch serviceResult {
-        case .success(let sources):
-          result(sources)
-        case .failure(let error):
-          result(FlutterError(code: error.code, message: error.message, details: nil))
+    providerQueue.async {
+      self.calendarService.listSources { serviceResult in
+        DispatchQueue.main.async {
+          switch serviceResult {
+          case .success(let sources):
+            result(sources)
+          case .failure(let error):
+            result(FlutterError(code: error.code, message: error.message, details: nil))
+          }
         }
       }
     }
@@ -164,13 +178,15 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     // Parse sourceId (optional — if nil, uses tiered fallback)
     let sourceId = args["sourceId"] as? String
 
-    calendarService.createCalendar(name: name, colorHex: colorHex, sourceId: sourceId) { serviceResult in
-      DispatchQueue.main.async {
-        switch serviceResult {
-        case .success(let calendarId):
-          result(calendarId)
-        case .failure(let error):
-          result(FlutterError(code: error.code, message: error.message, details: nil))
+    providerQueue.async {
+      self.calendarService.createCalendar(name: name, colorHex: colorHex, sourceId: sourceId) { serviceResult in
+        DispatchQueue.main.async {
+          switch serviceResult {
+          case .success(let calendarId):
+            result(calendarId)
+          case .failure(let error):
+            result(FlutterError(code: error.code, message: error.message, details: nil))
+          }
         }
       }
     }
@@ -202,13 +218,15 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     // Parse colorHex (optional)
     let colorHex = args["colorHex"] as? String
     
-    calendarService.updateCalendar(calendarId: calendarId, name: name, colorHex: colorHex) { serviceResult in
-      DispatchQueue.main.async {
-        switch serviceResult {
-        case .success:
-          result(nil)
-        case .failure(let error):
-          result(FlutterError(code: error.code, message: error.message, details: nil))
+    providerQueue.async {
+      self.calendarService.updateCalendar(calendarId: calendarId, name: name, colorHex: colorHex) { serviceResult in
+        DispatchQueue.main.async {
+          switch serviceResult {
+          case .success:
+            result(nil)
+          case .failure(let error):
+            result(FlutterError(code: error.code, message: error.message, details: nil))
+          }
         }
       }
     }
@@ -234,13 +252,15 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
       return
     }
     
-    calendarService.deleteCalendar(calendarId: calendarId) { serviceResult in
-      DispatchQueue.main.async {
-        switch serviceResult {
-        case .success:
-          result(nil)
-        case .failure(let error):
-          result(FlutterError(code: error.code, message: error.message, details: nil))
+    providerQueue.async {
+      self.calendarService.deleteCalendar(calendarId: calendarId) { serviceResult in
+        DispatchQueue.main.async {
+          switch serviceResult {
+          case .success:
+            result(nil)
+          case .failure(let error):
+            result(FlutterError(code: error.code, message: error.message, details: nil))
+          }
         }
       }
     }
@@ -283,17 +303,19 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     // Parse calendar IDs (optional)
     let calendarIds = args["calendarIds"] as? [String]
     
-    eventsService.retrieveEvents(
-      startDate: startDate,
-      endDate: endDate,
-      calendarIds: calendarIds
-    ) { serviceResult in
-      DispatchQueue.main.async {
-        switch serviceResult {
-        case .success(let events):
-          result(events)
-        case .failure(let error):
-          result(FlutterError(code: error.code, message: error.message, details: nil))
+    providerQueue.async {
+      self.eventsService.retrieveEvents(
+        startDate: startDate,
+        endDate: endDate,
+        calendarIds: calendarIds
+      ) { serviceResult in
+        DispatchQueue.main.async {
+          switch serviceResult {
+          case .success(let events):
+            result(events)
+          case .failure(let error):
+            result(FlutterError(code: error.code, message: error.message, details: nil))
+          }
         }
       }
     }
@@ -322,13 +344,15 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     // Parse timestamp (optional, for recurring events)
     let timestamp = args["timestamp"] as? Int64
     
-    eventsService.getEvent(eventId: eventId, timestamp: timestamp) { serviceResult in
-      DispatchQueue.main.async {
-        switch serviceResult {
-        case .success(let event):
-          result(event)
-        case .failure(let error):
-          result(FlutterError(code: error.code, message: error.message, details: nil))
+    providerQueue.async {
+      self.eventsService.getEvent(eventId: eventId, timestamp: timestamp) { serviceResult in
+        DispatchQueue.main.async {
+          switch serviceResult {
+          case .success(let event):
+            result(event)
+          case .failure(let error):
+            result(FlutterError(code: error.code, message: error.message, details: nil))
+          }
         }
       }
     }
@@ -469,25 +493,27 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     let startDate = Date(timeIntervalSince1970: TimeInterval(startDateMillis) / 1000.0)
     let endDate = Date(timeIntervalSince1970: TimeInterval(endDateMillis) / 1000.0)
 
-    eventsService.createEvent(
-      calendarId: calendarId,
-      title: title,
-      startDate: startDate,
-      endDate: endDate,
-      isAllDay: isAllDay,
-      description: description,
-      location: location,
-      url: url,
-      timeZone: timeZone,
-      availability: availability,
-      recurrenceRule: recurrenceRule
-    ) { serviceResult in
-      DispatchQueue.main.async {
-        switch serviceResult {
-        case .success(let eventId):
-          result(eventId)
-        case .failure(let error):
-          result(FlutterError(code: error.code, message: error.message, details: nil))
+    providerQueue.async {
+      self.eventsService.createEvent(
+        calendarId: calendarId,
+        title: title,
+        startDate: startDate,
+        endDate: endDate,
+        isAllDay: isAllDay,
+        description: description,
+        location: location,
+        url: url,
+        timeZone: timeZone,
+        availability: availability,
+        recurrenceRule: recurrenceRule
+      ) { serviceResult in
+        DispatchQueue.main.async {
+          switch serviceResult {
+          case .success(let eventId):
+            result(eventId)
+          case .failure(let error):
+            result(FlutterError(code: error.code, message: error.message, details: nil))
+          }
         }
       }
     }
@@ -515,16 +541,18 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     
     let timestamp = args["timestamp"] as? Int64
 
-    eventsService.deleteEvent(
-      eventId: eventId,
-      timestamp: timestamp
-    ) { serviceResult in
-      DispatchQueue.main.async {
-        switch serviceResult {
-        case .success:
-          result(nil)
-        case .failure(let error):
-          result(FlutterError(code: error.code, message: error.message, details: nil))
+    providerQueue.async {
+      self.eventsService.deleteEvent(
+        eventId: eventId,
+        timestamp: timestamp
+      ) { serviceResult in
+        DispatchQueue.main.async {
+          switch serviceResult {
+          case .success:
+            result(nil)
+          case .failure(let error):
+            result(FlutterError(code: error.code, message: error.message, details: nil))
+          }
         }
       }
     }
@@ -559,19 +587,22 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
       Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
     }
 
-    eventsService.updateEvent(
-      eventId: eventId,
-      timestamp: timestamp,
-      startDate: startDate,
-      endDate: endDate,
-      patch: EventFieldPatch(args: args)
-    ) { serviceResult in
-      DispatchQueue.main.async {
-        switch serviceResult {
-        case .success:
-          result(nil)
-        case .failure(let error):
-          result(FlutterError(code: error.code, message: error.message, details: nil))
+    let patch = EventFieldPatch(args: args)
+    providerQueue.async {
+      self.eventsService.updateEvent(
+        eventId: eventId,
+        timestamp: timestamp,
+        startDate: startDate,
+        endDate: endDate,
+        patch: patch
+      ) { serviceResult in
+        DispatchQueue.main.async {
+          switch serviceResult {
+          case .success:
+            result(nil)
+          case .failure(let error):
+            result(FlutterError(code: error.code, message: error.message, details: nil))
+          }
         }
       }
     }
@@ -613,21 +644,24 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     let durationMinutes = args["durationMinutes"] as? Int
     let recurrenceRule = args["recurrenceRule"] as? String
 
-    eventsService.updateRecurring(
-      eventId: eventId,
-      timestamp: timestamp,
-      span: span,
-      startMinuteOfDay: startMinuteOfDay,
-      durationMinutes: durationMinutes,
-      recurrenceRule: recurrenceRule,
-      patch: EventFieldPatch(args: args)
-    ) { serviceResult in
-      DispatchQueue.main.async {
-        switch serviceResult {
-        case .success(let affectedEventId):
-          result(affectedEventId)
-        case .failure(let error):
-          result(FlutterError(code: error.code, message: error.message, details: nil))
+    let patch = EventFieldPatch(args: args)
+    providerQueue.async {
+      self.eventsService.updateRecurring(
+        eventId: eventId,
+        timestamp: timestamp,
+        span: span,
+        startMinuteOfDay: startMinuteOfDay,
+        durationMinutes: durationMinutes,
+        recurrenceRule: recurrenceRule,
+        patch: patch
+      ) { serviceResult in
+        DispatchQueue.main.async {
+          switch serviceResult {
+          case .success(let affectedEventId):
+            result(affectedEventId)
+          case .failure(let error):
+            result(FlutterError(code: error.code, message: error.message, details: nil))
+          }
         }
       }
     }
@@ -665,17 +699,19 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
 
     let timestamp = args["timestamp"] as? Int64
 
-    eventsService.deleteRecurring(
-      eventId: eventId,
-      timestamp: timestamp,
-      span: span
-    ) { serviceResult in
-      DispatchQueue.main.async {
-        switch serviceResult {
-        case .success:
-          result(nil)
-        case .failure(let error):
-          result(FlutterError(code: error.code, message: error.message, details: nil))
+    providerQueue.async {
+      self.eventsService.deleteRecurring(
+        eventId: eventId,
+        timestamp: timestamp,
+        span: span
+      ) { serviceResult in
+        DispatchQueue.main.async {
+          switch serviceResult {
+          case .success:
+            result(nil)
+          case .failure(let error):
+            result(FlutterError(code: error.code, message: error.message, details: nil))
+          }
         }
       }
     }


### PR DESCRIPTION
iOS was doing all its EventKit work on the main thread. The `DispatchQueue.main.async` in each handler looked like threading, but it only marshalled the *reply* — the actual query/write ran inline on whatever thread called it (the platform/main thread). So a wide-range `listEvents` or a bulk create/update loop would jank the UI. This is the long-standing builttoroam/device_calendar#181.

Android already solved this with its single-thread provider executor (`runOffMainThread`). This brings iOS in line.

## What changed
Added a serial `providerQueue` and routed the 12 data ops through it — list/create/update/delete calendars, `listEvents`, `getEvent`, create/delete/update event, update/deleteRecurring. Each handler still parses + validates args on main (cheap, keeps early-return errors synchronous), then dispatches the EventKit call to the background queue; the existing `DispatchQueue.main.async` hops the result back.

Serial, not concurrent — preserves call order and serializes `EKEventStore` access (EventKit objects aren't thread-safe), exactly like Android's executor.

Permissions and the two modal handlers (`showEventModal`/`showCreateEventModal`) stay on main — they're light and have to touch UIKit. Same split Android uses.

## Testing
Full iOS integration suite green on simulator (67 passed, 4 pre-existing skips) — covers the full Dart → channel → EventKit roundtrip on every rerouted path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)