### PR TITLE
fix(android): honest permissionDenied when default-calendar resolution can't read

### DIFF
--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -718,9 +718,10 @@ class DeviceCalendar {
   ///   When omitted (`null`), the event is written to the platform's default
   ///   calendar for new events — on iOS `defaultCalendarForNewEvents`, on
   ///   Android the primary writable calendar (falling back to the first
-  ///   writable calendar). Throws a [DeviceCalendarException] if no
-  ///   default/writable calendar is available. Passing a non-null but
-  ///   empty/whitespace ID is still an error.
+  ///   writable calendar). On Android this reads the calendar list to pick a
+  ///   default, so it needs full access — not write-only. Throws a
+  ///   [DeviceCalendarException] if no default/writable calendar is available.
+  ///   Passing a non-null but empty/whitespace ID is still an error.
   /// [title] is the event title (required).
   /// [startDate] is the start date/time (required).
   /// [endDate] is the end date/time (required).

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
@@ -93,15 +93,32 @@ class CalendarService(private val context: Context) {
     /**
      * Resolves the id of a calendar to write new events into when the caller
      * omits one. Prefers the primary writable calendar; otherwise falls back to
-     * the first writable calendar. Returns null when no writable calendar
-     * exists. Reuses [listCalendars] so the writability definition and the
-     * permission/error handling stay in one place.
+     * the first writable calendar. `success(null)` means no writable calendar
+     * exists; `failure(permissionDenied)` means we couldn't read the calendar
+     * list to pick one. The two are distinct so the caller surfaces an honest
+     * error instead of reporting "no calendar" for a missing READ_CALENDAR.
+     *
+     * Reuses [listCalendars] so the writability definition stays in one place.
      */
-    fun resolveDefaultWritableCalendarId(): String? {
-        val calendars = listCalendars().getOrNull() ?: return null
-        val writable = calendars.filter { it["readOnly"] == false }
-        val chosen = writable.firstOrNull { it["isPrimary"] == true } ?: writable.firstOrNull()
-        return chosen?.get("id") as String?
+    fun resolveDefaultWritableCalendarId(): Result<String?> {
+        // Picking a default reads the calendar list, so it needs READ_CALENDAR.
+        // Guard it explicitly: a denied read can surface as either a thrown
+        // SecurityException or a silently empty cursor, and only the explicit
+        // check distinguishes "can't read" from "genuinely no calendars".
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR)
+            != PackageManager.PERMISSION_GRANTED) {
+            return Result.failure(
+                CalendarException(
+                    PlatformExceptionCodes.PERMISSION_DENIED,
+                    "Reading calendars to resolve a default requires READ_CALENDAR"
+                )
+            )
+        }
+        return listCalendars().map { calendars ->
+            val writable = calendars.filter { it["readOnly"] == false }
+            (writable.firstOrNull { it["isPrimary"] == true } ?: writable.firstOrNull())
+                ?.get("id") as? String
+        }
     }
 
     fun listSources(): Result<List<Map<String, Any>>> {

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -634,10 +634,16 @@ class EventsService(
         }
         
         // Resolve the target calendar. A null calendarId means "default
-        // calendar" — resolve the primary (or first) writable calendar.
-        val resolvedCalendarId = calendarId ?: calendarService.resolveDefaultWritableCalendarId()
-        if (resolvedCalendarId == null) {
-            return Result.failure(
+        // calendar" — resolve the primary (or first) writable calendar. The
+        // resolver fails with permissionDenied if it can't read the calendar
+        // list, so propagate that rather than flattening it into "no calendar".
+        val resolvedCalendarId: String
+        if (calendarId != null) {
+            resolvedCalendarId = calendarId
+        } else {
+            val resolution = calendarService.resolveDefaultWritableCalendarId()
+            resolution.exceptionOrNull()?.let { return Result.failure(it) }
+            resolvedCalendarId = resolution.getOrNull() ?: return Result.failure(
                 CalendarException(
                     PlatformExceptionCodes.OPERATION_FAILED,
                     "No writable calendar available"


### PR DESCRIPTION
Follow-up to #111.

When you call `createEvent()` without a `calendarId`, Android resolves a default by reading the calendar list — which needs `READ_CALENDAR`. Under write-only (`WRITE_CALENDAR` only), that read fails, and the old code flattened it into:

> `operationFailed` · "No writable calendar available"

…which is a lie — it tells the developer their account has no calendars when the real problem is missing read access. It's also a sharp inconsistency with the rest of the write-only tier: `createEvent(calendarId: x)` works under write-only, but `createEvent()` fails with a misleading code.

### Fix
- `resolveDefaultWritableCalendarId()` now returns `Result<String?>` and **guards `READ_CALENDAR` explicitly up front**. A denied read can surface either as a thrown `SecurityException` *or* a silently empty cursor depending on OEM/version, so inferring the cause after the fact isn't reliable — the explicit check is the only way to distinguish "can't read" from "genuinely no writable calendars."
- `createEvent` propagates that failure (so `permissionDenied` survives) and emits `operationFailed`/"No writable calendar available" only for the genuine `success(null)` case.
- Doc note on `createEvent`: omitting `calendarId` reads the calendar list on Android, so it needs full access, not write-only.
- Also tightens the loose `as String?` cast to `as? String`.

### Tests
Failure paths here need a device with no writable calendar or a live write-only grant, which the integration harness (auto-grants full) can't set up — so no automated coverage added. Full Android suite re-run green on a physical device (82 passed, 3 pre-existing skips); the default-calendar round-trip still passes under full access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)