### PR TITLE
chore(release): prepare 0.5.2

### DIFF
--- a/packages/device_calendar_plus/CHANGELOG.md
+++ b/packages/device_calendar_plus/CHANGELOG.md
@@ -1,3 +1,33 @@
+## 0.5.2 - 2026-06-15
+
+### Changed
+- No-op updates are now valid instead of throwing. `updateEvent`,
+  `updateRecurring` and `updateCalendar` return without a platform write when
+  no fields are provided, so "save with no edits" is a harmless no-op rather
+  than an `ArgumentError` (#95). `updateRecurring` returns the targeted scope's
+  event id. `updateRecurring`'s `duration` now accepts zero (an instantaneous
+  event); only a negative duration is rejected.
+
+### Fixed
+- Recurrence parsing accepts a negative `BYMONTHDAY` (e.g. `-1` for the last
+  day of the month) instead of rejecting the rule (#91)
+- Turning a recurring occurrence non-recurring with `thisAndFollowing` +
+  `Patch.clear()` now splits the series on iOS instead of collapsing the whole
+  series into one event (#93) — see the `device_calendar_plus_ios` changelog
+- `listEvents` returns every event across spans longer than ~4 years without
+  dropping or duplicating recurring instances (iOS, #94), and includes
+  zero-duration events sitting exactly on the query start (Android, #416) — see
+  the platform changelogs
+- `createCalendar` fails with a clear error on iOS sources that can't hold
+  calendars, instead of an opaque failure (#96) — see the
+  `device_calendar_plus_ios` changelog
+- iOS EventKit operations run off the main thread, preventing UI stalls on
+  large calendars (#79) — see the `device_calendar_plus_ios` changelog
+
+### Docs
+- Documented `listEvents` per-instance expansion and the `eventId@timestamp`
+  instanceId format (#97)
+
 ## 0.5.1 - 2026-06-15
 
 ### Fixed

--- a/packages/device_calendar_plus/pubspec.yaml
+++ b/packages/device_calendar_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus
 description: A modern, maintained Flutter plugin for reading and writing device calendar events on Android and iOS.
-version: 0.5.1
+version: 0.5.2
 repository: https://github.com/bullet-to/device_calendar_plus
 issue_tracker: https://github.com/bullet-to/device_calendar_plus/issues
 
@@ -20,9 +20,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  device_calendar_plus_platform_interface: ^0.5.1
-  device_calendar_plus_android: ^0.5.1
-  device_calendar_plus_ios: ^0.5.1
+  device_calendar_plus_platform_interface: ^0.5.2
+  device_calendar_plus_android: ^0.5.2
+  device_calendar_plus_ios: ^0.5.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/device_calendar_plus_android/CHANGELOG.md
+++ b/packages/device_calendar_plus_android/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.5.2 - 2026-06-15
+
+### Fixed
+- `listEvents` now returns a zero-duration (instantaneous) event that sits
+  exactly on the query's start time; the half-open overlap check previously
+  excluded it (#416)
+
 ## 0.5.1 - 2026-06-15
 
 - No functional changes; version aligned with the rest of the suite for the

--- a/packages/device_calendar_plus_android/pubspec.yaml
+++ b/packages/device_calendar_plus_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus_android
 description: Android implementation of the device_calendar_plus plugin.
-version: 0.5.1
+version: 0.5.2
 repository: https://github.com/bullet-to/device_calendar_plus
 
 resolution: workspace
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  device_calendar_plus_platform_interface: ^0.5.1
+  device_calendar_plus_platform_interface: ^0.5.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/device_calendar_plus_ios/CHANGELOG.md
+++ b/packages/device_calendar_plus_ios/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 0.5.2 - 2026-06-15
+
+### Fixed
+- EventKit reads and writes now run on a background serial queue instead of the
+  main thread, so operations on large calendars no longer stall the UI (#79)
+- `listEvents` over a span longer than EventKit's ~4-year predicate limit now
+  chunks the query into windows and de-duplicates recurring instances across
+  window boundaries, so long ranges return every event exactly once, sorted
+  (#94)
+- `createCalendar` now fails with a clear error on sources that can't hold
+  calendars (e.g. subscribed/holiday sources) instead of an opaque EventKit
+  failure (#96)
+- `updateRecurring(thisAndFollowing, recurrenceRule: Patch.clear())` now splits
+  the series — truncating the master before the occurrence and detaching a
+  standalone non-recurring event at the split point — instead of collapsing the
+  whole series into a single event. Matches Android's behavior (#93)
+
 ## 0.5.1 - 2026-06-15
 
 ### Fixed

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -994,6 +994,67 @@ class EventsService {
     return Calendar.current.date(from: components)
   }
 
+  /// Splits a `thisAndFollowing` series at `occurrence` and turns that
+  /// occurrence into a standalone non-recurring event, dropping every later
+  /// occurrence (earlier ones stay in the original series).
+  ///
+  /// EventKit can't do this natively: setting `recurrenceRules = nil` and
+  /// saving `.futureEvents` has no future series to detach, so it edits the
+  /// master and collapses the WHOLE series into one event at the original
+  /// start (the `allEvents` outcome). So mirror Android: truncate the master
+  /// before the occurrence, then create a fresh standalone event at the split
+  /// point.
+  ///
+  /// `occurrence` must already carry the caller's patched field values; it is
+  /// only read here (never saved), so its mutations don't touch the master.
+  private func detachThisAndFollowing(
+    occurrence: EKEvent,
+    eventId: String,
+    occurrenceDate: Date,
+    completion: @escaping (Result<String, CalendarError>) -> Void
+  ) {
+    guard let master = eventStore.event(withIdentifier: eventId),
+          let masterRule = master.recurrenceRules?.first else {
+      completion(.failure(CalendarError(
+        code: PlatformExceptionCodes.operationFailed,
+        message: "Could not resolve the master series to split"
+      )))
+      return
+    }
+
+    // Truncate the original series to end just before the split occurrence.
+    master.recurrenceRules = [ruleTruncated(masterRule, endingBefore: occurrenceDate)]
+
+    // The standalone carries the occurrence's fields with no recurrence. This
+    // field set mirrors Android's `insertEvent` in `updateRecurringThisAndFollowing`.
+    let standalone = EKEvent(eventStore: eventStore)
+    standalone.calendar = occurrence.calendar
+    standalone.title = occurrence.title
+    standalone.isAllDay = occurrence.isAllDay
+    standalone.startDate = occurrence.startDate
+    standalone.endDate = occurrence.endDate
+    standalone.notes = occurrence.notes
+    standalone.location = occurrence.location
+    standalone.url = occurrence.url
+    standalone.timeZone = occurrence.timeZone
+    standalone.availability = occurrence.availability
+
+    // Two-phase save: stage the truncation uncommitted, then commit both with
+    // the standalone. On failure `reset()` discards both so the calendar is
+    // left untouched (mirrors Android's roll-back of the new series).
+    do {
+      try eventStore.save(master, span: .futureEvents, commit: false)
+      try eventStore.save(standalone, span: .thisEvent, commit: true)
+      completion(.success(standalone.eventIdentifier ?? eventId))
+    } catch {
+      eventStore.reset()
+      completion(.failure(CalendarError(
+        code: PlatformExceptionCodes.operationFailed,
+        message: "Failed to detach occurrence into a standalone event: \(error.localizedDescription)"
+      )))
+    }
+  }
+
   /// Updates a recurring event, choosing which occurrences the edit affects.
   ///
   /// `span` is "allEvents" (the whole series) or "thisAndFollowing" (split the
@@ -1114,56 +1175,19 @@ class EventsService {
 
     patch.applyTimeZone(to: foundEvent)
 
-    // Clearing the rule on a `thisAndFollowing` split needs special handling.
-    // Setting `recurrenceRules = nil` and saving `.futureEvents` does NOT
-    // split — with no rule there is no future series for EventKit to detach,
-    // so it edits the underlying master and collapses the WHOLE series into a
-    // single event at the original start (the `allEvents` outcome). Instead,
-    // mirror Android: truncate the master before the occurrence, then create a
-    // fresh standalone non-recurring event at the split point (#93).
+    // Clearing the rule on a `thisAndFollowing` split is the one case EventKit
+    // gets wrong natively (it collapses the whole series), so it splits the
+    // series by hand rather than through the shared save below — mirror
+    // Android's dedicated `updateRecurringThisAndFollowing` (#93).
     if span == "thisAndFollowing",
        patch.clearedFields.contains("recurrenceRule"),
        let timestamp = timestamp {
-      let occurrenceDate =
-        Date(timeIntervalSince1970: TimeInterval(timestamp) / 1000.0)
-      guard let master = eventStore.event(withIdentifier: eventId),
-            let masterRule = master.recurrenceRules?.first else {
-        completion(.failure(CalendarError(
-          code: PlatformExceptionCodes.operationFailed,
-          message: "Could not resolve the master series to split"
-        )))
-        return
-      }
-
-      // Truncate the original series to end just before the split occurrence.
-      master.recurrenceRules = [ruleTruncated(masterRule, endingBefore: occurrenceDate)]
-
-      // The standalone event carries the occurrence's (already patched) fields
-      // with no recurrence. `foundEvent` is the occurrence and is never saved,
-      // so its mutations don't touch the master.
-      let standalone = EKEvent(eventStore: eventStore)
-      standalone.calendar = foundEvent.calendar
-      standalone.title = foundEvent.title
-      standalone.isAllDay = foundEvent.isAllDay
-      standalone.startDate = foundEvent.startDate
-      standalone.endDate = foundEvent.endDate
-      standalone.notes = foundEvent.notes
-      standalone.location = foundEvent.location
-      standalone.url = foundEvent.url
-      standalone.timeZone = foundEvent.timeZone
-      standalone.availability = foundEvent.availability
-
-      do {
-        try eventStore.save(master, span: .futureEvents, commit: false)
-        try eventStore.save(standalone, span: .thisEvent, commit: true)
-        completion(.success(standalone.eventIdentifier ?? eventId))
-      } catch {
-        eventStore.reset()
-        completion(.failure(CalendarError(
-          code: PlatformExceptionCodes.operationFailed,
-          message: "Failed to detach occurrence into a standalone event: \(error.localizedDescription)"
-        )))
-      }
+      detachThisAndFollowing(
+        occurrence: foundEvent,
+        eventId: eventId,
+        occurrenceDate: Date(timeIntervalSince1970: TimeInterval(timestamp) / 1000.0),
+        completion: completion
+      )
       return
     }
 

--- a/packages/device_calendar_plus_ios/pubspec.yaml
+++ b/packages/device_calendar_plus_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus_ios
 description: iOS implementation of the device_calendar_plus plugin.
-version: 0.5.1
+version: 0.5.2
 repository: https://github.com/bullet-to/device_calendar_plus
 
 resolution: workspace
@@ -12,7 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  device_calendar_plus_platform_interface: ^0.5.1
+  device_calendar_plus_platform_interface: ^0.5.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/device_calendar_plus_platform_interface/CHANGELOG.md
+++ b/packages/device_calendar_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.5.2 - 2026-06-15
+
+- No functional changes; version aligned with the rest of the suite for the
+  0.5.2 release
+
 ## 0.5.1 - 2026-06-15
 
 ### Docs

--- a/packages/device_calendar_plus_platform_interface/pubspec.yaml
+++ b/packages/device_calendar_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus_platform_interface
 description: Platform interface for device_calendar_plus plugin.
-version: 0.5.1
+version: 0.5.2
 repository: https://github.com/bullet-to/device_calendar_plus
 
 resolution: workspace


### PR DESCRIPTION
Bundles the fixes that landed since 0.5.1 and bumps all four packages **0.5.1 → 0.5.2** in lockstep (cross-dep constraints → `^0.5.2`).

### What's in it
- **device_calendar_plus** — no-op updates are valid instead of throwing (#95); negative `BYMONTHDAY` accepted (#91); `listEvents` per-instance docs (#97)
- **ios** — EventKit runs off the main thread (#79); `listEvents` 4-year chunking + de-dup (#94); `createCalendar` source guard (#96); `thisAndFollowing` + `Patch.clear()` splits the series instead of collapsing it (#93)
- **android** — `listEvents` returns zero-duration events sitting on the query start (#416)
- **platform_interface** — no functional changes; version aligned

Also folds in the iOS `detachThisAndFollowing` extraction that missed the #101 merge (behavior-preserving; verified green on iOS + Android).

### Verification
- All four packages: `dart pub publish --dry-run` → **0 warnings**
- `flutter analyze` clean; 168 unit tests pass
- Recurrence integration suites green on iOS (sim + physical) and Android (emulator + physical)

After merge: tag `v0.5.2` and run `./deploy.sh` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)