### PR TITLE
refactor(permissions): square Android partial-grant with iOS + tidy native paths

### DIFF
--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/PermissionService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/PermissionService.kt
@@ -63,6 +63,31 @@ class PermissionService(private val context: Context) {
     }
 
     /**
+     * The access tier implied purely by which calendar permissions are
+     * currently granted: [STATUS_GRANTED] (read + write), [STATUS_WRITE_ONLY]
+     * (write alone — genuine add-only access, mirroring iOS 17+), or `null` when
+     * write access isn't held. A `null` means there is no positive tier, so the
+     * caller decides whether that reads as denied or not-yet-determined.
+     */
+    private fun grantedTier(): String? {
+        val readGranted = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.READ_CALENDAR
+        ) == PackageManager.PERMISSION_GRANTED
+
+        val writeGranted = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.WRITE_CALENDAR
+        ) == PackageManager.PERMISSION_GRANTED
+
+        return when {
+            readGranted && writeGranted -> STATUS_GRANTED
+            writeGranted -> STATUS_WRITE_ONLY
+            else -> null
+        }
+    }
+
+    /**
      * Determines the current calendar permission status, distinguishing between
      * "never asked" ([STATUS_NOT_DETERMINED]) and "denied" ([STATUS_DENIED]).
      *
@@ -88,29 +113,17 @@ class PermissionService(private val context: Context) {
      * https://github.com/Baseflow/flutter-permission-handler/blob/39fba431428e5d82d35f4999663461468fe3a728/permission_handler_android/android/src/main/java/com/baseflow/permissionhandler/PermissionUtils.java#L400-L536
      */
     private fun getCurrentPermissionStatus(): String {
-        val readPermission = Manifest.permission.READ_CALENDAR
-        val writePermission = Manifest.permission.WRITE_CALENDAR
+        // Holding write access is a positive tier (full or write-only).
+        grantedTier()?.let { return it }
 
-        val readGranted = ContextCompat.checkSelfPermission(
-            context,
-            readPermission
-        ) == PackageManager.PERMISSION_GRANTED
-
-        val writeGranted = ContextCompat.checkSelfPermission(
-            context,
-            writePermission
-        ) == PackageManager.PERMISSION_GRANTED
-
-        if (readGranted && writeGranted) return STATUS_GRANTED
-
-        // Write granted but not read is genuine write-only access — the add-only
-        // tier requested via CalendarAccessLevel.writeOnly. (Reported on Android
-        // too, mirroring iOS 17+.)
-        if (writeGranted) return STATUS_WRITE_ONLY
-
-        val deniedPermissions = mutableListOf<String>()
-        if (!readGranted) deniedPermissions.add(readPermission)
-        if (!writeGranted) deniedPermissions.add(writePermission)
+        // Otherwise write isn't granted. Distinguish "never asked / can ask
+        // again" (NOT_DETERMINED) from "permanently denied" (DENIED).
+        val deniedPermissions = listOf(
+            Manifest.permission.READ_CALENDAR,
+            Manifest.permission.WRITE_CALENDAR
+        ).filter {
+            ContextCompat.checkSelfPermission(context, it) != PackageManager.PERMISSION_GRANTED
+        }
 
         // Without an Activity we can't check shouldShowRequestPermissionRationale,
         // so fall back to NOT_DETERMINED (safe default — caller can still request).
@@ -121,9 +134,7 @@ class PermissionService(private val context: Context) {
                 ActivityCompat.shouldShowRequestPermissionRationale(currentActivity, it)
             }
 
-        if (permanentlyDenied) return STATUS_DENIED
-
-        return STATUS_NOT_DETERMINED
+        return if (permanentlyDenied) STATUS_DENIED else STATUS_NOT_DETERMINED
     }
 
     private fun wasPermissionDeniedBefore(permissionName: String): Boolean {
@@ -214,25 +225,22 @@ class PermissionService(private val context: Context) {
         val callback = pendingCallback ?: return false
         pendingCallback = null
         
-        // Every requested permission granted? (A write-only request asks for
-        // WRITE_CALENDAR alone, so "all" is just that one.)
-        val allGranted = grantResults.isNotEmpty() &&
-            grantResults.all { it == PackageManager.PERMISSION_GRANTED }
-
-        if (!allGranted) {
-            permissions.forEachIndexed { index, permission ->
-                if (grantResults.getOrNull(index) != PackageManager.PERMISSION_GRANTED) {
-                    setPermissionDenied(permission)
-                }
+        // Record any denials so a later hasPermissions() can tell a permanent
+        // denial from a can-ask-again one.
+        permissions.forEachIndexed { index, permission ->
+            if (grantResults.getOrNull(index) != PackageManager.PERMISSION_GRANTED) {
+                setPermissionDenied(permission)
             }
-            callback(Result.success(STATUS_DENIED))
-            return true
         }
 
-        // Report the tier actually held — getCurrentPermissionStatus distinguishes
-        // full (read + write) from write-only (write alone), so a granted
-        // write-only request resolves to STATUS_WRITE_ONLY.
-        callback(Result.success(getCurrentPermissionStatus()))
+        // Report the tier actually held. WRITE_CALENDAR is the capability that
+        // matters: hold it and the app has at least write-only access, so a
+        // full request that granted write but denied read reads as writeOnly —
+        // not denied — matching iOS, which reports the real tier on a non-full
+        // grant. Lacking write, the request was denied. We use STATUS_DENIED
+        // here (not getCurrentPermissionStatus's can-ask-again NOT_DETERMINED)
+        // because a just-denied request should read as denied, again as on iOS.
+        callback(Result.success(grantedTier() ?: STATUS_DENIED))
         return true
     }
 }

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/PermissionService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/PermissionService.kt
@@ -105,7 +105,8 @@ class PermissionService(private val context: Context) {
      * | Denied once        | Dismiss | true                | true             |
      * | Permanently denied | Denied | false              | true             |
      *
-     * Decision logic when [PackageManager.PERMISSION_DENIED]:
+     * Decision logic when write access isn't held (keyed off WRITE_CALENDAR
+     * alone — the capability that defines whether any tier is reachable):
      * - `shouldShowRationale == false` AND SharedPrefs flag set --> [STATUS_DENIED] (permanently denied, must use app settings)
      * - everything else --> [STATUS_NOT_DETERMINED] (permission dialog can still be shown)
      *
@@ -117,22 +118,18 @@ class PermissionService(private val context: Context) {
         grantedTier()?.let { return it }
 
         // Otherwise write isn't granted. Distinguish "never asked / can ask
-        // again" (NOT_DETERMINED) from "permanently denied" (DENIED).
-        val deniedPermissions = listOf(
-            Manifest.permission.READ_CALENDAR,
-            Manifest.permission.WRITE_CALENDAR
-        ).filter {
-            ContextCompat.checkSelfPermission(context, it) != PackageManager.PERMISSION_GRANTED
-        }
+        // again" (NOT_DETERMINED) from "permanently denied" (DENIED). WRITE is
+        // the capability that defines whether any tier is reachable (a held
+        // READ-only state isn't possible — grantedTier already returned for any
+        // write-bearing tier), so the decision keys off WRITE alone.
+        val writePermission = Manifest.permission.WRITE_CALENDAR
 
         // Without an Activity we can't check shouldShowRequestPermissionRationale,
         // so fall back to NOT_DETERMINED (safe default — caller can still request).
         val currentActivity = activity ?: return STATUS_NOT_DETERMINED
 
-        val permanentlyDenied = deniedPermissions.any { wasPermissionDeniedBefore(it) } &&
-            deniedPermissions.none {
-                ActivityCompat.shouldShowRequestPermissionRationale(currentActivity, it)
-            }
+        val permanentlyDenied = wasPermissionDeniedBefore(writePermission) &&
+            !ActivityCompat.shouldShowRequestPermissionRationale(currentActivity, writePermission)
 
         return if (permanentlyDenied) STATUS_DENIED else STATUS_NOT_DETERMINED
     }
@@ -224,7 +221,16 @@ class PermissionService(private val context: Context) {
         
         val callback = pendingCallback ?: return false
         pendingCallback = null
-        
+
+        // A dismissed dialog delivers empty arrays — no grant, no denial. Report
+        // the real current status (can-ask-again) instead of a hard denial, so a
+        // later hasPermissions() doesn't disagree. Mirrors iOS, which re-reads
+        // the real status on a dismissed prompt.
+        if (grantResults.isEmpty()) {
+            callback(Result.success(getCurrentPermissionStatus()))
+            return true
+        }
+
         // Record any denials so a later hasPermissions() can tell a permanent
         // denial from a can-ask-again one.
         permissions.forEachIndexed { index, permission ->

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/PermissionService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/PermissionService.swift
@@ -189,30 +189,25 @@ class PermissionService {
     // dialog asking for full access and upgrades the app in-app if the user
     // agrees. On a non-grant we re-read the real status so the caller still sees
     // the tier they actually hold (e.g. writeOnly), not a misleading denied.
-    let writeOnlySupported: Bool
-    if #available(iOS 17.0, *) {
-      writeOnlySupported = true
-    } else {
-      writeOnlySupported = false
-    }
-
     // Report the tier we asked for on a grant; on a non-grant re-read the real
-    // status. (iOS 16 has only full access, so a write-only ask there grants
-    // full.) One handler serves all three request variants.
-    let grantedStatus = (writeOnly && writeOnlySupported)
-      ? PermissionService.statusWriteOnly
-      : PermissionService.statusGranted
-    let handler: (Bool, Error?) -> Void = { granted, _ in
-      completion(.success(granted ? grantedStatus : self.getCurrentPermissionStatus()))
-    }
-
+    // status. One handler serves all three request variants.
     if #available(iOS 17.0, *) {
+      let grantedStatus = writeOnly
+        ? PermissionService.statusWriteOnly
+        : PermissionService.statusGranted
+      let handler: (Bool, Error?) -> Void = { granted, _ in
+        completion(.success(granted ? grantedStatus : self.getCurrentPermissionStatus()))
+      }
       if writeOnly {
         eventStore.requestWriteOnlyAccessToEvents(completion: handler)
       } else {
         eventStore.requestFullAccessToEvents(completion: handler)
       }
     } else {
+      // iOS 16 and below: only full access exists, so any grant is full access.
+      let handler: (Bool, Error?) -> Void = { granted, _ in
+        completion(.success(granted ? PermissionService.statusGranted : self.getCurrentPermissionStatus()))
+      }
       eventStore.requestAccess(to: .event, completion: handler)
     }
   }

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/PermissionService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/PermissionService.swift
@@ -68,6 +68,26 @@ class PermissionService {
     return !(value?.isEmpty ?? true)
   }
 
+  private func missingWriteOnlyDescriptionError() -> PermissionError {
+    var errorMessage = "Write-only calendar usage description not declared in Info.plist.\n\n"
+    errorMessage += "Add the following to ios/Runner/Info.plist:\n"
+    errorMessage += "<key>NSCalendarsWriteOnlyAccessUsageDescription</key>\n"
+    errorMessage += "<string>Add events without reading existing events.</string>"
+
+    return PermissionError(code: PlatformExceptionCodes.permissionsNotDeclared, message: errorMessage)
+  }
+
+  private func missingUsageDescriptionError() -> PermissionError {
+    var errorMessage = "Calendar usage description not declared in Info.plist.\n\n"
+    errorMessage += "Add the following to ios/Runner/Info.plist:\n"
+    errorMessage += "<key>NSCalendarsUsageDescription</key>\n"
+    errorMessage += "<string>Access your calendar to view and manage events.</string>\n"
+    errorMessage += "<key>NSCalendarsWriteOnlyAccessUsageDescription</key>\n"
+    errorMessage += "<string>Add events without reading existing events.</string>"
+
+    return PermissionError(code: PlatformExceptionCodes.permissionsNotDeclared, message: errorMessage)
+  }
+
   /// Verifies the Info.plist declares the usage description the request needs.
   ///
   /// A write-only request on iOS 17+ goes through `requestWriteOnlyAccessToEvents`,
@@ -76,29 +96,12 @@ class PermissionService {
   /// Every other path uses `NSCalendarsUsageDescription`.
   private func checkUsageDescriptionDeclared(writeOnly: Bool) -> PermissionError? {
     if writeOnly, #available(iOS 17.0, *) {
-      if !isDescriptionDeclared("NSCalendarsWriteOnlyAccessUsageDescription") {
-        var errorMessage = "Write-only calendar usage description not declared in Info.plist.\n\n"
-        errorMessage += "Add the following to ios/Runner/Info.plist:\n"
-        errorMessage += "<key>NSCalendarsWriteOnlyAccessUsageDescription</key>\n"
-        errorMessage += "<string>Add events without reading existing events.</string>"
-
-        return PermissionError(code: PlatformExceptionCodes.permissionsNotDeclared, message: errorMessage)
-      }
-      return nil
+      return isDescriptionDeclared("NSCalendarsWriteOnlyAccessUsageDescription")
+        ? nil : missingWriteOnlyDescriptionError()
     }
 
-    if !isDescriptionDeclared("NSCalendarsUsageDescription") {
-      var errorMessage = "Calendar usage description not declared in Info.plist.\n\n"
-      errorMessage += "Add the following to ios/Runner/Info.plist:\n"
-      errorMessage += "<key>NSCalendarsUsageDescription</key>\n"
-      errorMessage += "<string>Access your calendar to view and manage events.</string>\n"
-      errorMessage += "<key>NSCalendarsWriteOnlyAccessUsageDescription</key>\n"
-      errorMessage += "<string>Add events without reading existing events.</string>"
-
-      return PermissionError(code: PlatformExceptionCodes.permissionsNotDeclared, message: errorMessage)
-    }
-
-    return nil
+    return isDescriptionDeclared("NSCalendarsUsageDescription")
+      ? nil : missingUsageDescriptionError()
   }
   
   private func getCurrentPermissionStatus() -> String {
@@ -141,10 +144,9 @@ class PermissionService {
     // A status check triggers no prompt, so any declared calendar usage
     // description — full or write-only — satisfies the configuration guard. An
     // add-only app that declares only the write-only key can still check status.
-    let declared = isDescriptionDeclared("NSCalendarsUsageDescription")
-      || isDescriptionDeclared("NSCalendarsWriteOnlyAccessUsageDescription")
-    if !declared, let error = checkUsageDescriptionDeclared(writeOnly: false) {
-      return .failure(error)
+    guard isDescriptionDeclared("NSCalendarsUsageDescription")
+      || isDescriptionDeclared("NSCalendarsWriteOnlyAccessUsageDescription") else {
+      return .failure(missingUsageDescriptionError())
     }
 
     return .success(getCurrentPermissionStatus())
@@ -182,35 +184,36 @@ class PermissionService {
       return
     }
 
-    // Otherwise attempt the request. This prompts on a fresh notDetermined.
-    //
-    // The one case that can't actually prompt: a full request while write-only
-    // is held. iOS treats write-only as a *determined* status, so
-    // requestFullAccessToEvents returns immediately without UI and not-granted —
-    // upgrading write-only → full requires Settings. On a non-grant we re-read
-    // the real status so the caller still sees writeOnly (route them to
-    // openAppSettings), not a misleading denied.
+    // Otherwise attempt the request. This prompts on a fresh notDetermined, and
+    // also on a full request while only write-only is held — iOS re-presents the
+    // dialog asking for full access and upgrades the app in-app if the user
+    // agrees. On a non-grant we re-read the real status so the caller still sees
+    // the tier they actually hold (e.g. writeOnly), not a misleading denied.
+    let writeOnlySupported: Bool
+    if #available(iOS 17.0, *) {
+      writeOnlySupported = true
+    } else {
+      writeOnlySupported = false
+    }
+
+    // Report the tier we asked for on a grant; on a non-grant re-read the real
+    // status. (iOS 16 has only full access, so a write-only ask there grants
+    // full.) One handler serves all three request variants.
+    let grantedStatus = (writeOnly && writeOnlySupported)
+      ? PermissionService.statusWriteOnly
+      : PermissionService.statusGranted
+    let handler: (Bool, Error?) -> Void = { granted, _ in
+      completion(.success(granted ? grantedStatus : self.getCurrentPermissionStatus()))
+    }
+
     if #available(iOS 17.0, *) {
       if writeOnly {
-        eventStore.requestWriteOnlyAccessToEvents { granted, error in
-          completion(.success(granted
-            ? PermissionService.statusWriteOnly
-            : self.getCurrentPermissionStatus()))
-        }
+        eventStore.requestWriteOnlyAccessToEvents(completion: handler)
       } else {
-        eventStore.requestFullAccessToEvents { granted, error in
-          completion(.success(granted
-            ? PermissionService.statusGranted
-            : self.getCurrentPermissionStatus()))
-        }
+        eventStore.requestFullAccessToEvents(completion: handler)
       }
     } else {
-      // iOS 16 and below has only the single full-access tier.
-      eventStore.requestAccess(to: .event) { granted, error in
-        completion(.success(granted
-          ? PermissionService.statusGranted
-          : self.getCurrentPermissionStatus()))
-      }
+      eventStore.requestAccess(to: .event, completion: handler)
     }
   }
 }


### PR DESCRIPTION
Follow-up to #107. Two native cleanups, no API change.

**Android** — factored `grantedTier()` so the status check and the request-result handler share one "tier you actually hold" mapping. Net behaviour change: a full request that grants `WRITE` but denies `READ` now reports `writeOnly` (matching iOS, which reports the real tier on a non-full grant) instead of `denied`. A fresh write denial still reads as `denied`.

**iOS** — collapsed `requestPermissions` into `alreadySatisfied` / `terminal` early-returns plus one shared completion handler across the three request variants, and pulled the missing-usage-description errors into small builders.

Pure native refactor; Dart tests unaffected. Wants an on-device pass (can't compile native in CI here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)