### PR TITLE
fix(ios): chunk listEvents over EventKit's 4-year span limit

### DIFF
--- a/packages/device_calendar_plus/example/integration_test/all_tests.dart
+++ b/packages/device_calendar_plus/example/integration_test/all_tests.dart
@@ -1,5 +1,6 @@
 import 'attendee_test.dart' as attendee;
 import 'device_calendar_test.dart' as device_calendar;
+import 'range_test.dart' as range;
 import 'recurrence_test.dart' as recurrence;
 import 'sources_test.dart' as sources;
 
@@ -8,4 +9,5 @@ void main() {
   recurrence.main();
   attendee.main();
   sources.main();
+  range.main();
 }

--- a/packages/device_calendar_plus/example/integration_test/range_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/range_test.dart
@@ -1,0 +1,137 @@
+import 'package:device_calendar_plus/device_calendar_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+/// Regression tests for builttoroam/device_calendar#452.
+///
+/// iOS EventKit's `predicateForEvents` silently truncates a date range longer
+/// than ~4 years to the first 4 years, so a naive single query drops the later
+/// events. The fix chunks wide ranges into <=4-year windows and merges the
+/// results — which must return every event exactly once, in start-date order,
+/// even for recurring series whose occurrences straddle a window boundary.
+///
+/// Android has no such limit, so these also serve as a cross-platform contract.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('listEvents wide range (>4 year span)', () {
+    late DeviceCalendar plugin;
+    String? calendarId;
+
+    // Anchored near "now" (not far-future): EventKit only expands recurring
+    // occurrences within a horizon around the present, so a series decades out
+    // would return only its master instance. A dedicated calendar + id/title
+    // filtering keeps these isolated from anything already on the device.
+    final base = DateTime.now().toUtc().add(const Duration(days: 2));
+    final queryStart = base.subtract(const Duration(days: 1));
+    final queryEnd = base.add(const Duration(days: 3000)); // ~8.2 years
+
+    setUpAll(() async {
+      plugin = DeviceCalendar.instance;
+      await plugin.requestPermissions();
+      calendarId = await plugin.createCalendar(
+        name: 'Range Test ${DateTime.now().millisecondsSinceEpoch}',
+        colorHex: '#00AAFF',
+      );
+    });
+
+    tearDownAll(() async {
+      if (calendarId != null) {
+        await plugin.deleteCalendar(calendarId!);
+      }
+    });
+
+    test('returns every event across a span longer than 4 years, once, sorted',
+        () async {
+      // 10 events from year 0 to ~7.4, including one at exactly +4 years (1461
+      // days, leap-adjusted) to stress the window boundary. Created in
+      // scrambled order so a sorted result isn't just an artifact of insertion.
+      const dayOffsets = [600, 2700, 0, 1461, 900, 2100, 300, 1800, 1200, 2400];
+      final expectedTitles = <String>{};
+      for (final offset in dayOffsets) {
+        final start = base.add(Duration(days: offset));
+        final title = 'range-evt-$offset';
+        expectedTitles.add(title);
+        await plugin.createEvent(
+          calendarId: calendarId!,
+          title: title,
+          startDate: start,
+          endDate: start.add(const Duration(hours: 1)),
+          timeZone: 'UTC',
+        );
+      }
+
+      final events = await plugin.listEvents(
+        queryStart,
+        queryEnd,
+        calendarIds: [calendarId!],
+      );
+      final ours = events.where((e) => expectedTitles.contains(e.title)).toList();
+
+      // Coverage: every created event comes back (the core #452 bug — later
+      // events were dropped by the 4-year truncation).
+      final returnedTitles = ours.map((e) => e.title).toSet();
+      expect(
+        returnedTitles,
+        containsAll(expectedTitles),
+        reason: 'missing events: ${expectedTitles.difference(returnedTitles)}',
+      );
+
+      // Dedup: chunked windows must not double-count an event near a boundary.
+      final instanceIds = ours.map((e) => e.instanceId).toList();
+      expect(
+        instanceIds.length,
+        instanceIds.toSet().length,
+        reason: 'duplicate instanceIds returned across windows',
+      );
+      expect(ours.length, dayOffsets.length);
+
+      // Ordering: listEvents promises start-date order across all windows.
+      for (var i = 1; i < ours.length; i++) {
+        expect(
+          ours[i].startDate.isBefore(ours[i - 1].startDate),
+          isFalse,
+          reason: 'events not sorted by start date at index $i',
+        );
+      }
+    });
+
+    test('does not duplicate recurring instances across window boundaries',
+        () async {
+      // 42 monthly occurrences => 3.5-year span, crossing the internal ~3-year
+      // window boundary while staying within EventKit's recurrence-expansion
+      // horizon. Each occurrence must appear exactly once.
+      const occurrenceCount = 42;
+      final start = base.add(const Duration(days: 5));
+      final recurringId = await plugin.createEvent(
+        calendarId: calendarId!,
+        title: 'monthly-series',
+        startDate: start,
+        endDate: start.add(const Duration(hours: 1)),
+        recurrenceRule: MonthlyRecurrence(end: CountEnd(occurrenceCount)),
+        timeZone: 'UTC',
+      );
+
+      final events = await plugin.listEvents(
+        queryStart,
+        queryEnd,
+        calendarIds: [calendarId!],
+      );
+      final occurrences =
+          events.where((e) => e.eventId == recurringId).toList();
+      final instanceIds = occurrences.map((e) => e.instanceId).toList();
+
+      expect(
+        instanceIds.length,
+        instanceIds.toSet().length,
+        reason: 'recurring instances duplicated across window boundary',
+      );
+      expect(
+        occurrences.length,
+        occurrenceCount,
+        reason: 'expected all $occurrenceCount monthly occurrences across the '
+            'span (crossing a window boundary)',
+      );
+    });
+  });
+}

--- a/packages/device_calendar_plus/example/integration_test/range_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/range_test.dart
@@ -6,7 +6,7 @@ import 'package:integration_test/integration_test.dart';
 ///
 /// iOS EventKit's `predicateForEvents` silently truncates a date range longer
 /// than ~4 years to the first 4 years, so a naive single query drops the later
-/// events. The fix chunks wide ranges into <=4-year windows and merges the
+/// events. The fix chunks wide ranges into <=3-year windows and merges the
 /// results — which must return every event exactly once, in start-date order,
 /// even for recurring series whose occurrences straddle a window boundary.
 ///

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -393,9 +393,9 @@ class DeviceCalendar {
   /// events that overlap this range are returned, but an event starting
   /// exactly at [endDate] is excluded.
   ///
-  /// **Important iOS Limitation**: iOS automatically limits event queries to a
-  /// maximum span of 4 years. If you specify a range exceeding 4 years, iOS
-  /// will truncate it to the first 4 years automatically.
+  /// Ranges longer than 4 years are supported. iOS's underlying query caps a
+  /// single span at ~4 years, so wide ranges are transparently split into
+  /// smaller windows and merged — every event in the range is returned once.
   ///
   /// [calendarIds] is an optional parameter to filter events to specific
   /// calendars. If null or empty, events from all calendars are returned.

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -92,17 +92,18 @@ class EventsService {
         end: window.end,
         calendars: calendars
       )
-      for event in eventStore.events(matching: predicate) {
-        let map = eventToMap(event: event)
-        let instanceId = map["instanceId"] as? String ?? UUID().uuidString
-        if seenInstanceIds.insert(instanceId).inserted {
-          eventMaps.append(map)
-        }
+      for event in eventStore.events(matching: predicate)
+      where seenInstanceIds.insert(instanceId(for: event)).inserted {
+        eventMaps.append(eventToMap(event: event))
       }
     }
 
+    // Sort on the map's startDate, not event.startDate: eventToMap rewrites
+    // all-day starts from UTC-floating to local midnight, so the two aren't
+    // order-equivalent once all-day and timed events mix. startDate is always
+    // present in the map, so the cast is a hard invariant, not a fallback.
     eventMaps.sort { lhs, rhs in
-      (lhs["startDate"] as? Int64 ?? 0) < (rhs["startDate"] as? Int64 ?? 0)
+      (lhs["startDate"] as! Int64) < (rhs["startDate"] as! Int64)
     }
 
     completion(.success(eventMaps))
@@ -116,7 +117,7 @@ class EventsService {
   /// of a range within one window this returns a single window equal to
   /// `[start, end]`, so there is no extra work. Adjacent windows share their
   /// boundary instant, so callers must dedupe events that match two windows.
-  static func dateWindows(
+  private static func dateWindows(
     from start: Date,
     to end: Date,
     maxWindow: TimeInterval = 3 * 365 * 24 * 60 * 60
@@ -132,20 +133,23 @@ class EventsService {
     return windows
   }
   
-  private func eventToMap(event: EKEvent) -> [String: Any] {
-    // Generate instanceId
-    let startMillis = Int64(event.startDate.timeIntervalSince1970 * 1000)
+  /// Stable identifier for a single fetched event. For a recurring series each
+  /// occurrence is distinguished by its start (`eventId@startMillis`); a
+  /// non-recurring event is just its `eventId`. Used both to populate the event
+  /// map and to dedupe occurrences that match two adjacent query windows.
+  private func instanceId(for event: EKEvent) -> String {
     let eventId = event.eventIdentifier ?? ""
-    let instanceId: String
-    if event.hasRecurrenceRules {
-      instanceId = "\(eventId)@\(startMillis)"
-    } else {
-      instanceId = eventId
-    }
-    
+    guard event.hasRecurrenceRules else { return eventId }
+    let startMillis = Int64(event.startDate.timeIntervalSince1970 * 1000)
+    return "\(eventId)@\(startMillis)"
+  }
+
+  private func eventToMap(event: EKEvent) -> [String: Any] {
+    let eventId = event.eventIdentifier ?? ""
+
     var eventMap: [String: Any] = [
       "eventId": eventId,
-      "instanceId": instanceId,
+      "instanceId": instanceId(for: event),
       "calendarId": event.calendar.calendarIdentifier,
       "title": event.title ?? "",
       "isAllDay": event.isAllDay

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -79,23 +79,57 @@ class EventsService {
       }
     }
     
-    // Create predicate for events
-    // Note: iOS automatically limits to 4-year spans
-    let predicate = eventStore.predicateForEvents(
-      withStart: startDate,
-      end: endDate,
-      calendars: calendars
-    )
-    
-    // Fetch events
-    let events = eventStore.events(matching: predicate)
-    
-    // Convert to maps
-    let eventMaps = events.map { event in
-      eventToMap(event: event)
+    // EKEventStore.predicateForEvents silently truncates ranges longer than
+    // ~4 years to the first 4 years (#452), so split wide ranges into smaller
+    // windows, query each, and merge. A boundary instant can match two adjacent
+    // windows, so dedupe by instanceId; listEvents returns events sorted by
+    // start date.
+    var eventMaps: [[String: Any]] = []
+    var seenInstanceIds = Set<String>()
+    for window in Self.dateWindows(from: startDate, to: endDate) {
+      let predicate = eventStore.predicateForEvents(
+        withStart: window.start,
+        end: window.end,
+        calendars: calendars
+      )
+      for event in eventStore.events(matching: predicate) {
+        let map = eventToMap(event: event)
+        let instanceId = map["instanceId"] as? String ?? UUID().uuidString
+        if seenInstanceIds.insert(instanceId).inserted {
+          eventMaps.append(map)
+        }
+      }
     }
-    
+
+    eventMaps.sort { lhs, rhs in
+      (lhs["startDate"] as? Int64 ?? 0) < (rhs["startDate"] as? Int64 ?? 0)
+    }
+
     completion(.success(eventMaps))
+  }
+
+  /// Splits `[start, end]` into consecutive windows no longer than `maxWindow`.
+  ///
+  /// EKEventStore.predicateForEvents silently truncates ranges longer than
+  /// ~4 years to the first 4 years (#452). A conservative ~3-year window stays
+  /// safely under that limit (with margin for leap years). For the common case
+  /// of a range within one window this returns a single window equal to
+  /// `[start, end]`, so there is no extra work. Adjacent windows share their
+  /// boundary instant, so callers must dedupe events that match two windows.
+  static func dateWindows(
+    from start: Date,
+    to end: Date,
+    maxWindow: TimeInterval = 3 * 365 * 24 * 60 * 60
+  ) -> [(start: Date, end: Date)] {
+    guard end > start else { return [(start, end)] }
+    var windows: [(start: Date, end: Date)] = []
+    var cursor = start
+    while cursor < end {
+      let next = min(cursor.addingTimeInterval(maxWindow), end)
+      windows.append((start: cursor, end: next))
+      cursor = next
+    }
+    return windows
   }
   
   private func eventToMap(event: EKEvent) -> [String: Any] {


### PR DESCRIPTION
Fixes #82.

`EKEventStore.predicateForEvents` silently caps a query at ~4 years — hand it a wider range and it returns only the first 4 years, dropping everything after. So `listEvents` over a long span lost events with no error ([builttoroam/device_calendar#452](https://github.com/builttoroam/device_calendar/issues/452)). Confirmed in the validation pass; Android has no such limit.

## Change (iOS only)
`retrieveEvents` now splits the range into consecutive **≤3-year windows** (safely under EventKit's limit, with margin for leap years), queries each, and merges:
- **Dedup** by `instanceId` — adjacent windows share their boundary instant, so an event/occurrence on the seam can match two windows.
- **Sort** the merged maps by `startDate` (preserves the `listEvents` "sorted by start date" contract across windows).
- **No overhead for normal use** — a range within one window yields a single fetch, exactly as before.

Kept in Swift (the platform with the quirk) rather than the shared Dart layer.

## Tests
New `integration_test/range_test.dart` covers the three easy-to-get-wrong cases, all verified on simulator:
- every event across a >4-year span is returned (the core bug),
- no duplicate instances across a window boundary — including a 42-occurrence monthly recurring series that crosses the seam,
- results sorted by start date across windows.

Full iOS suite green (69 passed, 4 pre-existing skips).

> Note: while writing these I found EventKit only expands *recurring* occurrences within a horizon near the present — a series dated decades out returns just its master instance. That's a separate EventKit behaviour (not caused by this change); the tests anchor near "now" to stay within it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)