### PR TITLE
fix: accept negative BYMONTHDAY (last-day-of-month) recurrence

### DIFF
--- a/packages/device_calendar_plus/lib/src/recurrence_rule.dart
+++ b/packages/device_calendar_plus/lib/src/recurrence_rule.dart
@@ -307,7 +307,10 @@ sealed class MonthlyRecurrence extends RecurrenceRule {
 
 /// Monthly recurrence on specific days of the month (BYMONTHDAY).
 class MonthlyByDate extends MonthlyRecurrence {
-  /// Days of the month (1-31) on which the event recurs.
+  /// Days of the month on which the event recurs.
+  ///
+  /// Per RFC 5545, values are 1..31 or -31..-1 (negative counts back from the
+  /// end of the month, so -1 is the last day). 0 is invalid.
   ///
   /// If null, the event recurs on the same day as the start date.
   final List<int>? daysOfMonth;
@@ -319,8 +322,9 @@ class MonthlyByDate extends MonthlyRecurrence {
     super.end,
     super.rawRrule,
   })  : assert(
-          daysOfMonth == null || daysOfMonth.every((d) => d >= 1 && d <= 31),
-          'daysOfMonth values must be between 1 and 31',
+          daysOfMonth == null ||
+              daysOfMonth.every((d) => d >= -31 && d <= 31 && d != 0),
+          'daysOfMonth values must be between -31 and 31, excluding 0',
         ),
         super._();
 
@@ -465,7 +469,9 @@ class YearlyByDate extends YearlyRecurrence {
   /// Months of the year (1-12). If null, uses the event's start date month.
   final List<int>? months;
 
-  /// Days of the month (1-31). If null, uses the event's start date day.
+  /// Days of the month. Per RFC 5545, values are 1..31 or -31..-1 (negative
+  /// counts back from the end of the month, so -1 is the last day); 0 is
+  /// invalid. If null, uses the event's start date day.
   final List<int>? daysOfMonth;
 
   YearlyByDate({
@@ -480,8 +486,9 @@ class YearlyByDate extends YearlyRecurrence {
           'months values must be between 1 and 12',
         ),
         assert(
-          daysOfMonth == null || daysOfMonth.every((d) => d >= 1 && d <= 31),
-          'daysOfMonth values must be between 1 and 31',
+          daysOfMonth == null ||
+              daysOfMonth.every((d) => d >= -31 && d <= 31 && d != 0),
+          'daysOfMonth values must be between -31 and 31, excluding 0',
         ),
         super._();
 

--- a/packages/device_calendar_plus/test/recurrence_rule_test.dart
+++ b/packages/device_calendar_plus/test/recurrence_rule_test.dart
@@ -322,6 +322,12 @@ void main() {
       expect((rule as MonthlyByDate).daysOfMonth, [1, 15]);
     });
 
+    test('parses monthly with last-day-of-month BYMONTHDAY=-1', () {
+      final rule = RecurrenceRule.fromRruleString('FREQ=MONTHLY;BYMONTHDAY=-1');
+      expect(rule, isA<MonthlyByDate>());
+      expect((rule as MonthlyByDate).daysOfMonth, [-1]);
+    });
+
     test('parses monthly with positional BYDAY', () {
       final rule = RecurrenceRule.fromRruleString('FREQ=MONTHLY;BYDAY=2TU');
       expect(rule, isA<MonthlyByWeekday>());
@@ -369,6 +375,15 @@ void main() {
       final yearly = rule as YearlyByDate;
       expect(yearly.months, [6, 12]);
       expect(yearly.daysOfMonth, [15]);
+    });
+
+    test('parses yearly with last-day-of-month BYMONTHDAY=-1', () {
+      final rule = RecurrenceRule.fromRruleString(
+          'FREQ=YEARLY;BYMONTH=2;BYMONTHDAY=-1');
+      expect(rule, isA<YearlyByDate>());
+      final yearly = rule as YearlyByDate;
+      expect(yearly.months, [2]);
+      expect(yearly.daysOfMonth, [-1]);
     });
 
     test('parses yearly with BYMONTH and positional BYDAY', () {
@@ -503,6 +518,23 @@ void main() {
       final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
       expect(parsed, isA<MonthlyByDate>());
       expect((parsed as MonthlyByDate).daysOfMonth, [1, 15]);
+    });
+
+    test('monthly by date roundtrip - last day of month (-1)', () {
+      final original = MonthlyRecurrence(daysOfMonth: [-1]);
+      expect(original.toRruleString(), 'FREQ=MONTHLY;BYMONTHDAY=-1');
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      expect(parsed, isA<MonthlyByDate>());
+      expect((parsed as MonthlyByDate).daysOfMonth, [-1]);
+    });
+
+    test('yearly by date roundtrip - last day of month (-1)', () {
+      final original = YearlyRecurrence(months: [2], daysOfMonth: [-1]);
+      final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
+      expect(parsed, isA<YearlyByDate>());
+      final yearly = parsed as YearlyByDate;
+      expect(yearly.months, [2]);
+      expect(yearly.daysOfMonth, [-1]);
     });
 
     test('monthly by weekday roundtrip - positional', () {
@@ -838,7 +870,16 @@ void main() {
         throwsA(isA<AssertionError>()),
       );
       expect(
+        () => MonthlyRecurrence(daysOfMonth: [-32]),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
         () => MonthlyRecurrence(daysOfMonth: [1, 15, 31]),
+        returnsNormally,
+      );
+      // RFC 5545 allows negative days (counted from month end): -1 = last day.
+      expect(
+        () => MonthlyRecurrence(daysOfMonth: [-1, -31]),
         returnsNormally,
       );
     });
@@ -866,6 +907,15 @@ void main() {
       expect(
         () => YearlyRecurrence(daysOfMonth: [32]),
         throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => YearlyRecurrence(daysOfMonth: [-32]),
+        throwsA(isA<AssertionError>()),
+      );
+      // RFC 5545 allows negative days (counted from month end): -1 = last day.
+      expect(
+        () => YearlyRecurrence(daysOfMonth: [-1, -31]),
+        returnsNormally,
       );
     });
 


### PR DESCRIPTION
Fixes #81.

`MonthlyByDate`/`YearlyByDate` asserted `daysOfMonth` ∈ 1..31, but RFC 5545 also allows -31..-1 (negative = counted back from month end, so `-1` is the last day). A valid `FREQ=MONTHLY;BYMONTHDAY=-1` tripped the assert, and `_RruleParser.parse` swallows the `AssertionError` and returns null — so the **whole rule, including the preserved `rawRrule`, was dropped** on read-back (in any build with asserts enabled: debug/profile/test).

iOS already emits `BYMONTHDAY=-1` correctly, so the loss was purely in the shared Dart parser — meaning it hit both platforms.

## Change
- Relaxed both asserts to `d >= -31 && d <= 31 && d != 0`, updated the doc comments.
- Added regression tests: parse `BYMONTHDAY=-1` (monthly + yearly), round-trip `MonthlyByDate([-1])` / `YearlyByDate([2], [-1])`, and extended the range-validation tests (negatives valid, `0` and `±32` still throw).

## Tests
167/167 pass in the package suite, analyzer clean. Dart-layer only (natives pass the raw RRULE string through), so unit coverage is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)