### PR TITLE
docs(listEvents): document per-instance expansion + instanceId

### DIFF
--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -401,11 +401,17 @@ class DeviceCalendar {
   /// calendars. If null or empty, events from all calendars are returned.
   ///
   /// Recurring events are automatically expanded into individual instances
-  /// within the date range. Each instance has:
-  /// - The same [Event.eventId]
+  /// within the date range — you get one [Event] per occurrence, not a single
+  /// master. Each instance has:
+  /// - The same [Event.eventId] (shared by the whole series)
   /// - Different [Event.startDate] and [Event.endDate]
+  /// - A distinct [Event.instanceId] (format `eventId@timestamp`) that pins
+  ///   the occurrence
   ///
-  /// This combination uniquely identifies each occurrence of a recurring event.
+  /// Pass that [Event.instanceId] to [getEvent], [updateEvent], [deleteEvent],
+  /// or [showEventModal] to act on a single occurrence. (For non-recurring
+  /// events `instanceId == eventId`.) The id is plugin-derived and unstable —
+  /// it changes if the occurrence's start date moves, so re-fetch after edits.
   ///
   /// Returns a list of [Event] objects sorted by start date.
   ///


### PR DESCRIPTION
\`listEvents\` already expands a recurring series into one \`Event\` per occurrence (and the \`eventId@timestamp\` \`instanceId\` scheme disambiguates them — unlike the upstream issue this came from). The doc described the "same eventId, different dates" combination but never named the \`instanceId\` field that callers actually pass to \`getEvent\`/\`updateEvent\`/\`deleteEvent\`/\`showEventModal\`.

Now the dartdoc spells out: one Event per occurrence, distinct \`instanceId\` per occurrence, what to do with it, and the unstable-id caveat.

No functional change. (The other upstream symptom — empty \`dayOfWeek\`/\`BYDAY\` — doesn't reproduce here; we emit it correctly.)

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)