### PR TITLE
feat(permissions): automatic permission requests (#90)

### DIFF
--- a/packages/device_calendar_plus/README.md
+++ b/packages/device_calendar_plus/README.md
@@ -235,7 +235,10 @@ Auto-permissions only act on a fresh (`notDetermined`) status — a tier you
 already hold is never silently escalated. If you hold write-only and call a read
 operation, you get `permissionDenied`, not a surprise prompt; call
 `requestPermissions(level: CalendarAccessLevel.full)` yourself when you want to
-ask for the upgrade (and to place any priming UI before it).
+ask for the upgrade (and to place any priming UI before it). Auto-mode prompts
+at most once per access level per app run — if the user declines, later calls
+throw `permissionDenied` rather than re-prompting; call `requestPermissions()`
+yourself to ask again.
 
 ### Check Permissions
 

--- a/packages/device_calendar_plus/README.md
+++ b/packages/device_calendar_plus/README.md
@@ -209,6 +209,34 @@ If you start with write-only and later need full read access, just call
 Android escalates silently. Either way the upgrade happens in-app; no trip to
 Settings required.
 
+#### Automatic permissions
+
+By default you request permission yourself. To have methods request it on first
+use instead, set `autoPermissions`:
+
+```dart
+// Set once, e.g. at app start.
+DeviceCalendar.instance.autoPermissions = AutoPermissionMode.asNeeded;
+
+// No explicit requestPermissions() needed — this prompts on first use, then
+// throws DeviceCalendarException(permissionDenied) if access isn't granted.
+await plugin.createEvent(/* ... */);
+```
+
+- `AutoPermissionMode.asNeeded` — each method asks for the minimum it needs:
+  add-only operations (`createEvent`, `showCreateEventModal`) request write-only,
+  everything else requests full. Defers the heavier full prompt until a read
+  actually happens.
+- `AutoPermissionMode.full` — request full access on the first operation that
+  needs it. Simplest for apps that read regularly.
+- `null` (the default) — manual: nothing prompts on its own.
+
+Auto-permissions only act on a fresh (`notDetermined`) status — a tier you
+already hold is never silently escalated. If you hold write-only and call a read
+operation, you get `permissionDenied`, not a surprise prompt; call
+`requestPermissions(level: CalendarAccessLevel.full)` yourself when you want to
+ask for the upgrade (and to place any priming UI before it).
+
 ### Check Permissions
 
 Use `hasPermissions()` to check the current permission status without prompting the user:

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -1,10 +1,12 @@
 import 'package:device_calendar_plus_platform_interface/device_calendar_plus_platform_interface.dart';
 import 'package:flutter/services.dart';
 
+import 'src/auto_permission_mode.dart';
 import 'src/calendar.dart';
 import 'src/calendar_access_level.dart';
 import 'src/calendar_permission_status.dart';
 import 'src/calendar_source.dart';
+import 'src/device_calendar_error.dart';
 import 'src/event.dart';
 import 'src/event_availability.dart';
 import 'src/event_span.dart';
@@ -26,6 +28,7 @@ export 'package:device_calendar_plus_platform_interface/device_calendar_plus_pla
         PatchClear;
 
 export 'src/attendee.dart';
+export 'src/auto_permission_mode.dart';
 export 'src/calendar.dart';
 export 'src/calendar_access_level.dart';
 export 'src/calendar_source.dart';
@@ -45,6 +48,22 @@ class DeviceCalendar {
   static final DeviceCalendar instance = DeviceCalendar._internal();
 
   factory DeviceCalendar() => instance;
+
+  /// Opts methods into requesting calendar permission automatically.
+  ///
+  /// When `null` (the default) nothing changes — methods never prompt on their
+  /// own and you call [requestPermissions] yourself. When set to an
+  /// [AutoPermissionMode], each method ensures the access it needs before
+  /// touching the platform: it requests permission once when the status is
+  /// [CalendarPermissionStatus.notDetermined], and throws a
+  /// [DeviceCalendarException] with [DeviceCalendarError.permissionDenied] if
+  /// access is not granted.
+  ///
+  /// Set this once, typically at app start:
+  /// ```dart
+  /// DeviceCalendar.instance.autoPermissions = AutoPermissionMode.asNeeded;
+  /// ```
+  AutoPermissionMode? autoPermissions;
 
   /// Requests calendar permissions from the user.
   ///
@@ -193,6 +212,51 @@ class DeviceCalendar {
     }
   }
 
+  /// Ensures the access an operation needs is held, requesting it when
+  /// [autoPermissions] is set. A no-op in manual mode (`autoPermissions ==
+  /// null`).
+  ///
+  /// [requiredTier] is the minimum access the calling operation needs:
+  /// [CalendarAccessLevel.writeOnly] for add-only operations, otherwise
+  /// [CalendarAccessLevel.full]. In [AutoPermissionMode.full] every request is
+  /// upgraded to full regardless of [requiredTier].
+  ///
+  /// Only a [CalendarPermissionStatus.notDetermined] status triggers a prompt;
+  /// a tier already held is never silently escalated. Throws
+  /// [DeviceCalendarException] ([DeviceCalendarError.permissionDenied]) when the
+  /// resulting access does not satisfy [requiredTier].
+  Future<void> _ensurePermission(CalendarAccessLevel requiredTier) async {
+    final mode = autoPermissions;
+    if (mode == null) return;
+
+    var status = await hasPermissions();
+    if (status == CalendarPermissionStatus.notDetermined) {
+      status = await requestPermissions(
+        level: mode == AutoPermissionMode.full
+            ? CalendarAccessLevel.full
+            : requiredTier,
+      );
+    }
+
+    if (!_satisfies(status, requiredTier)) {
+      throw DeviceCalendarException(
+        errorCode: DeviceCalendarError.permissionDenied,
+        message: 'Calendar access required for this operation was not granted '
+            '(autoPermissions: ${mode.name}).',
+      );
+    }
+  }
+
+  /// Whether [status] grants enough access for [tier]. Full access satisfies
+  /// any tier; write-only satisfies only a write-only requirement.
+  bool _satisfies(CalendarPermissionStatus status, CalendarAccessLevel tier) {
+    if (status == CalendarPermissionStatus.granted) return true;
+    if (status == CalendarPermissionStatus.writeOnly) {
+      return tier == CalendarAccessLevel.writeOnly;
+    }
+    return false;
+  }
+
   /// Converts a status value string to CalendarPermissionStatus
   CalendarPermissionStatus _convertStatusValue(String? statusValue) {
     // Default to denied if status is null or unrecognized
@@ -227,6 +291,7 @@ class DeviceCalendar {
   /// }
   /// ```
   Future<List<Calendar>> listCalendars() async {
+    await _ensurePermission(CalendarAccessLevel.full);
     try {
       final List<Map<String, dynamic>> rawCalendars =
           await DeviceCalendarPlusPlatform.instance.listCalendars();
@@ -261,6 +326,7 @@ class DeviceCalendar {
   /// }
   /// ```
   Future<List<CalendarSource>> listSources() async {
+    await _ensurePermission(CalendarAccessLevel.full);
     try {
       final List<Map<String, dynamic>> rawSources =
           await DeviceCalendarPlusPlatform.instance.listSources();
@@ -318,6 +384,7 @@ class DeviceCalendar {
       );
     }
 
+    await _ensurePermission(CalendarAccessLevel.full);
     try {
       final String calendarId = await DeviceCalendarPlusPlatform.instance
           .createCalendar(name, colorHex, platformOptions);
@@ -388,6 +455,7 @@ class DeviceCalendar {
       );
     }
 
+    await _ensurePermission(CalendarAccessLevel.full);
     try {
       await DeviceCalendarPlusPlatform.instance
           .updateCalendar(calendarId, name, colorHex);
@@ -416,6 +484,7 @@ class DeviceCalendar {
   /// await plugin.deleteCalendar(calendarId);
   /// ```
   Future<void> deleteCalendar(String calendarId) async {
+    await _ensurePermission(CalendarAccessLevel.full);
     try {
       await DeviceCalendarPlusPlatform.instance.deleteCalendar(calendarId);
     } on PlatformException catch (e, stackTrace) {
@@ -484,6 +553,7 @@ class DeviceCalendar {
     DateTime endDate, {
     List<String>? calendarIds,
   }) async {
+    await _ensurePermission(CalendarAccessLevel.full);
     try {
       final List<Map<String, dynamic>> rawEvents =
           await DeviceCalendarPlusPlatform.instance.listEvents(
@@ -521,6 +591,7 @@ class DeviceCalendar {
   /// final masterEvent = await plugin.getEvent(event.eventId);
   /// ```
   Future<Event?> getEvent(String id) async {
+    await _ensurePermission(CalendarAccessLevel.full);
     try {
       // Parse the ID to extract eventId and optional timestamp
       final parsed = InstanceIdParser.parse(id);
@@ -588,6 +659,7 @@ class DeviceCalendar {
   /// await plugin.showEventModal(event.instanceId, edit: true);
   /// ```
   Future<void> showEventModal(String id, {bool edit = false}) async {
+    await _ensurePermission(CalendarAccessLevel.full);
     try {
       final parsed = InstanceIdParser.parse(id);
 
@@ -689,6 +761,7 @@ class DeviceCalendar {
     final normalizedStartDate = isAllDay ? _stripTime(startDate) : startDate;
     final normalizedEndDate = isAllDay ? _stripTime(endDate) : endDate;
 
+    await _ensurePermission(CalendarAccessLevel.writeOnly);
     try {
       final String eventId =
           await DeviceCalendarPlusPlatform.instance.createEvent(
@@ -753,6 +826,7 @@ class DeviceCalendar {
     // timestamp, which the platform uses to remove that occurrence alone.
     final parsed = InstanceIdParser.parse(eventId);
 
+    await _ensurePermission(CalendarAccessLevel.full);
     try {
       await DeviceCalendarPlusPlatform.instance.deleteEvent(
         parsed.eventId,
@@ -881,6 +955,7 @@ class DeviceCalendar {
     // timestamp, which the platform uses to detach and edit that occurrence.
     final parsed = InstanceIdParser.parse(eventId);
 
+    await _ensurePermission(CalendarAccessLevel.full);
     try {
       await DeviceCalendarPlusPlatform.instance.updateEvent(
         parsed.eventId,
@@ -1121,6 +1196,7 @@ class DeviceCalendar {
       PatchClear() => const Patch.clear(),
     };
 
+    await _ensurePermission(CalendarAccessLevel.full);
     try {
       return await DeviceCalendarPlusPlatform.instance.updateRecurring(
         parsed.eventId,
@@ -1205,6 +1281,7 @@ class DeviceCalendar {
       );
     }
 
+    await _ensurePermission(CalendarAccessLevel.full);
     try {
       await DeviceCalendarPlusPlatform.instance.deleteRecurring(
         parsed.eventId,
@@ -1274,6 +1351,7 @@ class DeviceCalendar {
     final normalizedEnd =
         (isAllDay == true && endDate != null) ? _stripTime(endDate) : endDate;
 
+    await _ensurePermission(CalendarAccessLevel.writeOnly);
     try {
       await DeviceCalendarPlusPlatform.instance.showCreateEventModal(
         title: title,

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -432,7 +432,8 @@ class DeviceCalendar {
   /// [colorHex] is the new color in #RRGGBB format (optional, e.g., "#FF5733").
   ///
   /// Passing neither [name] nor [colorHex] is a no-op (nothing to change).
-  /// Requires full calendar access ([CalendarAccessLevel.full]).
+  /// Requires full calendar access ([CalendarAccessLevel.full]) — write-only is
+  /// add-only (new events), not editing calendars.
   ///
   /// Example:
   /// ```dart
@@ -500,7 +501,8 @@ class DeviceCalendar {
   /// [calendarId] is the ID of the calendar to delete.
   ///
   /// This will also delete all events within the calendar.
-  /// Requires full calendar access ([CalendarAccessLevel.full]).
+  /// Requires full calendar access ([CalendarAccessLevel.full]) — write-only is
+  /// add-only (new events), not deleting calendars.
   ///
   /// Example:
   /// ```dart
@@ -833,7 +835,8 @@ class DeviceCalendar {
   /// To delete an entire recurring series or truncate it from a split point
   /// forward, use [deleteRecurring] instead.
   ///
-  /// Requires full calendar access ([CalendarAccessLevel.full]).
+  /// Requires full calendar access ([CalendarAccessLevel.full]) — write-only is
+  /// add-only and can't delete existing events.
   ///
   /// Example:
   /// ```dart
@@ -913,7 +916,8 @@ class DeviceCalendar {
   /// value, [Patch.clear] to remove the existing value.
   ///
   /// Providing no fields is a no-op (nothing to change).
-  /// Requires full calendar access ([CalendarAccessLevel.full]).
+  /// Requires full calendar access ([CalendarAccessLevel.full]) — write-only is
+  /// add-only and can't modify existing events.
   ///
   /// Example:
   /// ```dart
@@ -1101,7 +1105,8 @@ class DeviceCalendar {
   /// `allEvents`, the new series' ID for `thisAndFollowing`.
   ///
   /// Providing no fields is a no-op (nothing to change).
-  /// Requires full calendar access ([CalendarAccessLevel.full]).
+  /// Requires full calendar access ([CalendarAccessLevel.full]) — write-only is
+  /// add-only and can't modify an existing series.
   ///
   /// Example:
   /// ```dart
@@ -1277,7 +1282,8 @@ class DeviceCalendar {
   ///   every later one are removed; the series is truncated to end before it.
   ///   Earlier occurrences are untouched.
   ///
-  /// Requires full calendar access ([CalendarAccessLevel.full]).
+  /// Requires full calendar access ([CalendarAccessLevel.full]) — write-only is
+  /// add-only and can't delete an existing series.
   ///
   /// Example:
   /// ```dart

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -49,6 +49,8 @@ class DeviceCalendar {
 
   factory DeviceCalendar() => instance;
 
+  AutoPermissionMode? _autoPermissions;
+
   /// Opts methods into requesting calendar permission automatically.
   ///
   /// When `null` (the default) nothing changes — methods never prompt on their
@@ -63,7 +65,19 @@ class DeviceCalendar {
   /// ```dart
   /// DeviceCalendar.instance.autoPermissions = AutoPermissionMode.asNeeded;
   /// ```
-  AutoPermissionMode? autoPermissions;
+  AutoPermissionMode? get autoPermissions => _autoPermissions;
+
+  set autoPermissions(AutoPermissionMode? mode) {
+    _autoPermissions = mode;
+    // A fresh configuration resets the once-per-run prompt budget.
+    _autoRequestedTiers.clear();
+  }
+
+  /// Access levels already auto-requested this run. Auto-mode prompts at most
+  /// once per level: Android folds a declined prompt back into notDetermined, so
+  /// without this a decline would re-prompt on every later call. Reset whenever
+  /// [autoPermissions] is set.
+  final Set<CalendarAccessLevel> _autoRequestedTiers = {};
 
   /// Requests calendar permissions from the user.
   ///
@@ -221,28 +235,35 @@ class DeviceCalendar {
   /// [CalendarAccessLevel.full]. In [AutoPermissionMode.full] every request is
   /// upgraded to full regardless of [requiredTier].
   ///
-  /// Only a [CalendarPermissionStatus.notDetermined] status triggers a prompt;
-  /// a tier already held is never silently escalated. Throws
-  /// [DeviceCalendarException] ([DeviceCalendarError.permissionDenied]) when the
-  /// resulting access does not satisfy [requiredTier].
+  /// Only a [CalendarPermissionStatus.notDetermined] status triggers a prompt,
+  /// and at most once per access level per run; a tier already held is never
+  /// silently escalated. Throws [DeviceCalendarException]
+  /// ([DeviceCalendarError.permissionDenied]) when the resulting access does not
+  /// satisfy [requiredTier].
   Future<void> _ensurePermission(CalendarAccessLevel requiredTier) async {
     final mode = autoPermissions;
     if (mode == null) return;
 
+    final tierToRequest = mode == AutoPermissionMode.full
+        ? CalendarAccessLevel.full
+        : requiredTier;
+
     var status = await hasPermissions();
-    if (status == CalendarPermissionStatus.notDetermined) {
-      status = await requestPermissions(
-        level: mode == AutoPermissionMode.full
-            ? CalendarAccessLevel.full
-            : requiredTier,
-      );
+    // Prompt only on a fresh notDetermined status, and only the first time this
+    // run for a given tier. Android folds a soft-deny back into notDetermined,
+    // so without the budget a declined prompt would re-fire on every later call.
+    // This makes "prompts on first use" literally true and matches iOS, where a
+    // decline becomes a terminal denied we never re-prompt.
+    if (status == CalendarPermissionStatus.notDetermined &&
+        _autoRequestedTiers.add(tierToRequest)) {
+      status = await requestPermissions(level: tierToRequest);
     }
 
     if (!_satisfies(status, requiredTier)) {
       throw DeviceCalendarException(
         errorCode: DeviceCalendarError.permissionDenied,
         message: 'Calendar access required for this operation was not granted '
-            '(autoPermissions: ${mode.name}).',
+            '(autoPermissions: ${mode.name}, status: ${status.name}).',
       );
     }
   }

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -312,8 +312,7 @@ class DeviceCalendar {
   /// }
   /// ```
   ///
-  /// Access: requires full access ([CalendarAccessLevel.full]) — it reads
-  /// calendar data, which write-only (add-only) access cannot do.
+  /// Requires full calendar access ([CalendarAccessLevel.full]).
   Future<List<Calendar>> listCalendars() async {
     await _ensurePermission(CalendarAccessLevel.full);
     try {
@@ -350,8 +349,7 @@ class DeviceCalendar {
   /// }
   /// ```
   ///
-  /// Access: requires full access ([CalendarAccessLevel.full]) — it reads
-  /// calendar data, which write-only (add-only) access cannot do.
+  /// Requires full calendar access ([CalendarAccessLevel.full]).
   Future<List<CalendarSource>> listSources() async {
     await _ensurePermission(CalendarAccessLevel.full);
     try {
@@ -377,9 +375,8 @@ class DeviceCalendar {
   /// Returns the ID of the newly created calendar.
   ///
   /// The calendar is created in the device's local storage by default.
-  /// Access: requires full access ([CalendarAccessLevel.full]). Write-only
-  /// access is add-only on iOS and cannot read or modify existing calendar
-  /// data, so it does not satisfy this call.
+  /// Requires full calendar access ([CalendarAccessLevel.full]) — unlike
+  /// [createEvent], write-only access does not extend to creating calendars.
   ///
   /// Example:
   /// ```dart
@@ -435,9 +432,7 @@ class DeviceCalendar {
   /// [colorHex] is the new color in #RRGGBB format (optional, e.g., "#FF5733").
   ///
   /// Passing neither [name] nor [colorHex] is a no-op (nothing to change).
-  /// Access: requires full access ([CalendarAccessLevel.full]). Write-only
-  /// access is add-only on iOS and cannot read or modify existing calendar
-  /// data, so it does not satisfy this call.
+  /// Requires full calendar access ([CalendarAccessLevel.full]).
   ///
   /// Example:
   /// ```dart
@@ -505,9 +500,7 @@ class DeviceCalendar {
   /// [calendarId] is the ID of the calendar to delete.
   ///
   /// This will also delete all events within the calendar.
-  /// Access: requires full access ([CalendarAccessLevel.full]). Write-only
-  /// access is add-only on iOS and cannot read or modify existing calendar
-  /// data, so it does not satisfy this call.
+  /// Requires full calendar access ([CalendarAccessLevel.full]).
   ///
   /// Example:
   /// ```dart
@@ -582,8 +575,7 @@ class DeviceCalendar {
   /// }
   /// ```
   ///
-  /// Access: requires full access ([CalendarAccessLevel.full]) — it reads
-  /// events, which write-only (add-only) access cannot do.
+  /// Requires full calendar access ([CalendarAccessLevel.full]).
   Future<List<Event>> listEvents(
     DateTime startDate,
     DateTime endDate, {
@@ -627,8 +619,7 @@ class DeviceCalendar {
   /// final masterEvent = await plugin.getEvent(event.eventId);
   /// ```
   ///
-  /// Access: requires full access ([CalendarAccessLevel.full]) — it reads an
-  /// event, which write-only (add-only) access cannot do.
+  /// Requires full calendar access ([CalendarAccessLevel.full]).
   Future<Event?> getEvent(String id) async {
     await _ensurePermission(CalendarAccessLevel.full);
     try {
@@ -698,8 +689,7 @@ class DeviceCalendar {
   /// await plugin.showEventModal(event.instanceId, edit: true);
   /// ```
   ///
-  /// Access: requires full access ([CalendarAccessLevel.full]) — it binds to an
-  /// existing event, which write-only (add-only) access cannot read.
+  /// Requires full calendar access ([CalendarAccessLevel.full]).
   Future<void> showEventModal(String id, {bool edit = false}) async {
     await _ensurePermission(CalendarAccessLevel.full);
     try {
@@ -740,10 +730,7 @@ class DeviceCalendar {
   ///
   /// Returns the system-generated event ID.
   ///
-  /// Access: needs only write-only access ([CalendarAccessLevel.writeOnly]) —
-  /// it just adds a new event — though full access works too. This is one of
-  /// the few operations the add-only tier covers; reading or changing existing
-  /// events requires [CalendarAccessLevel.full].
+  /// Works with write-only access ([CalendarAccessLevel.writeOnly]), or full.
   ///
   /// Example:
   /// ```dart
@@ -846,9 +833,7 @@ class DeviceCalendar {
   /// To delete an entire recurring series or truncate it from a split point
   /// forward, use [deleteRecurring] instead.
   ///
-  /// Access: requires full access ([CalendarAccessLevel.full]). Write-only
-  /// access is add-only on iOS and cannot read or modify existing calendar
-  /// data, so it does not satisfy this call.
+  /// Requires full calendar access ([CalendarAccessLevel.full]).
   ///
   /// Example:
   /// ```dart
@@ -928,9 +913,7 @@ class DeviceCalendar {
   /// value, [Patch.clear] to remove the existing value.
   ///
   /// Providing no fields is a no-op (nothing to change).
-  /// Access: requires full access ([CalendarAccessLevel.full]). Write-only
-  /// access is add-only on iOS and cannot read or modify existing calendar
-  /// data, so it does not satisfy this call.
+  /// Requires full calendar access ([CalendarAccessLevel.full]).
   ///
   /// Example:
   /// ```dart
@@ -1118,9 +1101,7 @@ class DeviceCalendar {
   /// `allEvents`, the new series' ID for `thisAndFollowing`.
   ///
   /// Providing no fields is a no-op (nothing to change).
-  /// Access: requires full access ([CalendarAccessLevel.full]). Write-only
-  /// access is add-only on iOS and cannot read or modify existing calendar
-  /// data, so it does not satisfy this call.
+  /// Requires full calendar access ([CalendarAccessLevel.full]).
   ///
   /// Example:
   /// ```dart
@@ -1296,9 +1277,7 @@ class DeviceCalendar {
   ///   every later one are removed; the series is truncated to end before it.
   ///   Earlier occurrences are untouched.
   ///
-  /// Access: requires full access ([CalendarAccessLevel.full]). Write-only
-  /// access is add-only on iOS and cannot read or modify existing calendar
-  /// data, so it does not satisfy this call.
+  /// Requires full calendar access ([CalendarAccessLevel.full]).
   ///
   /// Example:
   /// ```dart
@@ -1384,8 +1363,7 @@ class DeviceCalendar {
   /// );
   /// ```
   ///
-  /// Access: needs only write-only access ([CalendarAccessLevel.writeOnly]) —
-  /// it opens an editor to add a new event — though full access works too.
+  /// Works with write-only access ([CalendarAccessLevel.writeOnly]), or full.
   Future<void> showCreateEventModal({
     String? title,
     DateTime? startDate,

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -311,6 +311,9 @@ class DeviceCalendar {
   ///   print('  Color: ${calendar.colorHex}');
   /// }
   /// ```
+  ///
+  /// Access: requires full access ([CalendarAccessLevel.full]) — it reads
+  /// calendar data, which write-only (add-only) access cannot do.
   Future<List<Calendar>> listCalendars() async {
     await _ensurePermission(CalendarAccessLevel.full);
     try {
@@ -346,6 +349,9 @@ class DeviceCalendar {
   ///   print('${source.accountName} (${source.type})');
   /// }
   /// ```
+  ///
+  /// Access: requires full access ([CalendarAccessLevel.full]) — it reads
+  /// calendar data, which write-only (add-only) access cannot do.
   Future<List<CalendarSource>> listSources() async {
     await _ensurePermission(CalendarAccessLevel.full);
     try {
@@ -371,7 +377,9 @@ class DeviceCalendar {
   /// Returns the ID of the newly created calendar.
   ///
   /// The calendar is created in the device's local storage by default.
-  /// Requires calendar write permissions - call [requestPermissions] first.
+  /// Access: requires full access ([CalendarAccessLevel.full]). Write-only
+  /// access is add-only on iOS and cannot read or modify existing calendar
+  /// data, so it does not satisfy this call.
   ///
   /// Example:
   /// ```dart
@@ -427,7 +435,9 @@ class DeviceCalendar {
   /// [colorHex] is the new color in #RRGGBB format (optional, e.g., "#FF5733").
   ///
   /// Passing neither [name] nor [colorHex] is a no-op (nothing to change).
-  /// Requires calendar write permissions - call [requestPermissions] first.
+  /// Access: requires full access ([CalendarAccessLevel.full]). Write-only
+  /// access is add-only on iOS and cannot read or modify existing calendar
+  /// data, so it does not satisfy this call.
   ///
   /// Example:
   /// ```dart
@@ -495,7 +505,9 @@ class DeviceCalendar {
   /// [calendarId] is the ID of the calendar to delete.
   ///
   /// This will also delete all events within the calendar.
-  /// Requires calendar write permissions - call [requestPermissions] first.
+  /// Access: requires full access ([CalendarAccessLevel.full]). Write-only
+  /// access is add-only on iOS and cannot read or modify existing calendar
+  /// data, so it does not satisfy this call.
   ///
   /// Example:
   /// ```dart
@@ -569,6 +581,9 @@ class DeviceCalendar {
   ///   print('${event.title} at ${event.startDate}');
   /// }
   /// ```
+  ///
+  /// Access: requires full access ([CalendarAccessLevel.full]) — it reads
+  /// events, which write-only (add-only) access cannot do.
   Future<List<Event>> listEvents(
     DateTime startDate,
     DateTime endDate, {
@@ -611,6 +626,9 @@ class DeviceCalendar {
   /// // Get master event definition for a recurring event
   /// final masterEvent = await plugin.getEvent(event.eventId);
   /// ```
+  ///
+  /// Access: requires full access ([CalendarAccessLevel.full]) — it reads an
+  /// event, which write-only (add-only) access cannot do.
   Future<Event?> getEvent(String id) async {
     await _ensurePermission(CalendarAccessLevel.full);
     try {
@@ -679,6 +697,9 @@ class DeviceCalendar {
   /// // Open directly in the editor
   /// await plugin.showEventModal(event.instanceId, edit: true);
   /// ```
+  ///
+  /// Access: requires full access ([CalendarAccessLevel.full]) — it binds to an
+  /// existing event, which write-only (add-only) access cannot read.
   Future<void> showEventModal(String id, {bool edit = false}) async {
     await _ensurePermission(CalendarAccessLevel.full);
     try {
@@ -718,7 +739,11 @@ class DeviceCalendar {
   /// [recurrenceRule] is an optional recurrence rule for repeating events.
   ///
   /// Returns the system-generated event ID.
-  /// Requires calendar write permissions - call [requestPermissions] first.
+  ///
+  /// Access: needs only write-only access ([CalendarAccessLevel.writeOnly]) —
+  /// it just adds a new event — though full access works too. This is one of
+  /// the few operations the add-only tier covers; reading or changing existing
+  /// events requires [CalendarAccessLevel.full].
   ///
   /// Example:
   /// ```dart
@@ -821,7 +846,9 @@ class DeviceCalendar {
   /// To delete an entire recurring series or truncate it from a split point
   /// forward, use [deleteRecurring] instead.
   ///
-  /// Requires calendar write permissions - call [requestPermissions] first.
+  /// Access: requires full access ([CalendarAccessLevel.full]). Write-only
+  /// access is add-only on iOS and cannot read or modify existing calendar
+  /// data, so it does not satisfy this call.
   ///
   /// Example:
   /// ```dart
@@ -901,7 +928,9 @@ class DeviceCalendar {
   /// value, [Patch.clear] to remove the existing value.
   ///
   /// Providing no fields is a no-op (nothing to change).
-  /// Requires calendar write permissions - call [requestPermissions] first.
+  /// Access: requires full access ([CalendarAccessLevel.full]). Write-only
+  /// access is add-only on iOS and cannot read or modify existing calendar
+  /// data, so it does not satisfy this call.
   ///
   /// Example:
   /// ```dart
@@ -1089,7 +1118,9 @@ class DeviceCalendar {
   /// `allEvents`, the new series' ID for `thisAndFollowing`.
   ///
   /// Providing no fields is a no-op (nothing to change).
-  /// Requires calendar write permissions - call [requestPermissions] first.
+  /// Access: requires full access ([CalendarAccessLevel.full]). Write-only
+  /// access is add-only on iOS and cannot read or modify existing calendar
+  /// data, so it does not satisfy this call.
   ///
   /// Example:
   /// ```dart
@@ -1265,7 +1296,9 @@ class DeviceCalendar {
   ///   every later one are removed; the series is truncated to end before it.
   ///   Earlier occurrences are untouched.
   ///
-  /// Requires calendar write permissions - call [requestPermissions] first.
+  /// Access: requires full access ([CalendarAccessLevel.full]). Write-only
+  /// access is add-only on iOS and cannot read or modify existing calendar
+  /// data, so it does not satisfy this call.
   ///
   /// Example:
   /// ```dart
@@ -1350,6 +1383,9 @@ class DeviceCalendar {
   ///   location: 'Conference Room A',
   /// );
   /// ```
+  ///
+  /// Access: needs only write-only access ([CalendarAccessLevel.writeOnly]) —
+  /// it opens an editor to add a new event — though full access works too.
   Future<void> showCreateEventModal({
     String? title,
     DateTime? startDate,

--- a/packages/device_calendar_plus/lib/src/auto_permission_mode.dart
+++ b/packages/device_calendar_plus/lib/src/auto_permission_mode.dart
@@ -7,8 +7,10 @@
 ///
 /// When a mode is set, each method ensures permission on first use: if the
 /// status is [CalendarPermissionStatus.notDetermined] it requests the
-/// appropriate tier, and if access is ultimately not granted it throws a
-/// [DeviceCalendarException] with [DeviceCalendarError.permissionDenied].
+/// appropriate tier, at most once per access level per app run. If the user
+/// declines, later calls throw [DeviceCalendarException] with
+/// [DeviceCalendarError.permissionDenied] without re-prompting — call
+/// [DeviceCalendar.requestPermissions] yourself to ask again.
 ///
 /// Auto-permissions only act on a fresh ([CalendarPermissionStatus.notDetermined])
 /// status — they never silently escalate a tier you already hold. An app that

--- a/packages/device_calendar_plus/lib/src/auto_permission_mode.dart
+++ b/packages/device_calendar_plus/lib/src/auto_permission_mode.dart
@@ -1,0 +1,33 @@
+/// How [DeviceCalendar] obtains calendar permission when a method is called
+/// before access has been granted.
+///
+/// Opt in by setting [DeviceCalendar.autoPermissions]. While it is `null` (the
+/// default) methods never prompt on their own — you call
+/// [DeviceCalendar.requestPermissions] yourself, exactly as before.
+///
+/// When a mode is set, each method ensures permission on first use: if the
+/// status is [CalendarPermissionStatus.notDetermined] it requests the
+/// appropriate tier, and if access is ultimately not granted it throws a
+/// [DeviceCalendarException] with [DeviceCalendarError.permissionDenied].
+///
+/// Auto-permissions only act on a fresh ([CalendarPermissionStatus.notDetermined])
+/// status — they never silently escalate a tier you already hold. An app that
+/// holds write-only and then calls a read operation gets a `permissionDenied`,
+/// not a surprise upgrade prompt; call [DeviceCalendar.requestPermissions] with
+/// [CalendarAccessLevel.full] yourself when you want to ask for the upgrade
+/// (and to control where any priming UI appears).
+enum AutoPermissionMode {
+  /// Request the minimum tier each operation needs: add-only operations (such
+  /// as [DeviceCalendar.createEvent]) ask for write-only access; every other
+  /// operation asks for full access.
+  ///
+  /// Defers the heavier full-access prompt until an operation actually needs to
+  /// read. Best for apps that mostly add events and only occasionally read.
+  asNeeded,
+
+  /// Request full read/write access on the first operation that needs
+  /// permission, whatever that operation is.
+  ///
+  /// The simplest choice for any app that reads calendar data regularly.
+  full,
+}

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -605,6 +605,35 @@ void main() {
           )),
         );
       });
+
+      test('asNeeded does not prompt when already fully granted', () async {
+        DeviceCalendar.instance.autoPermissions = AutoPermissionMode.asNeeded;
+        mockPlatform.setPermissionStatus(CalendarPermissionStatus.granted);
+
+        await DeviceCalendar.instance.listCalendars();
+
+        expect(mockPlatform.requestPermissionsCallCount, 0);
+      });
+
+      test('prompts at most once per tier per run, even after a soft-deny',
+          () async {
+        DeviceCalendar.instance.autoPermissions = AutoPermissionMode.full;
+        // notDetermined = Android "can ask again"; the request itself is declined.
+        mockPlatform.setPermissionStatus(CalendarPermissionStatus.notDetermined);
+        mockPlatform.setPostRequestStatus(CalendarPermissionStatus.denied);
+
+        await expectLater(
+          DeviceCalendar.instance.listCalendars(),
+          throwsA(isA<DeviceCalendarException>()),
+        );
+        await expectLater(
+          DeviceCalendar.instance.listCalendars(),
+          throwsA(isA<DeviceCalendarException>()),
+        );
+
+        // Only the first call prompted; the second failed fast without re-asking.
+        expect(mockPlatform.requestPermissionsCallCount, 1);
+      });
     });
 
     group('hasPermissions', () {

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -44,6 +44,13 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     with MockPlatformInterfaceMixin {
   String? _permissionStatusCode = "notDetermined";
 
+  /// When set, the status [requestPermissions] returns (simulating the result
+  /// of a prompt), distinct from the [hasPermissions] status.
+  String? _postRequestStatusCode;
+
+  /// How many times [requestPermissions] has been called.
+  int requestPermissionsCallCount = 0;
+
   /// The `writeOnly` argument of the most recent requestPermissions call.
   bool? lastWriteOnly;
   List<Map<String, dynamic>> _events = [];
@@ -84,6 +91,12 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
 
   void setPermissionStatus(CalendarPermissionStatus status) {
     _permissionStatusCode = status.name;
+  }
+
+  /// Sets the status [requestPermissions] returns, as if a prompt resolved to
+  /// it. Leave unset to have requestPermissions echo [setPermissionStatus].
+  void setPostRequestStatus(CalendarPermissionStatus status) {
+    _postRequestStatusCode = status.name;
   }
 
   void setEvents(List<Map<String, dynamic>> events) {
@@ -133,8 +146,9 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
   @override
   Future<String?> requestPermissions(bool writeOnly) async {
     lastWriteOnly = writeOnly;
+    requestPermissionsCallCount++;
     if (_exceptionToThrow != null) throw _exceptionToThrow!;
-    return _permissionStatusCode;
+    return _postRequestStatusCode ?? _permissionStatusCode;
   }
 
   @override
@@ -380,6 +394,8 @@ void main() {
   setUp(() {
     mockPlatform = MockDeviceCalendarPlusPlatform();
     DeviceCalendarPlusPlatform.instance = mockPlatform;
+    // DeviceCalendar is a singleton, so reset the opt-in flag between tests.
+    DeviceCalendar.instance.autoPermissions = null;
   });
 
   group('DeviceCalendar', () {
@@ -454,6 +470,139 @@ void main() {
               'SOME_OTHER_ERROR',
             ),
           ),
+        );
+      });
+    });
+
+    group('autoPermissions', () {
+      Future<String> createAnEvent() => DeviceCalendar.instance.createEvent(
+            calendarId: 'cal',
+            title: 'Standup',
+            startDate: DateTime(2026, 1, 1, 9),
+            endDate: DateTime(2026, 1, 1, 10),
+          );
+
+      test('manual mode (null) never prompts, even when notDetermined',
+          () async {
+        mockPlatform.setPermissionStatus(CalendarPermissionStatus.notDetermined);
+        await DeviceCalendar.instance.listCalendars();
+        expect(mockPlatform.requestPermissionsCallCount, 0);
+      });
+
+      test('full mode requests full access for a read op when notDetermined',
+          () async {
+        DeviceCalendar.instance.autoPermissions = AutoPermissionMode.full;
+        mockPlatform.setPermissionStatus(CalendarPermissionStatus.notDetermined);
+        mockPlatform.setPostRequestStatus(CalendarPermissionStatus.granted);
+
+        await DeviceCalendar.instance.listCalendars();
+
+        expect(mockPlatform.requestPermissionsCallCount, 1);
+        expect(mockPlatform.lastWriteOnly, isFalse);
+      });
+
+      test('asNeeded mode requests write-only for an add-only op', () async {
+        DeviceCalendar.instance.autoPermissions = AutoPermissionMode.asNeeded;
+        mockPlatform.setPermissionStatus(CalendarPermissionStatus.notDetermined);
+        mockPlatform.setPostRequestStatus(CalendarPermissionStatus.writeOnly);
+
+        await createAnEvent();
+
+        expect(mockPlatform.lastWriteOnly, isTrue);
+      });
+
+      test('asNeeded mode requests full access for a read op', () async {
+        DeviceCalendar.instance.autoPermissions = AutoPermissionMode.asNeeded;
+        mockPlatform.setPermissionStatus(CalendarPermissionStatus.notDetermined);
+        mockPlatform.setPostRequestStatus(CalendarPermissionStatus.granted);
+
+        await DeviceCalendar.instance.listCalendars();
+
+        expect(mockPlatform.lastWriteOnly, isFalse);
+      });
+
+      test('full mode requests full access even for an add-only op', () async {
+        DeviceCalendar.instance.autoPermissions = AutoPermissionMode.full;
+        mockPlatform.setPermissionStatus(CalendarPermissionStatus.notDetermined);
+        mockPlatform.setPostRequestStatus(CalendarPermissionStatus.granted);
+
+        await createAnEvent();
+
+        expect(mockPlatform.lastWriteOnly, isFalse);
+      });
+
+      test('does not prompt when access is already granted', () async {
+        DeviceCalendar.instance.autoPermissions = AutoPermissionMode.full;
+        mockPlatform.setPermissionStatus(CalendarPermissionStatus.granted);
+
+        await DeviceCalendar.instance.listCalendars();
+
+        expect(mockPlatform.requestPermissionsCallCount, 0);
+      });
+
+      test('a held write-only tier satisfies an add-only op without prompting',
+          () async {
+        DeviceCalendar.instance.autoPermissions = AutoPermissionMode.asNeeded;
+        mockPlatform.setPermissionStatus(CalendarPermissionStatus.writeOnly);
+
+        await createAnEvent();
+
+        expect(mockPlatform.requestPermissionsCallCount, 0);
+      });
+
+      test('does not auto-escalate a held write-only tier for a read op',
+          () async {
+        DeviceCalendar.instance.autoPermissions = AutoPermissionMode.asNeeded;
+        mockPlatform.setPermissionStatus(CalendarPermissionStatus.writeOnly);
+
+        await expectLater(
+          DeviceCalendar.instance.listCalendars(),
+          throwsA(isA<DeviceCalendarException>().having(
+            (e) => e.errorCode,
+            'errorCode',
+            DeviceCalendarError.permissionDenied,
+          )),
+        );
+        expect(mockPlatform.requestPermissionsCallCount, 0);
+      });
+
+      test('a no-op update does not prompt (guard runs after the no-op return)',
+          () async {
+        DeviceCalendar.instance.autoPermissions = AutoPermissionMode.full;
+        mockPlatform.setPermissionStatus(CalendarPermissionStatus.notDetermined);
+
+        // No changed fields: a valid no-op that must not trigger a prompt.
+        await DeviceCalendar.instance.updateEvent(eventId: 'evt');
+
+        expect(mockPlatform.requestPermissionsCallCount, 0);
+      });
+
+      test('throws permissionDenied when access is denied', () async {
+        DeviceCalendar.instance.autoPermissions = AutoPermissionMode.full;
+        mockPlatform.setPermissionStatus(CalendarPermissionStatus.denied);
+
+        await expectLater(
+          DeviceCalendar.instance.listCalendars(),
+          throwsA(isA<DeviceCalendarException>().having(
+            (e) => e.errorCode,
+            'errorCode',
+            DeviceCalendarError.permissionDenied,
+          )),
+        );
+      });
+
+      test('throws permissionDenied when the prompt is declined', () async {
+        DeviceCalendar.instance.autoPermissions = AutoPermissionMode.full;
+        mockPlatform.setPermissionStatus(CalendarPermissionStatus.notDetermined);
+        mockPlatform.setPostRequestStatus(CalendarPermissionStatus.denied);
+
+        await expectLater(
+          DeviceCalendar.instance.listCalendars(),
+          throwsA(isA<DeviceCalendarException>().having(
+            (e) => e.errorCode,
+            'errorCode',
+            DeviceCalendarError.permissionDenied,
+          )),
         );
       });
     });


### PR DESCRIPTION
Closes #90. Stacked on #109.

Opt-in `AutoPermissionMode` so methods request access on first use instead of needing an explicit `requestPermissions()`:

```dart
DeviceCalendar.instance.autoPermissions = AutoPermissionMode.asNeeded;
await plugin.createEvent(/* ... */); // prompts on first use, else throws permissionDenied
```

- **`asNeeded`** — each method asks for the minimum it needs: add-only ops (`createEvent`, `showCreateEventModal`) request write-only, everything else full.
- **`full`** — request full on the first op that needs it.
- **`null`** (default) — manual, nothing changes.

One shared `_ensurePermission(tier)` fronts every method. It only prompts on a `notDetermined` status — a held tier is never silently escalated (a read while holding write-only throws `permissionDenied`, so you control where the upgrade prompt + priming UI land). The gate runs **after** argument validation and no-op-update early returns, so invalid input and no-change saves never trigger a prompt.

Design discussion on the issue: bullet-to/device_calendar_plus#90 (comment). Pure Dart — no native or platform-interface changes. 13 new unit tests; full suite green (182). Worth an on-device pass on the `asNeeded` escalation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)