### PR TITLE
feat: optional calendarId in createEvent (default calendar)

### DIFF
--- a/packages/device_calendar_plus/example/integration_test/device_calendar_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/device_calendar_test.dart
@@ -431,6 +431,36 @@ void main() {
       expect(createdEvent.location, 'Test Location');
     });
 
+    test('Create Event without calendarId (default calendar)', () async {
+      // Omitting calendarId routes the event to the platform's default
+      // calendar (iOS: defaultCalendarForNewEvents, Android: primary/first
+      // writable calendar resolved from the calendar list).
+      final now = DateTime.now();
+      final startDate = DateTime(now.year, now.month, now.day, 16, 0);
+      final endDate = DateTime(now.year, now.month, now.day, 17, 0);
+
+      final eventId = await plugin.createEvent(
+        title: 'Default Calendar Event',
+        startDate: startDate,
+        endDate: endDate,
+        description: 'Created without a calendarId',
+      );
+
+      expect(eventId, isNotEmpty);
+
+      try {
+        final fetched = await plugin.getEvent(eventId);
+        expect(fetched, isNotNull);
+        expect(fetched!.eventId, isNotEmpty);
+        expect(fetched.title, 'Default Calendar Event');
+        expect(fetched.description, 'Created without a calendarId');
+        // The platform resolved a concrete calendar for us.
+        expect(fetched.calendarId, isNotEmpty);
+      } finally {
+        await plugin.deleteEvent(eventId: eventId);
+      }
+    });
+
     test('Create Event with URL', () async {
       // Verifies the url field round-trips through the plugin on both
       // platforms. iOS maps to EKEvent.url; Android maps to CUSTOM_APP_URI.

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -712,9 +712,15 @@ class DeviceCalendar {
     }
   }
 
-  /// Creates a new event in the specified calendar.
+  /// Creates a new event in a calendar.
   ///
-  /// [calendarId] is the ID of the calendar to create the event in (required).
+  /// [calendarId] is the ID of the calendar to create the event in (optional).
+  ///   When omitted (`null`), the event is written to the platform's default
+  ///   calendar for new events — on iOS `defaultCalendarForNewEvents`, on
+  ///   Android the primary writable calendar (falling back to the first
+  ///   writable calendar). Throws a [DeviceCalendarException] if no
+  ///   default/writable calendar is available. Passing a non-null but
+  ///   empty/whitespace ID is still an error.
   /// [title] is the event title (required).
   /// [startDate] is the start date/time (required).
   /// [endDate] is the end date/time (required).
@@ -755,9 +761,16 @@ class DeviceCalendar {
   ///   endDate: DateTime(2024, 3, 15, 9, 15),
   ///   recurrenceRule: DailyRecurrence(end: CountEnd(30)),
   /// );
+  ///
+  /// // Create an event in the default calendar (no calendarId)
+  /// final defaultId = await plugin.createEvent(
+  ///   title: 'Lunch',
+  ///   startDate: DateTime.now(),
+  ///   endDate: DateTime.now().add(Duration(hours: 1)),
+  /// );
   /// ```
   Future<String> createEvent({
-    required String calendarId,
+    String? calendarId,
     required String title,
     required DateTime startDate,
     required DateTime endDate,
@@ -769,8 +782,9 @@ class DeviceCalendar {
     EventAvailability availability = EventAvailability.busy,
     RecurrenceRule? recurrenceRule,
   }) async {
-    // Validate required fields
-    if (calendarId.trim().isEmpty) {
+    // Validate fields. A null calendarId is valid (use the default calendar);
+    // an explicit but empty/whitespace ID targets nothing — a programmer error.
+    if (calendarId != null && calendarId.trim().isEmpty) {
       throw ArgumentError.value(
         calendarId,
         'calendarId',

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -69,7 +69,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
 
   // Callback to capture createEvent arguments
   Future<String> Function(
-    String calendarId,
+    String? calendarId,
     String title,
     DateTime startDate,
     DateTime endDate,
@@ -117,7 +117,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
 
   void setCreateEventCallback(
     Future<String> Function(
-      String calendarId,
+      String? calendarId,
       String title,
       DateTime startDate,
       DateTime endDate,
@@ -220,7 +220,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
 
   @override
   Future<String> createEvent(
-    String calendarId,
+    String? calendarId,
     String title,
     DateTime startDate,
     DateTime endDate,
@@ -843,6 +843,51 @@ void main() {
           ),
           throwsArgumentError,
         );
+      });
+
+      test('throws ArgumentError when calendar ID is whitespace', () async {
+        expect(
+          () => DeviceCalendar.instance.createEvent(
+            calendarId: '   ',
+            title: 'Meeting',
+            startDate: DateTime.now(),
+            endDate: DateTime.now().add(Duration(hours: 1)),
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('forwards null calendarId to the platform when omitted', () async {
+        const sentinel = 'unset';
+        Object? capturedCalendarId = sentinel;
+
+        final mock = MockDeviceCalendarPlusPlatform();
+        mock.setCreateEventCallback((
+          calendarId,
+          title,
+          startDate,
+          endDate,
+          isAllDay,
+          description,
+          location,
+          url,
+          timeZone,
+          availability,
+          recurrenceRule,
+        ) {
+          capturedCalendarId = calendarId;
+          return Future.value('event-id');
+        });
+
+        DeviceCalendarPlusPlatform.instance = mock;
+
+        await DeviceCalendar.instance.createEvent(
+          title: 'Default Calendar Event',
+          startDate: DateTime.now(),
+          endDate: DateTime.now().add(Duration(hours: 1)),
+        );
+
+        expect(capturedCalendarId, isNull);
       });
 
       test('throws ArgumentError when title is empty', () async {

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
@@ -89,7 +89,21 @@ class CalendarService(private val context: Context) {
         
         return Result.success(calendars)
     }
-    
+
+    /**
+     * Resolves the id of a calendar to write new events into when the caller
+     * omits one. Prefers the primary writable calendar; otherwise falls back to
+     * the first writable calendar. Returns null when no writable calendar
+     * exists. Reuses [listCalendars] so the writability definition and the
+     * permission/error handling stay in one place.
+     */
+    fun resolveDefaultWritableCalendarId(): String? {
+        val calendars = listCalendars().getOrNull() ?: return null
+        val writable = calendars.filter { it["readOnly"] == false }
+        val chosen = writable.firstOrNull { it["isPrimary"] == true } ?: writable.firstOrNull()
+        return chosen?.get("id") as String?
+    }
+
     fun listSources(): Result<List<Map<String, Any>>> {
         val sources = mutableListOf<Map<String, Any>>()
         val seen = mutableSetOf<String>()

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
@@ -49,7 +49,7 @@ class DeviceCalendarPlusAndroidPlugin :
         val context = flutterPluginBinding.applicationContext
         appContext = context
         calendarService = CalendarService(context)
-        eventsService = EventsService(context)
+        eventsService = EventsService(context, calendarService!!)
         permissionService = PermissionService(context)
         providerExecutor = Executors.newSingleThreadExecutor { runnable ->
             Thread(runnable, "DeviceCalendarPlusProvider").apply { isDaemon = true }
@@ -370,8 +370,9 @@ class DeviceCalendarPlusAndroidPlugin :
         val availability = call.argument<String>("availability")
         val recurrenceRule = call.argument<String>("recurrenceRule")
         
-        // Validate required arguments
-        if (calendarId == null || title == null || startDateMillis == null || 
+        // Validate required arguments.
+        // calendarId is optional: null routes the event to the default calendar.
+        if (title == null || startDateMillis == null ||
             endDateMillis == null || isAllDay == null || availability == null) {
             result.error(
                 PlatformExceptionCodes.INVALID_ARGUMENTS,

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -8,8 +8,13 @@ import java.util.Date
 
 private const val MINUTES_PER_DAY = 1440
 
-class EventsService(private val context: Context) {
-    
+// Default-calendar resolution reuses CalendarService rather than duplicating
+// its cursor logic, so it's injected by the plugin.
+class EventsService(
+    private val context: Context,
+    private val calendarService: CalendarService,
+) {
+
     fun retrieveEvents(
         startDate: Date,
         endDate: Date,
@@ -605,7 +610,7 @@ class EventsService(private val context: Context) {
     }
 
     fun createEvent(
-        calendarId: String,
+        calendarId: String?,
         title: String,
         startDate: java.util.Date,
         endDate: java.util.Date,
@@ -628,6 +633,18 @@ class EventsService(private val context: Context) {
             )
         }
         
+        // Resolve the target calendar. A null calendarId means "default
+        // calendar" — resolve the primary (or first) writable calendar.
+        val resolvedCalendarId = calendarId ?: calendarService.resolveDefaultWritableCalendarId()
+        if (resolvedCalendarId == null) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.OPERATION_FAILED,
+                    "No writable calendar available"
+                )
+            )
+        }
+
         try {
             // For all-day events, Android interprets timestamps as UTC to determine the calendar date
             // We need to convert local date components to UTC midnight to preserve the calendar date
@@ -643,7 +660,7 @@ class EventsService(private val context: Context) {
             }
             
             val values = android.content.ContentValues().apply {
-                put(CalendarContract.Events.CALENDAR_ID, calendarId.toLong())
+                put(CalendarContract.Events.CALENDAR_ID, resolvedCalendarId.toLong())
                 put(CalendarContract.Events.TITLE, title)
                 put(CalendarContract.Events.DTSTART, startMillis)
                 put(CalendarContract.Events.ALL_DAY, if (isAllDay) 1 else 0)

--- a/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
+++ b/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
@@ -142,7 +142,7 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
 
   @override
   Future<String> createEvent(
-    String calendarId,
+    String? calendarId,
     String title,
     DateTime startDate,
     DateTime endDate,

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
@@ -448,8 +448,7 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     }
     
     // Parse required parameters
-    guard let calendarId = args["calendarId"] as? String,
-          let title = args["title"] as? String,
+    guard let title = args["title"] as? String,
           let startDateMillis = args["startDate"] as? Int64,
           let endDateMillis = args["endDate"] as? Int64,
           let isAllDay = args["isAllDay"] as? Bool,
@@ -461,8 +460,10 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
       ))
       return
     }
-    
+
     // Parse optional parameters
+    // calendarId is optional: nil routes the event to the default calendar.
+    let calendarId = args["calendarId"] as? String
     let description = args["description"] as? String
     let location = args["location"] as? String
     let url = args["url"] as? String

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -398,8 +398,33 @@ class EventsService {
     }
   }
   
+  /// Resolves the calendar to write a new event into.
+  ///
+  /// A non-nil `calendarId` looks up that specific calendar (not found is an
+  /// error). A nil `calendarId` uses the store's default calendar for new
+  /// events (no default available is an error).
+  private func resolveCalendar(calendarId: String?) -> Result<EKCalendar, CalendarError> {
+    if let calendarId = calendarId {
+      guard let calendar = eventStore.calendar(withIdentifier: calendarId) else {
+        return .failure(CalendarError(
+          code: PlatformExceptionCodes.notFound,
+          message: "Calendar with ID \(calendarId) not found"
+        ))
+      }
+      return .success(calendar)
+    }
+
+    guard let calendar = eventStore.defaultCalendarForNewEvents else {
+      return .failure(CalendarError(
+        code: PlatformExceptionCodes.operationFailed,
+        message: "No default calendar available for new events"
+      ))
+    }
+    return .success(calendar)
+  }
+
   func createEvent(
-    calendarId: String,
+    calendarId: String?,
     title: String,
     startDate: Date,
     endDate: Date,
@@ -421,15 +446,16 @@ class EventsService {
       return
     }
     
-    // Get the calendar
-    guard let calendar = eventStore.calendar(withIdentifier: calendarId) else {
-      completion(.failure(CalendarError(
-        code: PlatformExceptionCodes.notFound,
-        message: "Calendar with ID \(calendarId) not found"
-      )))
+    // Resolve the target calendar (specific id, or the default for new events)
+    let calendar: EKCalendar
+    switch resolveCalendar(calendarId: calendarId) {
+    case .success(let resolved):
+      calendar = resolved
+    case .failure(let error):
+      completion(.failure(error))
       return
     }
-    
+
     // Create the event
     let event = EKEvent(eventStore: eventStore)
     event.calendar = calendar

--- a/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
+++ b/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
@@ -138,7 +138,7 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
 
   @override
   Future<String> createEvent(
-    String calendarId,
+    String? calendarId,
     String title,
     DateTime startDate,
     DateTime endDate,

--- a/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
+++ b/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
@@ -172,8 +172,12 @@ abstract class DeviceCalendarPlusPlatform extends PlatformInterface {
   ///
   /// Returns the ID of the newly created event (system-generated).
   /// Requires calendar write permissions.
+  ///
+  /// [calendarId] selects the target calendar. When `null`, the platform
+  /// writes to its default calendar for new events (failing with
+  /// `OPERATION_FAILED` if none is available).
   Future<String> createEvent(
-    String calendarId,
+    String? calendarId,
     String title,
     DateTime startDate,
     DateTime endDate,

--- a/packages/device_calendar_plus_platform_interface/test/device_calendar_plus_platform_interface_test.dart
+++ b/packages/device_calendar_plus_platform_interface/test/device_calendar_plus_platform_interface_test.dart
@@ -53,7 +53,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
 
   @override
   Future<String> createEvent(
-    String calendarId,
+    String? calendarId,
     String title,
     DateTime startDate,
     DateTime endDate,


### PR DESCRIPTION
Closes #88.

`createEvent` no longer requires a `calendarId`. Leave it off and the event lands in the platform's default calendar:

- **iOS** — `defaultCalendarForNewEvents`
- **Android** — the primary writable calendar, falling back to the first writable one (resolved from the calendar list)

`calendarId` is now `String?` everywhere. Passing `null` is the valid "use default" path; passing an explicit empty/whitespace id is still an `ArgumentError`. If no default/writable calendar exists, you get a `DeviceCalendarException`.

```dart
// before: had to know a calendar id
await plugin.createEvent(calendarId: someId, title: 'Lunch', ...);

// now: just add it to the default calendar
await plugin.createEvent(title: 'Lunch', startDate: ..., endDate: ...);
```

### Notes
- Android resolution reuses `CalendarService.listCalendars`, so there's one definition of "writable" and the permission/error handling is shared. `CalendarService` is injected into `EventsService` instead of re-instantiated.
- A thermonuclear review flagged an early draft that claimed this "pairs with write-only access" — not true on Android, where resolving a default calendar needs read access (iOS's API works under write-only, Android's doesn't). Dropped the claim rather than ship a cross-platform inconsistency.

### Tests
- Unit: null `calendarId` forwards `null` to the platform; whitespace id still throws.
- Integration: create-without-calendarId round-trips and lands in a real calendar (verified on device — see below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)