### PR TITLE
fix(android): return zero-duration events on the query start

### DIFF
--- a/packages/device_calendar_plus/example/integration_test/all_tests.dart
+++ b/packages/device_calendar_plus/example/integration_test/all_tests.dart
@@ -1,5 +1,6 @@
 import 'attendee_test.dart' as attendee;
 import 'device_calendar_test.dart' as device_calendar;
+import 'edge_cases_test.dart' as edge_cases;
 import 'range_test.dart' as range;
 import 'recurrence_test.dart' as recurrence;
 import 'sources_test.dart' as sources;
@@ -10,4 +11,5 @@ void main() {
   attendee.main();
   sources.main();
   range.main();
+  edge_cases.main();
 }

--- a/packages/device_calendar_plus/example/integration_test/edge_cases_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/edge_cases_test.dart
@@ -1,0 +1,115 @@
+import 'package:device_calendar_plus/device_calendar_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+/// Device probes for upstream edge cases that couldn't be decided by reading
+/// the code (builttoroam/device_calendar #416, #607).
+///
+/// These run the real Dart -> channel -> native -> provider roundtrip on both
+/// platforms. A failure here is a reproduced bug to fix; a pass is evidence the
+/// case doesn't affect this plugin.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late DeviceCalendar plugin;
+  String? calendarId;
+
+  // Anchored a few days out from "now" so timed events sit comfortably inside
+  // a sane query window regardless of the device clock/timezone.
+  DateTime utcMidnightToday() {
+    final now = DateTime.now().toUtc();
+    return DateTime.utc(now.year, now.month, now.day);
+  }
+
+  setUpAll(() async {
+    plugin = DeviceCalendar.instance;
+    await plugin.requestPermissions();
+    calendarId = await plugin.createCalendar(
+      name: 'Edge Test ${DateTime.now().millisecondsSinceEpoch}',
+      colorHex: '#FF8800',
+    );
+  });
+
+  tearDownAll(() async {
+    if (calendarId != null) {
+      await plugin.deleteCalendar(calendarId!);
+    }
+  });
+
+  group('listEvents zero-duration timed event (#416)', () {
+    test('returns a zero-duration timed event that falls inside the range',
+        () async {
+      // Non-all-day event with start == end, at midnight UTC, well inside the
+      // query window. Probes whether the provider materialises a zero-duration
+      // instance at all (independent of the boundary filter).
+      final at = utcMidnightToday().add(const Duration(days: 2));
+      final id = await plugin.createEvent(
+        calendarId: calendarId!,
+        title: 'zero-dur-inside',
+        startDate: at,
+        endDate: at, // zero duration
+        timeZone: 'UTC',
+      );
+
+      final events = await plugin.listEvents(
+        at.subtract(const Duration(days: 1)),
+        at.add(const Duration(days: 1)),
+        calendarIds: [calendarId!],
+      );
+
+      expect(
+        events.any((e) => e.eventId == id || e.title == 'zero-dur-inside'),
+        isTrue,
+        reason: 'zero-duration timed event inside the range was dropped',
+      );
+    });
+
+    test('returns a zero-duration event sitting exactly on the query start',
+        () async {
+      // The boundary the strict open-interval filter
+      // (eventEnd > startMillis && eventBegin < endMillis) would exclude:
+      // begin == end == queryStart. A caller querying [start, end] reasonably
+      // expects an event at exactly `start` to appear.
+      final at = utcMidnightToday().add(const Duration(days: 4));
+      final id = await plugin.createEvent(
+        calendarId: calendarId!,
+        title: 'zero-dur-boundary',
+        startDate: at,
+        endDate: at,
+        timeZone: 'UTC',
+      );
+
+      final events = await plugin.listEvents(
+        at, // query starts exactly at the event instant
+        at.add(const Duration(days: 1)),
+        calendarIds: [calendarId!],
+      );
+
+      expect(
+        events.any((e) => e.eventId == id || e.title == 'zero-dur-boundary'),
+        isTrue,
+        reason: 'zero-duration event exactly at query start was excluded by the '
+            'strict open-interval overlap filter',
+      );
+    });
+  });
+
+  group('listCalendars freshness (#607)', () {
+    test('a newly created calendar appears immediately in listCalendars',
+        () async {
+      final name = 'fresh-cal-${DateTime.now().millisecondsSinceEpoch}';
+      final newId = await plugin.createCalendar(name: name, colorHex: '#22BB55');
+
+      try {
+        final calendars = await plugin.listCalendars();
+        expect(
+          calendars.any((c) => c.id == newId),
+          isTrue,
+          reason: 'calendar created this session is missing from listCalendars',
+        );
+      } finally {
+        await plugin.deleteCalendar(newId);
+      }
+    });
+  });
+}

--- a/packages/device_calendar_plus/example/integration_test/edge_cases_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/edge_cases_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
 /// Device probes for upstream edge cases that couldn't be decided by reading
-/// the code (builttoroam/device_calendar #416, #607).
+/// the code (builttoroam/device_calendar #416).
 ///
 /// These run the real Dart -> channel -> native -> provider roundtrip on both
 /// platforms. A failure here is a reproduced bug to fix; a pass is evidence the
@@ -91,25 +91,6 @@ void main() {
         reason: 'zero-duration event exactly at query start was excluded by the '
             'strict open-interval overlap filter',
       );
-    });
-  });
-
-  group('listCalendars freshness (#607)', () {
-    test('a newly created calendar appears immediately in listCalendars',
-        () async {
-      final name = 'fresh-cal-${DateTime.now().millisecondsSinceEpoch}';
-      final newId = await plugin.createCalendar(name: name, colorHex: '#22BB55');
-
-      try {
-        final calendars = await plugin.listCalendars();
-        expect(
-          calendars.any((c) => c.id == newId),
-          isTrue,
-          reason: 'calendar created this session is missing from listCalendars',
-        );
-      } finally {
-        await plugin.deleteCalendar(newId);
-      }
     });
   });
 }

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -153,16 +153,13 @@ class EventsService(private val context: Context) {
             val effectiveEnd = if (eventEnd <= eventBegin) eventBegin + 86_400_000L else eventEnd
             return effectiveEnd > startUtcMidnight && eventBegin < endUtcMidnight
         }
-        // Zero-duration (instantaneous) timed events have no span for the strict
-        // overlap check below to catch, so one sitting exactly on the query start
-        // is dropped. iOS EventKit includes it, so include it here too when its
-        // instant falls within the window (half-open at the end, like timed
-        // events). See builttoroam/device_calendar#416.
-        if (eventEnd == eventBegin) {
-            return eventBegin >= startMillis && eventBegin < endMillis
-        }
-        // Timed events: standard overlap check against original query range
-        return eventEnd > startMillis && eventBegin < endMillis
+        // Timed events: half-open overlap. A zero-duration (instantaneous) event
+        // has no span, so give it a minimal effective end — otherwise one sitting
+        // exactly on the query start fails `end > start` and is dropped. iOS
+        // EventKit includes it. Mirrors the all-day effectiveEnd above.
+        // See builttoroam/device_calendar#416.
+        val effectiveEnd = if (eventEnd <= eventBegin) eventBegin + 1 else eventEnd
+        return effectiveEnd > startMillis && eventBegin < endMillis
     }
 
     // A NULL column falls through to the documented "busy" default rather

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -153,6 +153,14 @@ class EventsService(private val context: Context) {
             val effectiveEnd = if (eventEnd <= eventBegin) eventBegin + 86_400_000L else eventEnd
             return effectiveEnd > startUtcMidnight && eventBegin < endUtcMidnight
         }
+        // Zero-duration (instantaneous) timed events have no span for the strict
+        // overlap check below to catch, so one sitting exactly on the query start
+        // is dropped. iOS EventKit includes it, so include it here too when its
+        // instant falls within the window (half-open at the end, like timed
+        // events). See builttoroam/device_calendar#416.
+        if (eventEnd == eventBegin) {
+            return eventBegin >= startMillis && eventBegin < endMillis
+        }
         // Timed events: standard overlap check against original query range
         return eventEnd > startMillis && eventBegin < endMillis
     }


### PR DESCRIPTION
From the #86 device-probe pass (upstream #416).

**What I probed.** Added integration tests for a zero-duration (start == end) timed event in two spots: well inside the query window, and sitting *exactly* on the query start. Ran them through the harness on both platforms:

| | inside range | exactly on query start |
|---|---|---|
| iOS | ✅ | ✅ |
| Android (before) | ✅ | ❌ |
| Android (after) | ✅ | ✅ |

**The bug.** Android's timed-overlap filter is a strict open interval — `eventEnd > startMillis && eventBegin < endMillis`. A zero-duration event has `begin == end`, so an event landing exactly on `startMillis` fails `eventEnd > startMillis` and gets dropped. iOS EventKit returns it. Per our cross-platform rule, Android conforms to iOS: include a zero-duration event when its instant falls in the window (kept half-open at the end, like every other timed event).

The provider *does* materialise zero-duration instances (the inside-range test passes), so this was purely the boundary comparison.

**Note:** the suite also showed the recurrence instance-ID update/delete tests failing intermittently on Android (different set each run, `Actual: 0`) — a pre-existing Calendar Provider expansion race, unrelated to this change (my edit only adds a zero-duration branch 1-hour recurring events never hit). Flagging separately, not fixing here.

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)