### PR TITLE
docs(permissions): correct iOS write-only upgrade behaviour

### DIFF
--- a/packages/device_calendar_plus/README.md
+++ b/packages/device_calendar_plus/README.md
@@ -196,16 +196,18 @@ if (status == CalendarPermissionStatus.writeOnly ||
   (`requestWriteOnlyAccessToEvents`). Add `NSCalendarsWriteOnlyAccessUsageDescription`
   to `Info.plist`. On iOS 16 and below there is no write-only tier, so this
   falls back to a full-access request and a grant reports `granted`. Write-only
-  is a durable tier here — escalating to full requires the user to change it in
-  Settings.
-- **Android**: requests only `WRITE_CALENDAR`. This is a softer boundary than on
-  iOS: `WRITE_CALENDAR` and `READ_CALENDAR` are in the same `CALENDAR`
-  permission group, so after a write-only grant a later
-  `requestPermissions()` (full) escalates to read access **immediately, with no
-  dialog**, and returns `granted`.
+  is not a ceiling — a later `requestPermissions()` (full) re-prompts and
+  upgrades the app to full access in-app if the user agrees.
+- **Android**: requests only `WRITE_CALENDAR`. `WRITE_CALENDAR` and
+  `READ_CALENDAR` are in the same `CALENDAR` permission group, so after a
+  write-only grant a later `requestPermissions()` (full) escalates to read
+  access **immediately, with no dialog** (where iOS shows a second prompt), and
+  returns `granted`.
 
-On iOS, request the level you need up front — once granted, the OS won't
-re-prompt to change the tier in-app.
+If you start with write-only and later need full read access, just call
+`requestPermissions()` again — iOS shows a second prompt for the upgrade and
+Android escalates silently. Either way the upgrade happens in-app; no trip to
+Settings required.
 
 ### Check Permissions
 

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -63,16 +63,15 @@ class DeviceCalendar {
   /// If you already hold a tier that satisfies the request, this returns
   /// immediately without prompting (full access satisfies a write-only ask).
   /// Requesting [CalendarAccessLevel.full] while only write-only is held
-  /// behaves differently per platform:
+  /// upgrades the app on both platforms — only the prompt differs:
   /// - **Android**: `READ_CALENDAR` and `WRITE_CALENDAR` belong to the same
   ///   `CALENDAR` permission group, so once write-only has granted
   ///   `WRITE_CALENDAR` the OS grants the read upgrade **immediately, with no
-  ///   dialog**, and this returns [CalendarPermissionStatus.granted]. Write-only
-  ///   is therefore not a hard boundary on Android — an app can escalate to full
-  ///   silently just by asking.
-  /// - **iOS**: treats the write-only choice as final and can't re-prompt
-  ///   in-app, so it returns the existing [CalendarPermissionStatus.writeOnly] —
-  ///   send the user to [openAppSettings] to grant full access there.
+  ///   dialog**, and this returns [CalendarPermissionStatus.granted].
+  /// - **iOS**: re-presents the system dialog, this time asking for full
+  ///   access. If the user agrees this returns [CalendarPermissionStatus.granted];
+  ///   if they decline it returns the still-held
+  ///   [CalendarPermissionStatus.writeOnly].
   ///
   /// Returns a [CalendarPermissionStatus] indicating the result
   ///

--- a/packages/device_calendar_plus/lib/src/calendar_access_level.dart
+++ b/packages/device_calendar_plus/lib/src/calendar_access_level.dart
@@ -19,15 +19,16 @@ enum CalendarAccessLevel {
   /// This is the gentler prompt for add-only apps. A granted request maps to
   /// [CalendarPermissionStatus.writeOnly].
   ///
-  /// - iOS 17+: `requestWriteOnlyAccessToEvents`. A distinct, durable tier — the
-  ///   app cannot escalate to full access without the user changing it in
-  ///   Settings.
+  /// - iOS 17+: `requestWriteOnlyAccessToEvents` — the gentler "Add Events Only"
+  ///   prompt. Not a permanent ceiling: a later [full] request re-prompts and,
+  ///   if the user agrees, upgrades the app to full access in-app.
   /// - iOS 16 and below: write-only does not exist, so this falls back to a
   ///   full-access request (`requestAccess(to: .event)`) and a granted result
   ///   reports [CalendarPermissionStatus.granted].
-  /// - Android: requests only `WRITE_CALENDAR`. Note this is a softer boundary
-  ///   than on iOS — `WRITE_CALENDAR` and `READ_CALENDAR` share the one
-  ///   `CALENDAR` permission group, so after a write-only grant a later
-  ///   full request escalates to read access **immediately, with no dialog**.
+  /// - Android: requests only `WRITE_CALENDAR`. `WRITE_CALENDAR` and
+  ///   `READ_CALENDAR` share the one `CALENDAR` permission group, so after a
+  ///   write-only grant a later full request escalates to read access
+  ///   **immediately, with no dialog** — where iOS shows a second prompt. Either
+  ///   way the upgrade succeeds in-app; only the prompt differs.
   writeOnly,
 }


### PR DESCRIPTION
Stacked on #108.

#107 shipped docs claiming iOS treats write-only as a durable/terminal tier you can only upgrade via Settings. That's wrong — calling `requestPermissions(level: full)` while holding write-only **re-prompts and upgrades the app in-app** if the user agrees (verified on device).

Fixes the claim in three places — the `CalendarAccessLevel` doc, the `requestPermissions` doc, and the README — so both platforms are described as upgrading: iOS via a second prompt, Android silently through the shared `CALENDAR` group.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)