### PR TITLE
fix(ios): reject createCalendar on read-only sources

### DIFF
--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/CalendarService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/CalendarService.swift
@@ -75,6 +75,17 @@ class CalendarService {
         )))
         return
       }
+      // Google/Exchange (and other non-iCloud) sources reject new calendars with
+      // EKError 500. Reject early with a clear error rather than letting
+      // saveCalendar throw an opaque "operation failed".
+      guard sourceSupportsCreation(found) else {
+        completion(.failure(CalendarError(
+          code: PlatformExceptionCodes.readOnly,
+          message: "Source '\(found.title)' does not allow calendars to be created. "
+            + "Use iCloud or the local source."
+        )))
+        return
+      }
       source = found
     } else {
       // No sourceId provided — prefer iCloud (syncs across devices), then local.


### PR DESCRIPTION
Passing an explicit \`sourceId\` for a Google/Exchange account (or any non-iCloud CalDAV source) let \`createCalendar\` charge ahead to \`saveCalendar\`, which throws \`EKError 500\` — *"That account does not allow calendars to be added or removed."* We caught it, but only as a generic \`operationFailed\`.

Now the explicit-\`sourceId\` path checks the existing \`sourceSupportsCreation()\` helper first and returns \`READ_ONLY\` early, so callers get \`DeviceCalendarException(DeviceCalendarError.readOnly)\` with a message that actually says what's wrong — same pattern \`updateCalendar\` already uses.

The default (no-\`sourceId\`) path was always immune; it falls back to iCloud/local.

No integration test: reproducing it needs a Google/Exchange account on the sim, which the test simulator doesn't have.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)