### PR TITLE
feat: no-op updates instead of throwing (#95)

### DIFF
--- a/.claude/rules/error-handling.md
+++ b/.claude/rules/error-handling.md
@@ -8,6 +8,28 @@ For bugs in the caller's code caught before any platform call. Use standard
 Dart error types (`ArgumentError`, `StateError`, etc.) since these indicate
 code that needs fixing, not conditions to handle at runtime.
 
+### Throw for *invalid* input, not *degenerate-but-valid* input
+
+Reserve `ArgumentError` for arguments the method genuinely cannot act on —
+where **no correct behavior exists**: `endDate` before `startDate`, an empty
+`eventId` that targets nothing, two contradictory arguments. Do **not** throw
+when the input has a single obvious, harmless interpretation — produce that
+result instead.
+
+The test: *does a well-defined, valid outcome exist for this input?* If yes,
+return it rather than throwing.
+
+- An update call with no changed fields → **no-op**: return without a platform
+  write. The post-condition ("the event matches the requested values") is
+  already satisfied. Don't throw "at least one field must be provided".
+- An empty collection argument → act on nothing, like `List.addAll([])`.
+
+This follows from the category above: an `ArgumentError` flags code that needs
+*fixing* and is not meant to be caught. A no-change save is a legitimate
+runtime state (the user opened an editor and pressed Save without editing), so
+rejecting it forces callers into defensive `try/catch` for a benign case.
+Mutation APIs should be idempotent under "no change".
+
 ## Runtime errors — `DeviceCalendarException`
 
 For errors from the native platform that callers should handle at runtime.

--- a/packages/device_calendar_plus/example/integration_test/device_calendar_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/device_calendar_test.dart
@@ -316,20 +316,20 @@ void main() {
       expect(updatedCalendar.colorHex!.toUpperCase(), isNot(equals('#FF0000')));
     });
 
-    test('Error Handling - Update with No Parameters', () async {
+    test('updateCalendar with no parameters is a no-op', () async {
       // Create a calendar first
       final timestamp = DateTime.now().millisecondsSinceEpoch;
       final calendarId =
-          await plugin.createCalendar(name: 'Error Test $timestamp');
+          await plugin.createCalendar(name: 'No-op Test $timestamp');
       createdCalendarIds.add(calendarId);
 
-      // Try to update without providing any parameters
-      try {
-        await plugin.updateCalendar(calendarId);
-        fail('Should have thrown an error when no parameters provided');
-      } on ArgumentError catch (e) {
-        expect(e.message, contains('At least one'));
-      }
+      // Updating with nothing to change must succeed quietly and leave the
+      // calendar untouched (a save with no edits is a legitimate no-op).
+      await plugin.updateCalendar(calendarId);
+
+      final calendars = await plugin.listCalendars();
+      final unchanged = calendars.firstWhere((c) => c.id == calendarId);
+      expect(unchanged.name, 'No-op Test $timestamp');
     });
 
     test('Error Handling - Update with Empty Name', () async {
@@ -934,7 +934,7 @@ void main() {
       expect(event, isNotNull);
     });
 
-    test('Update Event with No Fields Throws Error', () async {
+    test('Update Event with No Fields is a no-op', () async {
       final timestamp = DateTime.now().millisecondsSinceEpoch;
       final calendarId = await plugin.createCalendar(
         name: 'No Fields Test $timestamp',
@@ -949,11 +949,13 @@ void main() {
         endDate: DateTime.now().add(Duration(hours: 2)),
       );
 
-      // Attempt to update with no fields - should throw
-      expect(
-        () async => await plugin.updateEvent(eventId: eventId),
-        throwsA(isA<ArgumentError>()),
-      );
+      // Updating with no fields must succeed quietly and leave the event
+      // unchanged (a save with no edits is a legitimate no-op).
+      await plugin.updateEvent(eventId: eventId);
+
+      final event = await plugin.getEvent(eventId);
+      expect(event, isNotNull);
+      expect(event!.title, 'No Fields Test');
     });
 
     test('Update Event URL', () async {

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -331,6 +331,16 @@ class DeviceCalendar {
     String? name,
     String? colorHex,
   }) async {
+    // Validate calendarId — an empty id targets no calendar (matches the
+    // empty-id guards on updateEvent/updateRecurring).
+    if (calendarId.trim().isEmpty) {
+      throw ArgumentError.value(
+        calendarId,
+        'calendarId',
+        'Calendar ID cannot be empty',
+      );
+    }
+
     // No changed fields is a valid no-op: nothing to write, so return without
     // a platform call.
     if (name == null && colorHex == null) {

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -306,7 +306,7 @@ class DeviceCalendar {
   /// [name] is the new display name for the calendar (optional).
   /// [colorHex] is the new color in #RRGGBB format (optional, e.g., "#FF5733").
   ///
-  /// At least one of [name] or [colorHex] must be provided.
+  /// Passing neither [name] nor [colorHex] is a no-op (nothing to change).
   /// Requires calendar write permissions - call [requestPermissions] first.
   ///
   /// Example:
@@ -331,11 +331,10 @@ class DeviceCalendar {
     String? name,
     String? colorHex,
   }) async {
-    // Validate that at least one parameter is provided
+    // No changed fields is a valid no-op: nothing to write, so return without
+    // a platform call.
     if (name == null && colorHex == null) {
-      throw ArgumentError(
-        'At least one of name or colorHex must be provided',
-      );
+      return;
     }
 
     // Validate name if provided
@@ -754,7 +753,7 @@ class DeviceCalendar {
   /// pass `null`) to leave the field unchanged, [Patch.set] to assign a new
   /// value, [Patch.clear] to remove the existing value.
   ///
-  /// At least one field must be provided.
+  /// Providing no fields is a no-op (nothing to change).
   /// Requires calendar write permissions - call [requestPermissions] first.
   ///
   /// Example:
@@ -796,7 +795,9 @@ class DeviceCalendar {
       );
     }
 
-    // Validate at least one field is provided
+    // No changed fields is a valid no-op (e.g. the user pressed Save without
+    // editing): the event already matches the requested values, so there is
+    // nothing to write — return without a platform call.
     if (title == null &&
         startDate == null &&
         endDate == null &&
@@ -806,9 +807,7 @@ class DeviceCalendar {
         isAllDay == null &&
         timeZone == null &&
         availability == null) {
-      throw ArgumentError(
-        'At least one field must be provided to update',
-      );
+      return;
     }
 
     // Validate dates if both are provided
@@ -881,9 +880,10 @@ class DeviceCalendar {
   ///   preserving each occurrence's date (hour 0-23, minute 0-59). Duration
   ///   is preserved unless [duration] is also passed. Cannot be used on
   ///   all-day events.
-  /// - [duration] sets the event duration; it must be positive and a whole
-  ///   number of minutes. For all-day events, only whole-day durations are
-  ///   valid (e.g., `Duration(days: 3)` for a three-day conference).
+  /// - [duration] sets the event duration; it must be non-negative (zero is
+  ///   allowed for an instantaneous event) and a whole number of minutes. For
+  ///   all-day events, only whole-day durations are valid (e.g.,
+  ///   `Duration(days: 3)` for a three-day conference).
   ///
   /// [recurrenceRule] takes a [Patch]: omit it to leave recurrence unchanged,
   /// [Patch.set] to change the rule, [Patch.clear] to remove it (the event
@@ -899,7 +899,7 @@ class DeviceCalendar {
   /// Returns the event ID for the affected scope — the same ID for
   /// `allEvents`, the new series' ID for `thisAndFollowing`.
   ///
-  /// At least one field must be provided.
+  /// Providing no fields is a no-op (nothing to change).
   /// Requires calendar write permissions - call [requestPermissions] first.
   ///
   /// Example:
@@ -970,13 +970,15 @@ class DeviceCalendar {
       );
     }
 
-    // The platform contract is whole minutes; reject rather than silently
-    // truncate, and rule out zero/negative durations.
-    if (duration != null && duration <= Duration.zero) {
+    // A negative duration is invalid, but zero is allowed: zero-duration
+    // (instantaneous) events are supported — createEvent accepts
+    // endDate == startDate, and listEvents returns them (#416). The
+    // whole-minute check below still applies (0 is a whole minute).
+    if (duration != null && duration < Duration.zero) {
       throw ArgumentError.value(
         duration,
         'duration',
-        'duration must be positive',
+        'duration cannot be negative',
       );
     }
     if (duration != null &&
@@ -1008,7 +1010,9 @@ class DeviceCalendar {
       );
     }
 
-    // Validate at least one field is provided
+    // No changed fields is a valid no-op: there is nothing to write, and
+    // nothing to split for thisAndFollowing. Return the targeted event id —
+    // the scope the caller named, unchanged.
     if (title == null &&
         startTime == null &&
         duration == null &&
@@ -1019,9 +1023,7 @@ class DeviceCalendar {
         timeZone == null &&
         availability == null &&
         recurrenceRule == null) {
-      throw ArgumentError(
-        'At least one field must be provided to update',
-      );
+      return parsed.eventId;
     }
 
     // The platform layer works in RRULE strings; map the typed Patch across.

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -48,9 +48,10 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
   PlatformException? _exceptionToThrow;
 
   /// The arguments of the most recent updateEvent / updateRecurring /
-  /// deleteEvent call.
+  /// updateCalendar / deleteEvent call.
   UpdateEventCall? lastUpdateEvent;
   UpdateRecurringCall? lastUpdateRecurring;
+  ({String calendarId, String? name, String? colorHex})? lastUpdateCalendar;
   ({String eventId, int? timestamp})? lastDeleteEvent;
 
   /// What updateRecurring returns (the affected scope's event ID).
@@ -169,6 +170,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
   Future<void> updateCalendar(
       String calendarId, String? name, String? colorHex) async {
     if (_exceptionToThrow != null) throw _exceptionToThrow!;
+    lastUpdateCalendar = (calendarId: calendarId, name: name, colorHex: colorHex);
   }
 
   @override
@@ -710,14 +712,22 @@ void main() {
 
     group('updateCalendar', () {
       test('is a no-op when no parameters provided', () async {
-        // Nothing to change -> returns quietly without a platform write.
         await DeviceCalendar.instance.updateCalendar('calendar-123');
+        // Nothing to change -> short-circuits before any platform write.
+        expect(mockPlatform.lastUpdateCalendar, isNull);
       });
 
       test('throws ArgumentError when name is empty', () async {
         expect(
           () =>
               DeviceCalendar.instance.updateCalendar('calendar-123', name: ''),
+          throwsArgumentError,
+        );
+      });
+
+      test('throws ArgumentError when calendarId is empty', () async {
+        expect(
+          () => DeviceCalendar.instance.updateCalendar('   ', name: 'x'),
           throwsArgumentError,
         );
       });

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -709,11 +709,9 @@ void main() {
     });
 
     group('updateCalendar', () {
-      test('throws ArgumentError when no parameters provided', () async {
-        expect(
-          () => DeviceCalendar.instance.updateCalendar('calendar-123'),
-          throwsArgumentError,
-        );
+      test('is a no-op when no parameters provided', () async {
+        // Nothing to change -> returns quietly without a platform write.
+        await DeviceCalendar.instance.updateCalendar('calendar-123');
       });
 
       test('throws ArgumentError when name is empty', () async {
@@ -749,11 +747,10 @@ void main() {
         );
       });
 
-      test('throws ArgumentError when no fields provided', () async {
-        expect(
-          () => DeviceCalendar.instance.updateEvent(eventId: 'event-123'),
-          throwsArgumentError,
-        );
+      test('is a no-op when no fields provided', () async {
+        await DeviceCalendar.instance.updateEvent(eventId: 'event-123');
+        // Short-circuits before any platform write.
+        expect(mockPlatform.lastUpdateEvent, isNull);
       });
 
       test('throws ArgumentError when endDate is before startDate', () async {
@@ -780,14 +777,15 @@ void main() {
         );
       });
 
-      test('throws ArgumentError when no fields provided', () {
-        expect(
-          () => DeviceCalendar.instance.updateRecurring(
-            'event-123',
-            EventSpan.allEvents,
-          ),
-          throwsArgumentError,
+      test('is a no-op returning the targeted event id when no fields provided',
+          () async {
+        final result = await DeviceCalendar.instance.updateRecurring(
+          'event-123',
+          EventSpan.allEvents,
         );
+        // Returns the scope the caller named, and skips the platform write.
+        expect(result, 'event-123');
+        expect(mockPlatform.lastUpdateRecurring, isNull);
       });
 
       test('throws ArgumentError when thisAndFollowing given a bare event ID',
@@ -851,15 +849,17 @@ void main() {
         );
       });
 
-      test('throws ArgumentError when duration is zero', () {
-        expect(
-          () => DeviceCalendar.instance.updateRecurring(
-            'event-123',
-            EventSpan.allEvents,
-            duration: Duration.zero,
-          ),
-          throwsArgumentError,
+      test('accepts a zero duration (instantaneous event)', () async {
+        // Zero-duration events are supported (createEvent allows
+        // endDate == startDate; listEvents returns them, #416), so updating a
+        // series to one must not be rejected. Negative durations still throw.
+        final result = await DeviceCalendar.instance.updateRecurring(
+          'event-123',
+          EventSpan.allEvents,
+          duration: Duration.zero,
         );
+        expect(result, 'mock-event-id');
+        expect(mockPlatform.lastUpdateRecurring?.durationMinutes, 0);
       });
 
       test('throws ArgumentError when duration is negative', () {


### PR DESCRIPTION
`updateEvent` / `updateCalendar` / `updateRecurring` threw `ArgumentError` when called with no changed fields. That's the wrong category: a no-change save is a legitimate runtime state (open an editor, press Save without editing), and `ArgumentError` is for un-fixable programmer mistakes — not conditions to handle at runtime. Rejecting it forced callers into defensive `try/catch` for a benign case.

**Now an empty update is a quiet no-op:** skip the platform write and return. `updateRecurring` returns the targeted event id (and does *not* split for `thisAndFollowing` — there's nothing to change, and splitting a series into two identical ones is pointless).

**Also fixes an inconsistency this surfaced:** `updateRecurring` rejected a *zero* duration, but zero-duration events are first-class — `createEvent` accepts `endDate == startDate` and `listEvents` returns them (#416). It now rejects only *negative* durations.

**Rule:** codified the principle in `.claude/rules/error-handling.md` — throw for *invalid* input (no correct behavior exists), not *degenerate-but-valid* input (one obvious harmless result).

Kept as-is (genuinely invalid, discussed): empty `eventId`/`calendarId`/`instanceId`, `endDate < startDate`, `thisAndFollowing` without a timestamp, all-day + `startTime` contradiction, sub-minute/non-whole-day durations (reject beats silent truncation), and empty `title`/`name` on create.

Tests: flipped the 4 unit tests + 2 integration tests that asserted the old throws to assert the no-op (and zero-duration acceptance). 57 unit tests pass; iOS integration suite green.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)