### PR TITLE
feat: event reminders (relative-time alarms)

### DIFF
--- a/packages/device_calendar_plus/example/integration_test/all_tests.dart
+++ b/packages/device_calendar_plus/example/integration_test/all_tests.dart
@@ -3,6 +3,7 @@ import 'device_calendar_test.dart' as device_calendar;
 import 'edge_cases_test.dart' as edge_cases;
 import 'range_test.dart' as range;
 import 'recurrence_test.dart' as recurrence;
+import 'reminders_test.dart' as reminders;
 import 'sources_test.dart' as sources;
 
 void main() {
@@ -12,4 +13,5 @@ void main() {
   sources.main();
   range.main();
   edge_cases.main();
+  reminders.main();
 }

--- a/packages/device_calendar_plus/example/integration_test/reminders_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/reminders_test.dart
@@ -1,0 +1,114 @@
+import 'package:device_calendar_plus/device_calendar_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+/// Integration tests for relative event reminders (alarms).
+///
+/// These exercise the full create -> read -> update roundtrip on a real device
+/// calendar. Reminders are minute-granular on both platforms, so the set read
+/// back should match the minute values written, regardless of order.
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  final plugin = DeviceCalendar.instance;
+
+  String? testCalendarId;
+
+  setUpAll(() async {
+    await plugin.requestPermissions();
+    final timestamp = DateTime.now().millisecondsSinceEpoch;
+    testCalendarId = await plugin.createCalendar(
+      name: 'Reminder Test $timestamp',
+    );
+  });
+
+  tearDownAll(() async {
+    if (testCalendarId != null) {
+      await plugin.deleteCalendar(testCalendarId!);
+    }
+  });
+
+  /// Re-fetches the event and returns its reminders as a sorted minute set, so
+  /// assertions don't depend on platform ordering.
+  Future<Set<int>> reminderMinutes(String eventId) async {
+    final event = await plugin.getEvent(eventId);
+    final reminders = event?.reminders ?? const <Duration>[];
+    return reminders.map((d) => d.inMinutes).toSet();
+  }
+
+  testWidgets('creates an event with reminders and reads them back',
+      (tester) async {
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, now.day, 10, 0);
+    final end = DateTime(now.year, now.month, now.day, 11, 0);
+
+    final eventId = await plugin.createEvent(
+      calendarId: testCalendarId!,
+      title: 'Event with reminders',
+      startDate: start,
+      endDate: end,
+      reminders: [const Duration(minutes: 15), const Duration(hours: 1)],
+    );
+
+    expect(await reminderMinutes(eventId), {15, 60});
+  });
+
+  testWidgets('creates an event without reminders (null reminders field)',
+      (tester) async {
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, now.day, 12, 0);
+    final end = DateTime(now.year, now.month, now.day, 13, 0);
+
+    final eventId = await plugin.createEvent(
+      calendarId: testCalendarId!,
+      title: 'Event without reminders',
+      startDate: start,
+      endDate: end,
+    );
+
+    final event = await plugin.getEvent(eventId);
+    expect(event?.reminders == null || event!.reminders!.isEmpty, isTrue);
+  });
+
+  testWidgets('updateEvent Patch.set replaces the whole reminder set',
+      (tester) async {
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, now.day, 14, 0);
+    final end = DateTime(now.year, now.month, now.day, 15, 0);
+
+    final eventId = await plugin.createEvent(
+      calendarId: testCalendarId!,
+      title: 'Event to re-mind',
+      startDate: start,
+      endDate: end,
+      reminders: [const Duration(minutes: 15), const Duration(hours: 1)],
+    );
+
+    await plugin.updateEvent(
+      eventId: eventId,
+      reminders: Patch.set([const Duration(minutes: 30)]),
+    );
+
+    expect(await reminderMinutes(eventId), {30});
+  });
+
+  testWidgets('updateEvent Patch.clear removes all reminders', (tester) async {
+    final now = DateTime.now();
+    final start = DateTime(now.year, now.month, now.day, 16, 0);
+    final end = DateTime(now.year, now.month, now.day, 17, 0);
+
+    final eventId = await plugin.createEvent(
+      calendarId: testCalendarId!,
+      title: 'Event to clear',
+      startDate: start,
+      endDate: end,
+      reminders: [const Duration(minutes: 10)],
+    );
+
+    await plugin.updateEvent(
+      eventId: eventId,
+      reminders: const Patch.clear(),
+    );
+
+    expect(await reminderMinutes(eventId), isEmpty);
+  });
+}

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -736,6 +736,13 @@ class DeviceCalendar {
   ///   The platform will validate the timezone string.
   /// [availability] is the availability status (default: EventAvailability.busy).
   /// [recurrenceRule] is an optional recurrence rule for repeating events.
+  /// [reminders] is an optional list of relative reminders, each a [Duration]
+  ///   of lead time **before** the event start at which an alarm fires (e.g.
+  ///   `Duration(minutes: 15)`). Reminders are **minute-granular** on both
+  ///   platforms: a sub-minute [Duration] rounds to the nearest minute. A
+  ///   negative [Duration] (after-start) throws [ArgumentError]; a zero
+  ///   [Duration] (at start) is allowed. Omitting it (or passing `null`) creates
+  ///   the event with no reminders.
   ///
   /// Returns the system-generated event ID.
   ///
@@ -782,6 +789,7 @@ class DeviceCalendar {
     String? timeZone,
     EventAvailability availability = EventAvailability.busy,
     RecurrenceRule? recurrenceRule,
+    List<Duration>? reminders,
   }) async {
     // Validate fields. A null calendarId is valid (use the default calendar);
     // an explicit but empty/whitespace ID targets nothing — a programmer error.
@@ -811,6 +819,9 @@ class DeviceCalendar {
     final normalizedStartDate = isAllDay ? _stripTime(startDate) : startDate;
     final normalizedEndDate = isAllDay ? _stripTime(endDate) : endDate;
 
+    // Convert reminders to whole minutes before start (the wire format).
+    final reminderMinutes = _remindersToMinutes(reminders);
+
     await _ensurePermission(CalendarAccessLevel.writeOnly);
     try {
       final String eventId =
@@ -826,6 +837,7 @@ class DeviceCalendar {
         timeZone,
         availability.name,
         recurrenceRule?.toRruleString(),
+        reminderMinutes,
       );
       return eventId;
     } on PlatformException catch (e, stackTrace) {
@@ -926,9 +938,15 @@ class DeviceCalendar {
   ///   - Example: "3:00 PM EST" → "3:00 PM PST" (different instant in time)
   /// - [availability] - new availability status
   ///
+  /// - [reminders] - the event's reminder set ([Patch.set] to replace the whole
+  ///   set, [Patch.clear] to remove all reminders). Each [Duration] is lead
+  ///   time **before** start and is minute-granular; a negative [Duration]
+  ///   throws [ArgumentError] (zero is allowed).
+  ///
   /// [description], [location] and [url] take a [Patch]: omit the argument (or
   /// pass `null`) to leave the field unchanged, [Patch.set] to assign a new
-  /// value, [Patch.clear] to remove the existing value.
+  /// value, [Patch.clear] to remove the existing value. [reminders] takes a
+  /// `Patch<List<Duration>>` with the same three states.
   ///
   /// Providing no fields is a no-op (nothing to change).
   /// Requires full calendar access ([CalendarAccessLevel.full]) — write-only is
@@ -963,6 +981,7 @@ class DeviceCalendar {
     bool? isAllDay,
     String? timeZone,
     EventAvailability? availability,
+    Patch<List<Duration>>? reminders,
   }) async {
     // Validate eventId
     if (eventId.trim().isEmpty) {
@@ -984,9 +1003,18 @@ class DeviceCalendar {
         url == null &&
         isAllDay == null &&
         timeZone == null &&
-        availability == null) {
+        availability == null &&
+        reminders == null) {
       return;
     }
+
+    // Map the typed reminders Patch to the minutes wire format. Validation
+    // (negative durations) happens inside _remindersToMinutes.
+    final Patch<List<int>>? reminderMinutes = switch (reminders) {
+      null => null,
+      PatchSet(:final value) => Patch.set(_remindersToMinutes(value)!),
+      PatchClear() => const Patch.clear(),
+    };
 
     // Validate dates if both are provided
     if (startDate != null && endDate != null && endDate.isBefore(startDate)) {
@@ -1021,6 +1049,7 @@ class DeviceCalendar {
         isAllDay: isAllDay,
         timeZone: timeZone,
         availability: availability?.name,
+        reminders: reminderMinutes,
       );
     } on PlatformException catch (e, stackTrace) {
       final convertedException =
@@ -1432,4 +1461,31 @@ class DeviceCalendar {
   /// Strips time components from a DateTime, returning midnight of the same day.
   static DateTime _stripTime(DateTime dt) =>
       DateTime(dt.year, dt.month, dt.day);
+
+  /// Normalizes reminder [Duration]s to the whole-minutes-before-start wire
+  /// format (the canonical conversion, shared by both platforms).
+  ///
+  /// Each [Duration] is lead time before the event start, so a non-negative
+  /// value is required — a negative [Duration] (after-start) has no valid
+  /// interpretation and throws [ArgumentError]; zero (at start) is allowed.
+  /// Sub-minute values round to the nearest minute. Duplicate minute values are
+  /// de-duplicated to avoid redundant alarm rows, preserving first-seen order.
+  /// Returns `null` for a `null` input (no reminders).
+  static List<int>? _remindersToMinutes(List<Duration>? reminders) {
+    if (reminders == null) return null;
+    final seen = <int>{};
+    final minutes = <int>[];
+    for (final reminder in reminders) {
+      if (reminder < Duration.zero) {
+        throw ArgumentError.value(
+          reminder,
+          'reminders',
+          'A reminder offset cannot be negative (reminders fire before start)',
+        );
+      }
+      final value = (reminder.inSeconds / 60).round();
+      if (seen.add(value)) minutes.add(value);
+    }
+    return minutes;
+  }
 }

--- a/packages/device_calendar_plus/lib/src/event.dart
+++ b/packages/device_calendar_plus/lib/src/event.dart
@@ -98,6 +98,22 @@ class Event {
   /// supports programmatic write via this plugin.
   final List<Attendee>? attendees;
 
+  /// Relative-time reminders (alarms) for this event.
+  ///
+  /// Each [Duration] is the lead time **before** the event's start at which the
+  /// alarm fires (e.g. `Duration(minutes: 15)` fires 15 minutes before start).
+  ///
+  /// Null when the event has no reminders. Reminders are **minute-granular** on
+  /// both platforms: sub-minute durations round to the nearest minute, so a
+  /// `Duration(seconds: 90)` round-trips as `Duration(minutes: 2)`.
+  ///
+  /// **Platform mapping:**
+  /// - **iOS**: `EKAlarm(relativeOffset:)` on `EKEvent.alarms` (seconds before
+  ///   start).
+  /// - **Android**: rows in `CalendarContract.Reminders` (`MINUTES` before
+  ///   start, `METHOD_ALERT`).
+  final List<Duration>? reminders;
+
   /// Optional URL associated with this event.
   ///
   /// A typical use is a meeting link, a ticket page, or a deep link into the
@@ -127,6 +143,7 @@ class Event {
     required this.isRecurring,
     this.recurrenceRule,
     this.attendees,
+    this.reminders,
     this.url,
   });
 
@@ -134,6 +151,7 @@ class Event {
   factory Event.fromMap(Map<String, dynamic> map) {
     final rruleString = map['recurrenceRule'] as String?;
     final attendeesList = map['attendees'] as List<dynamic>?;
+    final remindersList = map['reminders'] as List<dynamic>?;
     return Event(
       eventId: map['eventId'] as String,
       instanceId: map['instanceId'] as String,
@@ -153,6 +171,9 @@ class Event {
           : null,
       attendees: attendeesList
           ?.map((a) => Attendee.fromMap(Map<String, dynamic>.from(a as Map)))
+          .toList(),
+      reminders: remindersList
+          ?.map((m) => Duration(minutes: (m as num).toInt()))
           .toList(),
       url: map['url'] as String?,
     );
@@ -182,6 +203,10 @@ class Event {
     }
     if (attendees != null) {
       map['attendees'] = attendees!.map((a) => a.toMap()).toList();
+    }
+    if (reminders != null) {
+      map['reminders'] =
+          reminders!.map((d) => (d.inSeconds / 60).round()).toList();
     }
 
     return map;
@@ -213,6 +238,7 @@ class Event {
         other.isRecurring == isRecurring &&
         other.recurrenceRule == recurrenceRule &&
         listEquals(other.attendees, attendees) &&
+        listEquals(other.reminders, reminders) &&
         other.url == url;
   }
 
@@ -234,6 +260,7 @@ class Event {
       isRecurring,
       recurrenceRule,
       attendees != null ? Object.hashAll(attendees!) : null,
+      reminders != null ? Object.hashAll(reminders!) : null,
       url,
     );
   }

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -20,6 +20,7 @@ typedef UpdateEventCall = ({
   bool? isAllDay,
   String? timeZone,
   String? availability,
+  Patch<List<int>>? reminders,
 });
 
 /// Arguments captured from the last
@@ -61,6 +62,12 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
   /// updateCalendar / deleteEvent call.
   UpdateEventCall? lastUpdateEvent;
   UpdateRecurringCall? lastUpdateRecurring;
+
+  /// The `reminders` (minutes) argument of the most recent createEvent call.
+  /// Captured separately from [_createEventCallback] so existing callback
+  /// callers keep their unchanged signature. Set to a sentinel before each
+  /// captured call so "passed null" is distinguishable from "never called".
+  Object? lastCreateEventReminders = 'unset';
   ({String calendarId, String? name, String? colorHex})? lastUpdateCalendar;
   ({String eventId, int? timestamp})? lastDeleteEvent;
 
@@ -231,8 +238,10 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     String? timeZone,
     String availability,
     String? recurrenceRule,
+    List<int>? reminders,
   ) async {
     if (_exceptionToThrow != null) throw _exceptionToThrow!;
+    lastCreateEventReminders = reminders;
     if (_createEventCallback != null) {
       return _createEventCallback!(
         calendarId,
@@ -270,6 +279,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     bool? isAllDay,
     String? timeZone,
     String? availability,
+    Patch<List<int>>? reminders,
   }) async {
     if (_exceptionToThrow != null) throw _exceptionToThrow!;
     lastUpdateEvent = (
@@ -284,6 +294,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
       isAllDay: isAllDay,
       timeZone: timeZone,
       availability: availability,
+      reminders: reminders,
     );
   }
 
@@ -939,6 +950,70 @@ void main() {
           ),
         );
       });
+
+      test('forwards reminders to the platform as whole minutes', () async {
+        await DeviceCalendar.instance.createEvent(
+          calendarId: 'cal-123',
+          title: 'Meeting',
+          startDate: DateTime.now(),
+          endDate: DateTime.now().add(Duration(hours: 1)),
+          reminders: [
+            Duration(minutes: 15),
+            Duration(hours: 1),
+            Duration(seconds: 90),
+          ],
+        );
+
+        expect(mockPlatform.lastCreateEventReminders, [15, 60, 2]);
+      });
+
+      test('forwards null reminders when omitted', () async {
+        await DeviceCalendar.instance.createEvent(
+          calendarId: 'cal-123',
+          title: 'Meeting',
+          startDate: DateTime.now(),
+          endDate: DateTime.now().add(Duration(hours: 1)),
+        );
+
+        expect(mockPlatform.lastCreateEventReminders, isNull);
+      });
+
+      test('allows a zero-duration reminder (at start)', () async {
+        await DeviceCalendar.instance.createEvent(
+          calendarId: 'cal-123',
+          title: 'Meeting',
+          startDate: DateTime.now(),
+          endDate: DateTime.now().add(Duration(hours: 1)),
+          reminders: [Duration.zero],
+        );
+
+        expect(mockPlatform.lastCreateEventReminders, [0]);
+      });
+
+      test('de-duplicates reminders that round to the same minute', () async {
+        await DeviceCalendar.instance.createEvent(
+          calendarId: 'cal-123',
+          title: 'Meeting',
+          startDate: DateTime.now(),
+          endDate: DateTime.now().add(Duration(hours: 1)),
+          reminders: [Duration(minutes: 15), Duration(seconds: 900)],
+        );
+
+        expect(mockPlatform.lastCreateEventReminders, [15]);
+      });
+
+      test('throws ArgumentError on a negative reminder', () async {
+        expect(
+          () => DeviceCalendar.instance.createEvent(
+            calendarId: 'cal-123',
+            title: 'Meeting',
+            startDate: DateTime.now(),
+            endDate: DateTime.now().add(Duration(hours: 1)),
+            reminders: [Duration(minutes: -5)],
+          ),
+          throwsArgumentError,
+        );
+      });
     });
 
     group('createCalendar', () {
@@ -1016,6 +1091,47 @@ void main() {
             eventId: 'event-123',
             startDate: DateTime(2024, 3, 20, 11, 0),
             endDate: DateTime(2024, 3, 20, 10, 0),
+          ),
+          throwsArgumentError,
+        );
+      });
+
+      test('passes a reminders Patch.set through as minutes', () async {
+        await DeviceCalendar.instance.updateEvent(
+          eventId: 'event-123',
+          reminders: Patch.set([Duration(minutes: 30), Duration(seconds: 90)]),
+        );
+
+        final reminders = mockPlatform.lastUpdateEvent?.reminders;
+        expect(reminders, isA<PatchSet<List<int>>>());
+        expect((reminders as PatchSet<List<int>>).value, [30, 2]);
+      });
+
+      test('passes a reminders Patch.clear through unchanged', () async {
+        await DeviceCalendar.instance.updateEvent(
+          eventId: 'event-123',
+          reminders: const Patch.clear(),
+        );
+
+        expect(
+          mockPlatform.lastUpdateEvent?.reminders,
+          isA<PatchClear<List<int>>>(),
+        );
+      });
+
+      test('reminders alone is enough to not be a no-op', () async {
+        await DeviceCalendar.instance.updateEvent(
+          eventId: 'event-123',
+          reminders: const Patch.clear(),
+        );
+        expect(mockPlatform.lastUpdateEvent, isNotNull);
+      });
+
+      test('throws ArgumentError on a negative reminder in Patch.set', () async {
+        expect(
+          () => DeviceCalendar.instance.updateEvent(
+            eventId: 'event-123',
+            reminders: Patch.set([Duration(minutes: -5)]),
           ),
           throwsArgumentError,
         );
@@ -1456,6 +1572,58 @@ void main() {
 
     test('returns null for unparseable string', () {
       expect(cal(colorHex: 'notacolor').color, isNull);
+    });
+  });
+
+  group('Event', () {
+    Map<String, dynamic> baseMap({List<int>? reminders}) => {
+          'eventId': 'e1',
+          'instanceId': 'e1',
+          'calendarId': 'c1',
+          'title': 'Standup',
+          'startDate': DateTime(2024, 1, 1, 9).millisecondsSinceEpoch,
+          'endDate': DateTime(2024, 1, 1, 10).millisecondsSinceEpoch,
+          'isAllDay': false,
+          'availability': 'busy',
+          'status': 'confirmed',
+          'isRecurring': false,
+          if (reminders != null) 'reminders': reminders,
+        };
+
+    group('fromMap', () {
+      test('parses reminders minutes into a List<Duration>', () {
+        final event = Event.fromMap(baseMap(reminders: [15, 60, 0]));
+        expect(event.reminders, [
+          const Duration(minutes: 15),
+          const Duration(hours: 1),
+          Duration.zero,
+        ]);
+      });
+
+      test('leaves reminders null when the platform reports none', () {
+        final event = Event.fromMap(baseMap());
+        expect(event.reminders, isNull);
+      });
+    });
+
+    group('toMap', () {
+      test('serializes reminders back to minutes', () {
+        final event = Event.fromMap(baseMap(reminders: [15, 60]));
+        expect(event.toMap()['reminders'], [15, 60]);
+      });
+
+      test('round-trips reminders through fromMap -> toMap -> fromMap', () {
+        final original = Event.fromMap(baseMap(reminders: [5, 30, 1440]));
+        final roundTripped = Event.fromMap(
+          Map<String, dynamic>.from(original.toMap()),
+        );
+        expect(roundTripped.reminders, original.reminders);
+      });
+
+      test('omits reminders when null', () {
+        final event = Event.fromMap(baseMap());
+        expect(event.toMap().containsKey('reminders'), isFalse);
+      });
     });
   });
 }

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
@@ -369,7 +369,9 @@ class DeviceCalendarPlusAndroidPlugin :
         val timeZone = call.argument<String>("timeZone")
         val availability = call.argument<String>("availability")
         val recurrenceRule = call.argument<String>("recurrenceRule")
-        
+        // Reminders: minutes before start (already normalized by the Dart layer).
+        val reminders = call.argument<List<Int>>("reminders")
+
         // Validate required arguments.
         // calendarId is optional: null routes the event to the default calendar.
         if (title == null || startDateMillis == null ||
@@ -397,11 +399,12 @@ class DeviceCalendarPlusAndroidPlugin :
                 url,
                 timeZone,
                 availability,
-                recurrenceRule
+                recurrenceRule,
+                reminders
             )
         }
     }
-    
+
     private fun handleDeleteEvent(call: MethodCall, result: Result) {
         val service = eventsService ?: error("EventsService not initialized - plugin lifecycle error")
         

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventFieldPatch.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventFieldPatch.kt
@@ -18,19 +18,43 @@ data class EventFieldPatch(
     val isAllDay: Boolean?,
     val timeZone: String?,
     val availability: String?,
+    val reminders: RemindersPatch,
     val clearedFields: List<String>
 ) {
+    /**
+     * The three states of a reminders edit: leave the event's reminders
+     * untouched, replace the whole set, or remove them all. Mirrors the Dart
+     * `Patch<List<Duration>>` over the method channel.
+     */
+    sealed class RemindersPatch {
+        object Unchanged : RemindersPatch()
+        data class Set(val minutes: List<Int>) : RemindersPatch()
+        object Clear : RemindersPatch()
+    }
+
     companion object {
         /** Reads the patch fields from a method-channel [call]. */
-        fun fromCall(call: MethodCall) = EventFieldPatch(
-            title = call.argument<String>("title"),
-            description = call.argument<String>("description"),
-            location = call.argument<String>("location"),
-            url = call.argument<String>("url"),
-            isAllDay = call.argument<Boolean>("isAllDay"),
-            timeZone = call.argument<String>("timeZone"),
-            availability = call.argument<String>("availability"),
-            clearedFields = call.argument<List<String>>("clearedFields") ?: emptyList()
-        )
+        fun fromCall(call: MethodCall): EventFieldPatch {
+            val clearedFields = call.argument<List<String>>("clearedFields") ?: emptyList()
+            // A present `reminders` key replaces the set; the key named in
+            // clearedFields clears it; neither leaves it unchanged.
+            val reminders = when {
+                call.argument<List<Int>>("reminders") != null ->
+                    RemindersPatch.Set(call.argument<List<Int>>("reminders")!!)
+                "reminders" in clearedFields -> RemindersPatch.Clear
+                else -> RemindersPatch.Unchanged
+            }
+            return EventFieldPatch(
+                title = call.argument<String>("title"),
+                description = call.argument<String>("description"),
+                location = call.argument<String>("location"),
+                url = call.argument<String>("url"),
+                isAllDay = call.argument<Boolean>("isAllDay"),
+                timeZone = call.argument<String>("timeZone"),
+                availability = call.argument<String>("availability"),
+                reminders = reminders,
+                clearedFields = clearedFields
+            )
+        }
     }
 }

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -304,7 +304,60 @@ class EventsService(
             eventMap["attendees"] = attendees
         }
 
+        // Query relative reminders (minutes before start)
+        val reminders = queryReminderMinutes(eventId.toLong())
+        if (reminders.isNotEmpty()) {
+            eventMap["reminders"] = reminders
+        }
+
         return eventMap
+    }
+
+    /**
+     * Reads the relative reminders of an event as whole minutes before start.
+     *
+     * Keeps only alert/default-method rows (the ones the plugin writes); email
+     * and SMS reminders are out of scope and skipped. A row with MINUTES_DEFAULT
+     * (-1) carries no fixed offset, so it is skipped too. Returns an empty list
+     * when the event has no qualifying reminders.
+     */
+    private fun queryReminderMinutes(eventId: Long): List<Int> {
+        val minutes = mutableListOf<Int>()
+        try {
+            context.contentResolver.query(
+                CalendarContract.Reminders.CONTENT_URI,
+                arrayOf(
+                    CalendarContract.Reminders.MINUTES,
+                    CalendarContract.Reminders.METHOD,
+                ),
+                "${CalendarContract.Reminders.EVENT_ID} = ?",
+                arrayOf(eventId.toString()),
+                null
+            )?.use { cursor ->
+                val minutesIdx = cursor.getColumnIndexOrThrow(CalendarContract.Reminders.MINUTES)
+                val methodIdx = cursor.getColumnIndexOrThrow(CalendarContract.Reminders.METHOD)
+                while (cursor.moveToNext()) {
+                    val method = if (cursor.isNull(methodIdx)) {
+                        CalendarContract.Reminders.METHOD_DEFAULT
+                    } else {
+                        cursor.getInt(methodIdx)
+                    }
+                    if (method != CalendarContract.Reminders.METHOD_ALERT &&
+                        method != CalendarContract.Reminders.METHOD_DEFAULT) {
+                        continue
+                    }
+                    if (cursor.isNull(minutesIdx)) continue
+                    val value = cursor.getInt(minutesIdx)
+                    // MINUTES_DEFAULT (-1) means "use the calendar's default" —
+                    // it has no concrete offset to report.
+                    if (value < 0) continue
+                    minutes.add(value)
+                }
+            }
+        } catch (_: Exception) {
+            // Silently return what we have if the reminder query fails.
+        }
+        return minutes
     }
 
     private fun queryAttendees(eventId: Long): List<Map<String, Any?>> {
@@ -620,7 +673,8 @@ class EventsService(
         url: String?,
         timeZone: String?,
         availability: String,
-        recurrenceRule: String?
+        recurrenceRule: String?,
+        reminders: List<Int>?
     ): Result<String> {
         // Check for write calendar permission
         if (android.content.pm.PackageManager.PERMISSION_GRANTED !=
@@ -632,7 +686,7 @@ class EventsService(
                 )
             )
         }
-        
+
         // Resolve the target calendar. A null calendarId means "default
         // calendar" — resolve the primary (or first) writable calendar. The
         // resolver fails with permissionDenied if it can't read the calendar
@@ -719,16 +773,26 @@ class EventsService(
                 
                 // Set status to confirmed
                 put(CalendarContract.Events.STATUS, CalendarContract.Events.STATUS_CONFIRMED)
+
+                // Flag the event as having alarms so the provider expands them.
+                val hasReminders = reminders != null && reminders.isNotEmpty()
+                put(CalendarContract.Events.HAS_ALARM, if (hasReminders) 1 else 0)
             }
-            
+
             val uri = context.contentResolver.insert(
                 CalendarContract.Events.CONTENT_URI,
                 values
             )
-            
+
             if (uri != null) {
                 val eventId = uri.lastPathSegment
                 if (eventId != null) {
+                    // Reminders attach as separate rows keyed by EVENT_ID — this
+                    // is the same whether or not the event recurs, so the
+                    // RRULE/DURATION handling above is untouched.
+                    if (reminders != null && reminders.isNotEmpty()) {
+                        insertReminderRows(eventId.toLong(), reminders)
+                    }
                     return Result.success(eventId)
                 }
             }
@@ -927,6 +991,10 @@ class EventsService(
             values.put(CalendarContract.Events.EVENT_TIMEZONE, java.util.TimeZone.getDefault().id)
         }
 
+        // A reminders set/clear also flips HAS_ALARM so the provider expands
+        // (or drops) the alarms. Unchanged leaves the column alone.
+        applyRemindersHasAlarm(values, patch.reminders)
+
         // Perform the update
         val updatedRows = context.contentResolver.update(
             CalendarContract.Events.CONTENT_URI,
@@ -943,6 +1011,10 @@ class EventsService(
                 )
             )
         }
+
+        // Reminder rows live in a separate table keyed by EVENT_ID — rewrite
+        // them after the event row update (no-op when unchanged).
+        applyRemindersRows(eventId.toLong(), patch.reminders)
 
         return Result.success(Unit)
     }
@@ -1050,13 +1122,17 @@ class EventsService(
         if (patch.timeZone != null) {
             values.put(CalendarContract.Events.EVENT_TIMEZONE, patch.timeZone)
         }
+        // The exception is a fresh event row, so a reminders set/clear sets its
+        // HAS_ALARM. Unchanged inherits the parent's value implicitly.
+        applyRemindersHasAlarm(values, patch.reminders)
 
         val exceptionUri = android.content.ContentUris.withAppendedId(
             CalendarContract.Events.CONTENT_EXCEPTION_URI,
             eventId.toLong()
         )
         val uri = context.contentResolver.insert(exceptionUri, values)
-        if (uri?.lastPathSegment == null) {
+        val exceptionId = uri?.lastPathSegment
+        if (exceptionId == null) {
             return Result.failure(
                 CalendarException(
                     PlatformExceptionCodes.OPERATION_FAILED,
@@ -1064,6 +1140,8 @@ class EventsService(
                 )
             )
         }
+        // Reminder rows attach to the detached exception's own event id.
+        applyRemindersRows(exceptionId.toLong(), patch.reminders)
         return Result.success(Unit)
     }
 
@@ -1245,6 +1323,8 @@ class EventsService(
             )
         }
 
+        applyRemindersHasAlarm(values, patch.reminders)
+
         // RRULE writes require sync-adapter context on Android — see
         // updateEventAsSyncAdapter for the rationale.
         val updatedRows = updateEventAsSyncAdapter(eventId, row.calendarId, values)
@@ -1256,6 +1336,10 @@ class EventsService(
                 )
             )
         }
+
+        // Reminder rows attach to the (master) event row by EVENT_ID — the same
+        // for recurring and non-recurring, so no DURATION/RRULE interaction.
+        applyRemindersRows(eventId.toLong(), patch.reminders)
         return Result.success(eventId)
     }
 
@@ -1346,6 +1430,18 @@ class EventsService(
             rrule = effectiveRrule
         )
         val newEventId = insertResult.getOrElse { return Result.failure(it) }
+
+        // The new series carries the patch's reminders when set/cleared, else
+        // it inherits the original series' reminders.
+        val effectiveReminders = when (val r = patch.reminders) {
+            is EventFieldPatch.RemindersPatch.Set -> r.minutes
+            is EventFieldPatch.RemindersPatch.Clear -> emptyList()
+            EventFieldPatch.RemindersPatch.Unchanged -> queryReminderMinutes(eventId.toLong())
+        }
+        if (effectiveReminders.isNotEmpty()) {
+            insertReminderRows(newEventId.toLong(), effectiveReminders)
+            setHasAlarm(newEventId.toLong(), row.calendarId, true)
+        }
 
         // Truncate the original series to end just before the anchor. UNTIL is
         // inclusive, so cutting it one second early keeps the anchor occurrence
@@ -1679,6 +1775,85 @@ class EventsService(
                 )
             )
         }
+    }
+
+    /**
+     * Inserts one [CalendarContract.Reminders] row per minute value, each a
+     * relative METHOD_ALERT reminder that many minutes before the event start.
+     */
+    private fun insertReminderRows(eventId: Long, minutes: List<Int>) {
+        for (m in minutes) {
+            val values = android.content.ContentValues().apply {
+                put(CalendarContract.Reminders.EVENT_ID, eventId)
+                put(CalendarContract.Reminders.MINUTES, m)
+                put(CalendarContract.Reminders.METHOD, CalendarContract.Reminders.METHOD_ALERT)
+            }
+            context.contentResolver.insert(CalendarContract.Reminders.CONTENT_URI, values)
+        }
+    }
+
+    /** Removes all reminder rows for [eventId]. */
+    private fun deleteReminderRows(eventId: Long) {
+        context.contentResolver.delete(
+            CalendarContract.Reminders.CONTENT_URI,
+            "${CalendarContract.Reminders.EVENT_ID} = ?",
+            arrayOf(eventId.toString())
+        )
+    }
+
+    /**
+     * Applies a reminders [patch] to the rows of [eventId]: a set replaces the
+     * whole reminder set (delete then re-insert), a clear removes them all, and
+     * unchanged leaves the rows untouched.
+     */
+    private fun applyRemindersRows(
+        eventId: Long,
+        patch: EventFieldPatch.RemindersPatch
+    ) {
+        when (patch) {
+            EventFieldPatch.RemindersPatch.Unchanged -> {}
+            EventFieldPatch.RemindersPatch.Clear -> deleteReminderRows(eventId)
+            is EventFieldPatch.RemindersPatch.Set -> {
+                deleteReminderRows(eventId)
+                if (patch.minutes.isNotEmpty()) {
+                    insertReminderRows(eventId, patch.minutes)
+                }
+            }
+        }
+    }
+
+    /**
+     * Writes HAS_ALARM into [values] to match a reminders [patch]: a non-empty
+     * set flips it on, an empty set or clear flips it off, unchanged leaves the
+     * column out so the existing flag stands.
+     */
+    private fun applyRemindersHasAlarm(
+        values: android.content.ContentValues,
+        patch: EventFieldPatch.RemindersPatch
+    ) {
+        when (patch) {
+            EventFieldPatch.RemindersPatch.Unchanged -> {}
+            EventFieldPatch.RemindersPatch.Clear ->
+                values.put(CalendarContract.Events.HAS_ALARM, 0)
+            is EventFieldPatch.RemindersPatch.Set ->
+                values.put(
+                    CalendarContract.Events.HAS_ALARM,
+                    if (patch.minutes.isNotEmpty()) 1 else 0
+                )
+        }
+    }
+
+    /** Sets HAS_ALARM for an event row (used when reminders are added later). */
+    private fun setHasAlarm(eventId: Long, calendarId: String, hasAlarm: Boolean) {
+        val values = android.content.ContentValues().apply {
+            put(CalendarContract.Events.HAS_ALARM, if (hasAlarm) 1 else 0)
+        }
+        context.contentResolver.update(
+            CalendarContract.Events.CONTENT_URI,
+            values,
+            "${CalendarContract.Events._ID} = ?",
+            arrayOf(eventId.toString())
+        )
     }
 
     private fun availabilityToInt(availability: String): Int {

--- a/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
+++ b/packages/device_calendar_plus_android/lib/device_calendar_plus_android.dart
@@ -153,6 +153,7 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
     String? timeZone,
     String availability,
     String? recurrenceRule,
+    List<int>? reminders,
   ) async {
     final result = await methodChannel.invokeMethod<String>(
       'createEvent',
@@ -168,6 +169,7 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
         'timeZone': timeZone,
         'availability': availability,
         'recurrenceRule': recurrenceRule,
+        'reminders': reminders,
       },
     );
     return result!;
@@ -197,6 +199,7 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
     bool? isAllDay,
     String? timeZone,
     String? availability,
+    Patch<List<int>>? reminders,
   }) async {
     final args = <String, dynamic>{
       'eventId': eventId,
@@ -212,6 +215,7 @@ class DeviceCalendarPlusAndroid extends DeviceCalendarPlusPlatform {
       'description': description,
       'location': location,
       'url': url,
+      'reminders': reminders,
     });
     await methodChannel.invokeMethod<void>('updateEvent', args);
   }

--- a/packages/device_calendar_plus_android/test/device_calendar_plus_android_test.dart
+++ b/packages/device_calendar_plus_android/test/device_calendar_plus_android_test.dart
@@ -107,6 +107,7 @@ void main() {
         'America/New_York',
         'busy',
         null,
+        [15, 60],
       );
 
       expect(log[0].arguments['calendarId'], equals('cal-123'));
@@ -121,6 +122,7 @@ void main() {
       expect(log[0].arguments['url'], equals('https://example.com/event/123'));
       expect(log[0].arguments['timeZone'], equals('America/New_York'));
       expect(log[0].arguments['availability'], equals('busy'));
+      expect(log[0].arguments['reminders'], equals([15, 60]));
     });
 
     test('updateEvent serializes only provided fields', () async {
@@ -138,6 +140,30 @@ void main() {
       expect(log[0].arguments['isAllDay'], isNull);
       expect(log[0].arguments['timeZone'], isNull);
       expect(log[0].arguments['availability'], isNull);
+      // Reminders unchanged: no key, not in clearedFields.
+      expect(log[0].arguments['reminders'], isNull);
+      expect(log[0].arguments['clearedFields'], isEmpty);
+    });
+
+    test('updateEvent serializes a reminders Patch.set as minutes', () async {
+      await plugin.updateEvent(
+        'event-123',
+        reminders: Patch.set([30, 60]),
+      );
+
+      expect(log[0].arguments['reminders'], equals([30, 60]));
+      expect(log[0].arguments['clearedFields'], isEmpty);
+    });
+
+    test('updateEvent serializes a reminders Patch.clear via clearedFields',
+        () async {
+      await plugin.updateEvent(
+        'event-123',
+        reminders: const Patch.clear(),
+      );
+
+      expect(log[0].arguments['reminders'], isNull);
+      expect(log[0].arguments['clearedFields'], contains('reminders'));
     });
   });
 }

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/DeviceCalendarPlusIosPlugin.swift
@@ -469,6 +469,8 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
     let url = args["url"] as? String
     let timeZone = args["timeZone"] as? String
     let recurrenceRule = args["recurrenceRule"] as? String
+    // Reminders: minutes before start (already normalized by the Dart layer).
+    let reminders = args["reminders"] as? [Int]
 
     // Convert dates
     let startDate = Date(timeIntervalSince1970: TimeInterval(startDateMillis) / 1000.0)
@@ -487,6 +489,7 @@ public class DeviceCalendarPlusIosPlugin: NSObject, FlutterPlugin, EKEventViewDe
         timeZone: timeZone,
         availability: availability,
         recurrenceRule: recurrenceRule,
+        reminders: reminders,
         completion: $0)
     }
   }

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventFieldPatch.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventFieldPatch.swift
@@ -9,6 +9,15 @@ import EventKit
 /// remaining parameters are the ones that differ per operation. The Swift
 /// counterpart of Android's `EventFieldPatch`.
 struct EventFieldPatch {
+  /// The three states of a reminders edit: leave the event's reminders
+  /// untouched, replace the whole set, or remove them all. Mirrors the Dart
+  /// `Patch<List<Duration>>` over the method channel.
+  enum RemindersPatch {
+    case unchanged
+    case set([Int])  // minutes before start
+    case clear
+  }
+
   let title: String?
   let description: String?
   let location: String?
@@ -16,6 +25,7 @@ struct EventFieldPatch {
   let isAllDay: Bool?
   let timeZone: String?
   let availability: String?
+  let reminders: RemindersPatch
   let clearedFields: [String]
 
   /// Reads the patch fields from method-channel arguments.
@@ -28,6 +38,15 @@ struct EventFieldPatch {
     timeZone = args["timeZone"] as? String
     availability = args["availability"] as? String
     clearedFields = args["clearedFields"] as? [String] ?? []
+    // A present `reminders` key replaces the set; the key named in
+    // clearedFields clears it; neither leaves it unchanged.
+    if let minutes = args["reminders"] as? [Int] {
+      reminders = .set(minutes)
+    } else if clearedFields.contains("reminders") {
+      reminders = .clear
+    } else {
+      reminders = .unchanged
+    }
   }
 
   /// Applies the patch to `event`, except the time zone — each write path
@@ -49,6 +68,14 @@ struct EventFieldPatch {
     } else if let url = url {
       event.url = URL(string: url)
     }
+    switch reminders {
+    case .unchanged:
+      break
+    case .clear:
+      event.alarms = nil
+    case .set(let minutes):
+      EventFieldPatch.applyReminders(minutes, to: event)
+    }
     if let isAllDay = isAllDay { event.isAllDay = isAllDay }
     if let availability = availability {
       switch availability {
@@ -59,6 +86,18 @@ struct EventFieldPatch {
       default: break
       }
     }
+  }
+
+  /// Replaces `event.alarms` with relative-offset alarms built from `minutes`
+  /// (whole minutes before start). An empty list clears the alarms. Shared by
+  /// the update patch and `EventsService.createEvent` so the EKAlarm mapping
+  /// lives in one place.
+  static func applyReminders(_ minutes: [Int], to event: EKEvent) {
+    if minutes.isEmpty {
+      event.alarms = nil
+      return
+    }
+    event.alarms = minutes.map { EKAlarm(relativeOffset: -Double($0) * 60) }
   }
 
   /// Normalizes the event's time zone: all-day events carry none; otherwise

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -246,6 +246,21 @@ class EventsService {
       }
     }
 
+    // Serialize relative reminders. Keep only relative alarms that fire at or
+    // before start (relativeOffset <= 0); skip absolute-date alarms (no
+    // relativeOffset) and after-start ones (out of scope). Emit whole minutes.
+    if let alarms = event.alarms, !alarms.isEmpty {
+      let reminderMinutes: [Int] = alarms.compactMap { alarm in
+        guard alarm.absoluteDate == nil, alarm.relativeOffset <= 0 else {
+          return nil
+        }
+        return Int((-alarm.relativeOffset / 60).rounded())
+      }
+      if !reminderMinutes.isEmpty {
+        eventMap["reminders"] = reminderMinutes
+      }
+    }
+
     return eventMap
   }
 
@@ -435,6 +450,7 @@ class EventsService {
     timeZone: String?,
     availability: String,
     recurrenceRule: String?,
+    reminders: [Int]?,
     completion: @escaping (Result<String, CalendarError>) -> Void
   ) {
     // Check permission - creating events only requires write access
@@ -507,7 +523,13 @@ class EventsService {
     if let rruleString = recurrenceRule, let rule = parseRecurrenceRule(rruleString) {
       event.recurrenceRules = [rule]
     }
-    
+
+    // Set relative reminders (alarms). Each value is whole minutes before
+    // start; EKAlarm uses a negative second offset.
+    if let reminders = reminders, !reminders.isEmpty {
+      EventFieldPatch.applyReminders(reminders, to: event)
+    }
+
     // Save the event
     do {
       try eventStore.save(event, span: .thisEvent)

--- a/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
+++ b/packages/device_calendar_plus_ios/lib/device_calendar_plus_ios.dart
@@ -149,6 +149,7 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
     String? timeZone,
     String availability,
     String? recurrenceRule,
+    List<int>? reminders,
   ) async {
     final result = await methodChannel.invokeMethod<String>(
       'createEvent',
@@ -164,6 +165,7 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
         'timeZone': timeZone,
         'availability': availability,
         'recurrenceRule': recurrenceRule,
+        'reminders': reminders,
       },
     );
     return result!;
@@ -193,6 +195,7 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
     bool? isAllDay,
     String? timeZone,
     String? availability,
+    Patch<List<int>>? reminders,
   }) async {
     final args = <String, dynamic>{
       'eventId': eventId,
@@ -208,6 +211,7 @@ class DeviceCalendarPlusIos extends DeviceCalendarPlusPlatform {
       'description': description,
       'location': location,
       'url': url,
+      'reminders': reminders,
     });
     await methodChannel.invokeMethod<void>('updateEvent', args);
   }

--- a/packages/device_calendar_plus_ios/test/device_calendar_plus_ios_test.dart
+++ b/packages/device_calendar_plus_ios/test/device_calendar_plus_ios_test.dart
@@ -92,6 +92,7 @@ void main() {
         'America/New_York',
         'busy',
         null,
+        [15, 60],
       );
 
       expect(log[0].arguments['calendarId'], equals('cal-123'));
@@ -106,6 +107,7 @@ void main() {
       expect(log[0].arguments['url'], equals('https://example.com/event/123'));
       expect(log[0].arguments['timeZone'], equals('America/New_York'));
       expect(log[0].arguments['availability'], equals('busy'));
+      expect(log[0].arguments['reminders'], equals([15, 60]));
     });
 
     test('updateEvent serializes only provided fields', () async {
@@ -123,6 +125,30 @@ void main() {
       expect(log[0].arguments['isAllDay'], isNull);
       expect(log[0].arguments['timeZone'], isNull);
       expect(log[0].arguments['availability'], isNull);
+      // Reminders unchanged: no key, not in clearedFields.
+      expect(log[0].arguments['reminders'], isNull);
+      expect(log[0].arguments['clearedFields'], isEmpty);
+    });
+
+    test('updateEvent serializes a reminders Patch.set as minutes', () async {
+      await plugin.updateEvent(
+        'event-123',
+        reminders: Patch.set([30, 60]),
+      );
+
+      expect(log[0].arguments['reminders'], equals([30, 60]));
+      expect(log[0].arguments['clearedFields'], isEmpty);
+    });
+
+    test('updateEvent serializes a reminders Patch.clear via clearedFields',
+        () async {
+      await plugin.updateEvent(
+        'event-123',
+        reminders: const Patch.clear(),
+      );
+
+      expect(log[0].arguments['reminders'], isNull);
+      expect(log[0].arguments['clearedFields'], contains('reminders'));
     });
   });
 }

--- a/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
+++ b/packages/device_calendar_plus_platform_interface/lib/device_calendar_plus_platform_interface.dart
@@ -170,6 +170,11 @@ abstract class DeviceCalendarPlusPlatform extends PlatformInterface {
   ///
   /// [recurrenceRule] is an optional RRULE string for recurring events.
   ///
+  /// [reminders] is an optional list of relative reminder offsets, each in
+  /// **whole minutes before the event start**. The shared Dart layer has
+  /// already converted the public `Duration` values to minutes — native code
+  /// works purely in minutes. `null` means no reminders.
+  ///
   /// Returns the ID of the newly created event (system-generated).
   /// Requires calendar write permissions.
   ///
@@ -188,6 +193,7 @@ abstract class DeviceCalendarPlusPlatform extends PlatformInterface {
     String? timeZone,
     String availability,
     String? recurrenceRule,
+    List<int>? reminders,
   );
 
   /// Deletes an event from the device.
@@ -221,9 +227,15 @@ abstract class DeviceCalendarPlusPlatform extends PlatformInterface {
   /// - [isAllDay] - change between all-day and timed event
   /// - [timeZone] - new timezone identifier
   /// - [availability] - new availability identifier
+  /// - [reminders] - replace or clear the event's reminder set (minutes before
+  ///   start)
   ///
   /// [description], [location] and [url] take a [Patch]: `null` leaves the
   /// field unchanged, [Patch.set] assigns a value, [Patch.clear] removes it.
+  /// [reminders] takes a `Patch<List<int>>`: `null` leaves the reminders
+  /// unchanged, [Patch.set] replaces the whole set with the given minutes,
+  /// [Patch.clear] removes all reminders. The shared Dart layer has already
+  /// converted the public `Duration` values to whole minutes.
   ///
   /// At least one field must be provided.
   /// Requires calendar write permissions.
@@ -239,6 +251,7 @@ abstract class DeviceCalendarPlusPlatform extends PlatformInterface {
     bool? isAllDay,
     String? timeZone,
     String? availability,
+    Patch<List<int>>? reminders,
   });
 
   /// Updates a recurring event's series, choosing which occurrences the edit

--- a/packages/device_calendar_plus_platform_interface/lib/src/patch.dart
+++ b/packages/device_calendar_plus_platform_interface/lib/src/patch.dart
@@ -43,15 +43,18 @@ final class PatchClear<T> extends Patch<T> {
   int get hashCode => (PatchClear<T>).hashCode;
 }
 
-/// Writes patchable string fields into a method-channel argument map.
+/// Writes patchable fields into a method-channel argument map.
 ///
 /// For each entry: a [PatchSet] adds `key: value`; a [PatchClear] appends the
 /// key to the `clearedFields` list; a `null` patch is omitted entirely. The
 /// platform side treats a key listed in `clearedFields` as "remove", a present
 /// key as "set", and an absent key as "leave unchanged".
+///
+/// Values cross the channel as dynamic, so fields of any serializable type
+/// (strings, `List<int>` reminder offsets, …) share the one path.
 void writePatchFields(
   Map<String, dynamic> args,
-  Map<String, Patch<String>?> fields,
+  Map<String, Patch<Object?>?> fields,
 ) {
   final cleared = <String>[];
   for (final entry in fields.entries) {

--- a/packages/device_calendar_plus_platform_interface/test/device_calendar_plus_platform_interface_test.dart
+++ b/packages/device_calendar_plus_platform_interface/test/device_calendar_plus_platform_interface_test.dart
@@ -64,6 +64,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     String? timeZone,
     String availability,
     String? recurrenceRule,
+    List<int>? reminders,
   ) async =>
       'mock-event-id';
 
@@ -83,6 +84,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     bool? isAllDay,
     String? timeZone,
     String? availability,
+    Patch<List<int>>? reminders,
   }) async {}
 
   @override


### PR DESCRIPTION
Closes #87 — our biggest genuine feature gap.

You can now attach reminders to events and read them back:

```dart
await plugin.createEvent(
  title: 'Standup',
  startDate: ...,
  endDate: ...,
  reminders: [Duration(minutes: 15), Duration(hours: 1)],
);

// update: replace / clear / leave alone
await plugin.updateEvent(eventId: id, reminders: Patch.set([Duration(minutes: 30)]));
await plugin.updateEvent(eventId: id, reminders: Patch.clear());

final event = await plugin.getEvent(id);
event.reminders; // [Duration(minutes: 15), Duration(hours: 1)]
```

### Design
- **Type:** `List<Duration>` (matches `eventide`), but **normalized to whole minutes** in the shared Dart layer — minutes are what cross the channel, identically for both platforms. iOS ↔ `EKAlarm(relativeOffset:)` (seconds), Android ↔ `CalendarContract.Reminders` rows (`MINUTES`, `METHOD_ALERT`) + `Events.HAS_ALARM`.
- **Granularity:** iOS supports seconds, Android only minutes — so per the cross-platform rule we expose the common subset. Sub-minute durations round to the nearest minute; document that and you get lossless round-trips for the normal case (15 min, 1 h, 1 day).
- **Validation:** negative `Duration` → `ArgumentError`; zero (reminder at start) is valid.
- **`updateEvent`:** `Patch<List<Duration>>` — `null` unchanged, `Patch.set` replaces the set, `Patch.clear` removes all.
- **Out of scope (v1):** absolute-time alarms, per-alarm methods (email/SMS), after-start offsets.

### Review
Ran the thermonuclear pass — verdict APPROVE-WITH-FIXES, no blockers. Applied the headline fix: reminders ride the existing `writePatchFields` path (widened to `Patch<Object?>`) rather than a parallel single-field helper, which deletes a near-duplicate and removes a fragile call-order dependency on `clearedFields`. Left the Android HAS_ALARM/rows split as-is on purpose — the rows rewrite must run after the not-found/insert guard or an update to a missing event orphans reminder rows, so the two-phase write is deliberate.

### Tests
- Unit (200 pass): minute normalization + sub-minute rounding + dedup, negative→throw, zero allowed, `Event` reminders round-trip, channel serialization of the set/clear/unchanged sentinel.
- Integration (`reminders_test.dart`): create→read, replace, clear round-trips. Device runs below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)