### PR TITLE
Fix turning a recurring instance non-recurring (this & future) on iOS (#93)

### DIFF
--- a/packages/device_calendar_plus/example/integration_test/recurrence_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/recurrence_test.dart
@@ -525,6 +525,58 @@ void main() {
           reason: 'the new series must start at the split point');
     });
 
+    test(
+        'thisAndFollowing with Patch.clear turns the anchor into a standalone '
+        'non-recurring event and drops future occurrences (#93)', () async {
+      // Issue #93's "this and future" case: split the series at the chosen
+      // occurrence, make that occurrence a standalone non-recurring event,
+      // and remove every later occurrence. Past occurrences stay in the
+      // original series.
+      expect(calendarId, isNotNull, reason: 'setUpAll must create a calendar');
+      final series = await createDailySeries(plugin, calendarId!, count: 10);
+
+      final occurrences = await occurrencesOf(
+          plugin, calendarId!, series.eventId, series.start);
+      expect(occurrences.length, greaterThanOrEqualTo(6));
+      final splitPoint = occurrences[4];
+      final splitMillis = splitPoint.startDate.millisecondsSinceEpoch;
+
+      final standaloneId = await plugin.updateRecurring(
+        splitPoint.instanceId,
+        EventSpan.thisAndFollowing,
+        recurrenceRule: const Patch.clear(),
+      );
+
+      // The original master keeps only the occurrences before the split.
+      final remainingMaster = await occurrencesOf(
+          plugin, calendarId!, series.eventId, series.start);
+      expect(remainingMaster, isNotEmpty,
+          reason: 'occurrences before the split must survive');
+      expect(
+        remainingMaster
+            .every((e) => e.startDate.millisecondsSinceEpoch < splitMillis),
+        isTrue,
+        reason: 'the original series must not extend past the split point',
+      );
+
+      // The anchor is now a standalone non-recurring event at the split point.
+      final standalone = await plugin.getEvent(standaloneId);
+      expect(standalone, isNotNull);
+      expect(standalone!.recurrenceRule, isNull,
+          reason: 'the detached event must carry no recurrence rule');
+      expect(standalone.startDate.millisecondsSinceEpoch, splitMillis,
+          reason: 'the standalone event must sit at the split point');
+
+      // No future occurrences: the detached event expands to exactly one,
+      // and nothing past the split survives under the new id.
+      final detachedOccurrences = await occurrencesOf(
+          plugin, calendarId!, standaloneId, series.start);
+      expect(detachedOccurrences.length, 1,
+          reason: 'a non-recurring event expands to a single occurrence');
+      expect(detachedOccurrences.single.startDate.millisecondsSinceEpoch,
+          splitMillis);
+    });
+
     test('updateEvent with an instance ID edits only the one occurrence',
         skip: _isAndroidEmulator
             ? 'Android emulator Calendar Provider drops master occurrences '

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -883,7 +883,10 @@ class DeviceCalendar {
   ///   Clearing [recurrenceRule] collapses the series into a single event.
   /// - [EventSpan.thisAndFollowing] — the series is split at the
   ///   occurrence timestamp: that occurrence and every later one carry the
-  ///   edit; earlier occurrences are untouched.
+  ///   edit; earlier occurrences are untouched. Clearing [recurrenceRule] here
+  ///   turns the occurrence into a standalone non-recurring event and drops
+  ///   every later one, leaving the earlier occurrences in the original series
+  ///   (the "this and future, made non-recurring" case).
   ///
   /// Time fields:
   /// - [startTime] sets the time-of-day for every occurrence in scope,

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -955,6 +955,28 @@ class EventsService {
 
   // MARK: - updateRecurring (issue #36)
 
+  /// Copies `rule` but caps it to end just before `date`, so the series stops
+  /// at the occurrence before `date`. Used to truncate a master series at a
+  /// `thisAndFollowing` split point. `EKRecurrenceEnd(end:)` is inclusive, so
+  /// the cap sits one second early to keep the split occurrence off the
+  /// original series (mirrors Android's `timestamp - 1000`).
+  private func ruleTruncated(
+    _ rule: EKRecurrenceRule,
+    endingBefore date: Date
+  ) -> EKRecurrenceRule {
+    return EKRecurrenceRule(
+      recurrenceWith: rule.frequency,
+      interval: rule.interval,
+      daysOfTheWeek: rule.daysOfTheWeek,
+      daysOfTheMonth: rule.daysOfTheMonth,
+      monthsOfTheYear: rule.monthsOfTheYear,
+      weeksOfTheYear: rule.weeksOfTheYear,
+      daysOfTheYear: rule.daysOfTheYear,
+      setPositions: rule.setPositions,
+      end: EKRecurrenceEnd(end: date.addingTimeInterval(-1))
+    )
+  }
+
   /// Keeps the calendar date of `date` but replaces the time-of-day with
   /// `hour`:`minute`, interpreted in `timeZone`. The Swift counterpart of
   /// Android's `replaceTimeOfDay`.
@@ -1091,6 +1113,59 @@ class EventsService {
     }
 
     patch.applyTimeZone(to: foundEvent)
+
+    // Clearing the rule on a `thisAndFollowing` split needs special handling.
+    // Setting `recurrenceRules = nil` and saving `.futureEvents` does NOT
+    // split — with no rule there is no future series for EventKit to detach,
+    // so it edits the underlying master and collapses the WHOLE series into a
+    // single event at the original start (the `allEvents` outcome). Instead,
+    // mirror Android: truncate the master before the occurrence, then create a
+    // fresh standalone non-recurring event at the split point (#93).
+    if span == "thisAndFollowing",
+       patch.clearedFields.contains("recurrenceRule"),
+       let timestamp = timestamp {
+      let occurrenceDate =
+        Date(timeIntervalSince1970: TimeInterval(timestamp) / 1000.0)
+      guard let master = eventStore.event(withIdentifier: eventId),
+            let masterRule = master.recurrenceRules?.first else {
+        completion(.failure(CalendarError(
+          code: PlatformExceptionCodes.operationFailed,
+          message: "Could not resolve the master series to split"
+        )))
+        return
+      }
+
+      // Truncate the original series to end just before the split occurrence.
+      master.recurrenceRules = [ruleTruncated(masterRule, endingBefore: occurrenceDate)]
+
+      // The standalone event carries the occurrence's (already patched) fields
+      // with no recurrence. `foundEvent` is the occurrence and is never saved,
+      // so its mutations don't touch the master.
+      let standalone = EKEvent(eventStore: eventStore)
+      standalone.calendar = foundEvent.calendar
+      standalone.title = foundEvent.title
+      standalone.isAllDay = foundEvent.isAllDay
+      standalone.startDate = foundEvent.startDate
+      standalone.endDate = foundEvent.endDate
+      standalone.notes = foundEvent.notes
+      standalone.location = foundEvent.location
+      standalone.url = foundEvent.url
+      standalone.timeZone = foundEvent.timeZone
+      standalone.availability = foundEvent.availability
+
+      do {
+        try eventStore.save(master, span: .futureEvents, commit: false)
+        try eventStore.save(standalone, span: .thisEvent, commit: true)
+        completion(.success(standalone.eventIdentifier ?? eventId))
+      } catch {
+        eventStore.reset()
+        completion(.failure(CalendarError(
+          code: PlatformExceptionCodes.operationFailed,
+          message: "Failed to detach occurrence into a standalone event: \(error.localizedDescription)"
+        )))
+      }
+      return
+    }
 
     // Apply the recurrence-rule patch.
     if patch.clearedFields.contains("recurrenceRule") {


### PR DESCRIPTION
Closes #93.

@SuperKrallan filed this against 0.4.x, where `EventSpan.thisInstance` + `recurrenceRule` threw. That API is gone since 0.5.0 — single-occurrence edits now go through `updateEvent`/`deleteEvent` with an instance ID, and the three cases from the issue map cleanly:

| Issue case | Current API |
|---|---|
| **This event** (detach one occurrence) | `updateEvent(eventId: instanceId, …)` |
| **This & future** (anchor → standalone, future dropped) | `updateRecurring(instanceId, thisAndFollowing, recurrenceRule: Patch.clear())` |
| **All** (collapse series to one event) | `updateRecurring(instanceId, allEvents, recurrenceRule: Patch.clear())` |

While adding a regression test for the **this & future** case, I found iOS was silently wrong on it.

### The bug
On iOS, setting `recurrenceRules = nil` and saving `.futureEvents` doesn't split the series — with no rule there's nothing for EventKit to detach forward, so it edits the underlying master and **collapses the whole series into one event at the original start** (the `allEvents` outcome). Android already did the right thing.

### The fix
Mirror Android: truncate the master's rule to end just before the occurrence, then create a fresh standalone non-recurring event at the split point. Earlier occurrences stay in the original series; future ones are gone.

### Tests
New integration test asserts: master keeps only pre-split occurrences, the detached event is non-recurring and sits at the split point, and it expands to exactly one occurrence. Green on **iOS simulator + physical iPhone** and **Android emulator + physical device**.

Changelog entry lands with the 0.5.2 release prep, alongside the other bundled fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)