### PR TITLE
docs: slim consumer docs + 0.7.1 topics

### DIFF
--- a/packages/device_calendar_plus/CHANGELOG.md
+++ b/packages/device_calendar_plus/CHANGELOG.md
@@ -4,6 +4,12 @@
 - Add the `device` pub.dev topic (dropped `federated` to stay within the
   five-topic limit).
 
+### Docs
+- Slimmed the README to an overview plus a getting-started snippet, and moved
+  the worked examples into focused topic guides under `doc/`. Trimmed the API
+  doc comments to the consumer-facing contract and removed native-API
+  implementation details. No code or behavior changes.
+
 ## 0.7.0 - 2026-06-17
 
 ### Added

--- a/packages/device_calendar_plus/CHANGELOG.md
+++ b/packages/device_calendar_plus/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.7.1 - 2026-06-17
+
+### Changed
+- Add the `device` pub.dev topic (dropped `federated` to stay within the
+  five-topic limit).
+
 ## 0.7.0 - 2026-06-17
 
 ### Added

--- a/packages/device_calendar_plus/README.md
+++ b/packages/device_calendar_plus/README.md
@@ -771,7 +771,7 @@ For `thisAndFollowing`, pass an instance ID (`event.instanceId`) that carries an
 - [x] **Update recurrence rules** — change, add or remove a recurrence rule via `updateRecurring`
 - [x] **Delete recurring events** — delete a whole series, this-and-following, or a single occurrence via `deleteRecurring`
 - [x] **Attendees** — read-only on both platforms; use `showCreateEventModal` / `showEventModal(edit: true)` to add via native UI
-- [ ] **Reminders / alarms** — read/write on both platforms
+- [x] **Reminders / alarms** — relative-time reminders, read/write on both platforms
 - [ ] **Platform-specific extras** — organizer and other platform-native fields exposed where supported (event URL is now supported)
 
 ## 🤝 Contributing

--- a/packages/device_calendar_plus/README.md
+++ b/packages/device_calendar_plus/README.md
@@ -2,7 +2,7 @@
 
 A Flutter plugin for reading and writing calendar events on **Android** and **iOS**.
 
-The original [`device_calendar`](https://pub.dev/packages/device_calendar) plugin got abandoned, and I needed calendars that actually worked for [Bullet](https://bullet.to). So I rebuilt it: a cleaner Dart API, timezones that behave, and no `timezone` package tagging along. Getting EventKit and Android's Calendar Provider to agree on anything is a proper slog, but that's my problem to lose sleep over, not yours. You just get the tidy bit. 😎
+A maintained replacement for the abandoned [`device_calendar`](https://pub.dev/packages/device_calendar) plugin, built for [Bullet](https://bullet.to): a cleaner Dart API, timezones that behave, and no `timezone` package tagging along. Getting EventKit and Android's Calendar Provider to agree on anything is a slog - this package handles it so your app doesn't have to.
 
 [![pub package](https://img.shields.io/pub/v/device_calendar_plus.svg)](https://pub.dev/packages/device_calendar_plus)
 [![pub points](https://img.shields.io/pub/points/device_calendar_plus)](https://pub.dev/packages/device_calendar_plus/score)
@@ -23,9 +23,9 @@ Built for [Bullet](https://bullet.to), a calmer task + notes + calendar app, and
 
 ## One API, both platforms
 
-I only put things in this plugin that work the same on Android and iOS. If a feature is read-only on one platform, it's read-only here. If it doesn't exist on one, it doesn't go in. Where the two platforms naturally disagree, Android is bent to match iOS, which sets the contract.
+This plugin exposes only what works the same on Android and iOS. If a feature is read-only on one platform, it's read-only here. If it doesn't exist on one, it isn't included. Where the platforms naturally disagree, Android is conformed to iOS, which sets the contract.
 
-It's honest best-effort, though. A few platform realities I just can't paper over: older iOS has no write-only permission tier, and the native editor screens do their own thing across different calendar apps. I call those out in the docs where they show up, rather than hide them behind an API pretending everything's identical.
+It's best-effort, and honest about the gaps. A few platform realities can't be smoothed over: older iOS has no write-only permission tier, and the native editor screens behave differently across calendar apps. Those cases are flagged in the docs where they show up, not hidden behind an API pretending everything's identical.
 
 ## Supported versions
 
@@ -147,7 +147,7 @@ try {
 
 ## Contributing
 
-I'm keeping pull requests closed, and not to be precious about it. Holding the whole API and the iOS/Android parity in my own head is honestly the only way I keep it consistent. Bug reports and feature requests are very welcome though, so open an issue and let's chat. :)
+Pull requests are closed. Keeping the API surface and the iOS/Android parity consistent works best with a single hand on the wheel. Bug reports and feature requests are very welcome though, so open an issue and let's chat. :)
 
 ## License
 

--- a/packages/device_calendar_plus/README.md
+++ b/packages/device_calendar_plus/README.md
@@ -1,65 +1,56 @@
 # device_calendar_plus
 
-A modern, maintained Flutter plugin for reading and writing device calendar events on **Android** and **iOS**.
-Modern replacement for the unmaintained [`device_calendar`](https://pub.dev/packages/device_calendar) plugin — rebuilt for 2025 Flutter standards, working towards feature parity with a cleaner API, and no timezone package dependency.
+A Flutter plugin for reading and writing calendar events on **Android** and **iOS**.
+
+The original [`device_calendar`](https://pub.dev/packages/device_calendar) plugin got abandoned, and I needed calendars that actually worked for [Bullet](https://bullet.to). So I rebuilt it: a cleaner Dart API, timezones that behave, and no `timezone` package tagging along. Getting EventKit and Android's Calendar Provider to agree on anything is a proper slog, but that's my problem to lose sleep over, not yours. You just get the tidy bit. 😎
 
 [![pub package](https://img.shields.io/pub/v/device_calendar_plus.svg)](https://pub.dev/packages/device_calendar_plus)
 [![pub points](https://img.shields.io/pub/points/device_calendar_plus)](https://pub.dev/packages/device_calendar_plus/score)
 [![platforms](https://img.shields.io/badge/platforms-android%20%7C%20ios-blue.svg)](#)
 [![MIT license](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-## ✨ Overview
+Built for [Bullet](https://bullet.to), a calmer task + notes + calendar app, and running in production there.
 
-`device_calendar_plus` lets Flutter apps read and write native calendar data using:
+## What it does
 
-- **Android** Calendar Provider
-- **iOS** EventKit
+- **Permissions** - request and check access, including a write-only tier
+- **Calendars & sources** - create, read, update, delete, and target a specific account
+- **Events** - create, read, update, delete, and query by date range
+- **Recurring events** - full RRULE support with a typed `RecurrenceRule` model; edit or delete a whole series, this-and-following, or a single occurrence
+- **Reminders** - relative before-start alarms, read and write
+- **Native UI** - open the OS event viewer/editor, or a pre-filled create screen
+- **All-day & timezones** - floating dates and sane local-time behaviour
 
-It provides a **clean Dart API**, proper **time-zone handling**, and an **actively maintained** federated structure.
+## One API, both platforms
 
-Created by [Bullet](https://bullet.to) — a personal task + notes + calendar app using this plugin in production.
+I only put things in this plugin that work the same on Android and iOS. If a feature is read-only on one platform, it's read-only here. If it doesn't exist on one, it doesn't go in. Where the two platforms naturally disagree, Android is bent to match iOS, which sets the contract.
 
-## ✅ Supported versions
+It's honest best-effort, though. A few platform realities I just can't paper over: older iOS has no write-only permission tier, and the native editor screens do their own thing across different calendar apps. I call those out in the docs where they show up, rather than hide them behind an API pretending everything's identical.
+
+## Supported versions
 
 | Platform    | Min OS / SDK   | Target / Compile       |
 | ----------- | -------------- | ---------------------- |
 | **Android** | **minSdk 24+** | **target/compile 35**  |
 | **iOS**     | **iOS 13+**    | Latest Xcode / iOS SDK |
 
-## 🚀 Features
-
-- **Permissions**: Request and check calendar permissions
-- **Calendars**: Create, read, update, and delete calendars
-- **Sources/accounts**: List calendar sources (iCloud, Google, local, etc.) and target a specific account when creating calendars
-- **Events**: Create, read, update, and delete events
-- **Query**: Retrieve events by date range or specific event IDs
-- **Native UI**: Open native event modal for viewing or editing (`edit: true`) on both Android and iOS
-- **All-Day Events**: Proper handling of floating calendar dates
-- **Timezones**: Correct timezone behavior for timed events
-- **Recurring events**: Create, read, and delete recurring events (daily, weekly, monthly, yearly) with full RRULE support
-- **Edit a recurring series**: `updateRecurring()` and `deleteRecurring()` with `EventSpan` — apply changes to the whole series, this-and-following, or just one occurrence
-
-## 🧩 Installation
-
-Add the dependency to your project:
+## Install
 
 ```yaml
 dependencies:
   device_calendar_plus: <latest version>
 ```
 
-
-
 ### iOS
 
-Add usage descriptions to your app’s **Info.plist**:
+Add usage descriptions to your app's **Info.plist**:
 
 ```xml
-<!-- iOS 10–16 (legacy key, still valid) -->
+<!-- iOS 10-16 (legacy key, still valid) -->
 <key>NSCalendarsUsageDescription</key>
 <string>Access your calendar to view and manage events.</string>
 
-<!-- iOS 17+ (choose as appropriate) -->
+<!-- iOS 17+ -->
 <key>NSCalendarsFullAccessUsageDescription</key>
 <string>Full access to view and edit your calendar events.</string>
 <key>NSCalendarsWriteOnlyAccessUsageDescription</key>
@@ -75,718 +66,93 @@ Add calendar permissions to `android/app/src/main/AndroidManifest.xml`:
 <uses-permission android:name="android.permission.WRITE_CALENDAR" />
 ```
 
-**ProGuard / R8**: ProGuard rules are automatically applied by the plugin. No manual configuration needed.
+ProGuard / R8 rules are applied automatically, so there's nothing to configure.
 
-## ⏰ DateTime and Timezone Behavior
-
-**All DateTimes returned by this plugin are in local time.**
-
-### All-Day Events (Floating Dates)
-
-All-day events are treated as **floating calendar dates**, not specific instants in time. This means:
-
-- An all-day event for "January 15, 2024" will always display as January 15, regardless of what timezone your device is in
-- The date components (year, month, day) are preserved across timezone changes
-- **Do NOT convert all-day event DateTimes to UTC** — they represent calendar dates, not moments in time
-- Example: A birthday on "January 15" should always show as January 15, whether you're in New York or Tokyo
-
-### Non-All-Day Events (Instants in Time)
-
-Regular timed events represent specific moments in time and can be converted to UTC as needed:
-
-- These events have specific start/end times in a timezone (e.g., "3:00 PM New York time")
-- They represent absolute instants that correspond to different local times across timezones
-- **You can freely convert these DateTimes to UTC** for storage, comparison, or API calls
-- Example: A meeting at "3:00 PM EST" is the same instant as "12:00 PM PST"
-
-### Summary
-
-```dart
-// All-day event - treat as a calendar date, NOT a UTC instant
-final birthdayEvent = await plugin.getEvent(birthdayId);
-if (birthdayEvent.isAllDay) {
-  // ✅ Use the date components directly
-  print('Birthday: ${birthdayEvent.startDate.year}-${birthdayEvent.startDate.month}-${birthdayEvent.startDate.day}');
-  
-  // ❌ Don't convert to UTC - it's a calendar date, not a moment in time
-  // final utcDate = birthdayEvent.startDate.toUtc(); // DON'T DO THIS
-}
-
-// Regular timed event - this IS an instant in time
-final meetingEvent = await plugin.getEvent(meetingId);
-if (!meetingEvent.isAllDay) {
-  // ✅ Convert to UTC for storage/comparison
-  final utcTime = meetingEvent.startDate.toUtc();
-  
-  // ✅ Format in local time for display
-  print('Meeting at: ${meetingEvent.startDate}');
-}
-```
-
-## 🧱 Error Handling
-
-The plugin throws two categories of errors:
-
-**Runtime errors** — `DeviceCalendarException` with a `DeviceCalendarError` enum code. These represent conditions your app should handle (permission denied, event not found, calendar read-only, etc.):
-
-```dart
-try {
-  await plugin.createEvent(...);
-} on DeviceCalendarException catch (e) {
-  switch (e.errorCode) {
-    case DeviceCalendarError.permissionDenied:
-      // Ask user to grant permission
-    case DeviceCalendarError.notFound:
-      // Calendar or event doesn't exist
-    default:
-      // Handle other cases
-  }
-}
-```
-
-**Programmer errors** — standard Dart errors (`ArgumentError`, etc.) for invalid arguments. These indicate bugs in your code, not runtime conditions to handle:
-
-```dart
-// These throw ArgumentError — fix your code, don't catch them:
-plugin.createEvent(calendarId: '', ...);  // empty ID
-plugin.createEvent(..., endDate: beforeStart);  // end before start
-plugin.updateEvent(eventId: 'x');  // no fields to update
-```
-
-> **Note on error codes:**
-> `DeviceCalendarError` exists for developer ergonomics and clearer `switch` handling.
-> We may introduce new enum values in future minor versions as new error cases appear.
-> We do not consider this a breaking change.
-
-
-## 🛠️ Usage Examples
-
-### Request Permissions
+## Getting started
 
 ```dart
 import 'package:device_calendar_plus/device_calendar_plus.dart';
 
-// Get the singleton instance
 final plugin = DeviceCalendar.instance;
 
-// Request calendar permissions
+// 1. Permissions - either ask for them yourself...
 final status = await plugin.requestPermissions();
-if (status != CalendarPermissionStatus.granted) {
-  // Handle permission denied
-  return;
-}
-```
+if (status != CalendarPermissionStatus.granted) return;
 
-#### Write-only access
+//    ...or let methods prompt on first use (set once at app start, then skip
+//    the explicit request above):
+// plugin.autoPermissions = AutoPermissionMode.full;
 
-Apps that only add events (and never read existing ones) can request the
-gentler add-only prompt instead of full read/write:
-
-```dart
-final status = await plugin.requestPermissions(
-  level: CalendarAccessLevel.writeOnly,
-);
-if (status == CalendarPermissionStatus.writeOnly ||
-    status == CalendarPermissionStatus.granted) {
-  // Can create events
-}
-```
-
-- **iOS 17+**: shows the "Add Events Only" prompt
-  (`requestWriteOnlyAccessToEvents`). Add `NSCalendarsWriteOnlyAccessUsageDescription`
-  to `Info.plist`. On iOS 16 and below there is no write-only tier, so this
-  falls back to a full-access request and a grant reports `granted`. Write-only
-  is not a ceiling — a later `requestPermissions()` (full) re-prompts and
-  upgrades the app to full access in-app if the user agrees.
-- **Android**: requests only `WRITE_CALENDAR`. `WRITE_CALENDAR` and
-  `READ_CALENDAR` are in the same `CALENDAR` permission group, so after a
-  write-only grant a later `requestPermissions()` (full) escalates to read
-  access **immediately, with no dialog** (where iOS shows a second prompt), and
-  returns `granted`.
-
-If you start with write-only and later need full read access, just call
-`requestPermissions()` again — iOS shows a second prompt for the upgrade and
-Android escalates silently. Either way the upgrade happens in-app; no trip to
-Settings required.
-
-#### Automatic permissions
-
-By default you request permission yourself. To have methods request it on first
-use instead, set `autoPermissions`:
-
-```dart
-// Set once, e.g. at app start.
-DeviceCalendar.instance.autoPermissions = AutoPermissionMode.asNeeded;
-
-// No explicit requestPermissions() needed — this prompts on first use, then
-// throws DeviceCalendarException(permissionDenied) if access isn't granted.
-await plugin.createEvent(/* ... */);
-```
-
-- `AutoPermissionMode.asNeeded` — each method asks for the minimum it needs:
-  add-only operations (`createEvent`, `showCreateEventModal`) request write-only,
-  everything else requests full. Defers the heavier full prompt until a read
-  actually happens.
-- `AutoPermissionMode.full` — request full access on the first operation that
-  needs it. Simplest for apps that read regularly.
-- `null` (the default) — manual: nothing prompts on its own.
-
-Auto-permissions only act on a fresh (`notDetermined`) status — a tier you
-already hold is never silently escalated. If you hold write-only and call a read
-operation, you get `permissionDenied`, not a surprise prompt; call
-`requestPermissions(level: CalendarAccessLevel.full)` yourself when you want to
-ask for the upgrade (and to place any priming UI before it). Auto-mode prompts
-at most once per access level per app run — if the user declines, later calls
-throw `permissionDenied` rather than re-prompting; call `requestPermissions()`
-yourself to ask again.
-
-### Check Permissions
-
-Use `hasPermissions()` to check the current permission status without prompting the user:
-
-```dart
-final plugin = DeviceCalendar.instance;
-
-// Check current permission status (doesn't prompt)
-final status = await plugin.hasPermissions();
-
-if (status == CalendarPermissionStatus.granted) {
-  // Permissions already granted
-  final calendars = await plugin.listCalendars();
-} else if (status == CalendarPermissionStatus.notDetermined) {
-  // User hasn't been asked yet - now we can prompt
-  final newStatus = await plugin.requestPermissions();
-} else {
-  // Denied or restricted - show appropriate UI
-  print('Permissions: $status');
-}
-```
-
-### List Calendars
-
-```dart
-final plugin = DeviceCalendar.instance;
-
-// List all calendars
-final calendars = await plugin.listCalendars();
-for (final calendar in calendars) {
-  print('${calendar.name} (${calendar.readOnly ? "read-only" : "writable"})');
-  if (calendar.isPrimary) {
-    print('  ⭐ Primary calendar');
-  }
-  // Raw hex string (e.g. "#FF5733")
-  if (calendar.colorHex != null) {
-    print('  Color: ${calendar.colorHex}');
-  }
-  // Or use the parsed Flutter Color directly for theming
-  if (calendar.color != null) {
-    // e.g. Container(color: calendar.color, ...)
-  }
-}
-
-// Find a writable calendar
-final writableCalendar = calendars.firstWhere(
-  (cal) => !cal.readOnly,
-  orElse: () => calendars.first,
-);
-```
-
-### List Sources
-
-Sources are the accounts that own calendars (iCloud, Google, local, Exchange, etc.). Use them to discover where a new calendar can live, and to target a specific account when calling `createCalendar`.
-
-```dart
-final plugin = DeviceCalendar.instance;
-final sources = await plugin.listSources();
-
-for (final source in sources) {
-  print('${source.accountName} — ${source.type}');
-  if (source.supportsCalendarCreation) {
-    print('  ✓ can create calendars here');
-  }
-}
-
-// Pick the first source that supports creation
-final writable = sources.firstWhere((s) => s.supportsCalendarCreation);
-
-// iOS: pass the source id via CreateCalendarOptionsIos
-await plugin.createCalendar(
-  name: 'Work',
-  platformOptions: CreateCalendarOptionsIos(sourceId: writable.id),
-);
-
-// Android: pass accountName + accountType via CreateCalendarOptionsAndroid
-await plugin.createCalendar(
-  name: 'Work',
-  platformOptions: CreateCalendarOptionsAndroid(
-    accountName: writable.accountName,
-    accountType: writable.accountType,
-  ),
-);
-```
-
-> **Note on Android**: Only sources that already have at least one calendar are returned. Freshly-added accounts won't appear until their first calendar exists.
-
-### Create Calendar
-
-```dart
-final plugin = DeviceCalendar.instance;
-
-// Simplest case — picks a sensible default source on each platform
-final calendarId = await plugin.createCalendar(name: 'My Calendar');
-
-// With a color
-final colored = await plugin.createCalendar(
-  name: 'Work',
-  colorHex: '#FF5733',
-);
-
-// Target a specific account (see "List Sources" above for full example)
-final scoped = await plugin.createCalendar(
-  name: 'Project Calendar',
-  platformOptions: CreateCalendarOptionsAndroid(accountName: 'MyApp'),
-);
-```
-
-Returns the new calendar's ID. Requires write permission.
-
-### Update Calendar
-
-```dart
-final plugin = DeviceCalendar.instance;
-
-// Rename
-await plugin.updateCalendar(calendarId, name: 'New Name');
-
-// Recolor
-await plugin.updateCalendar(calendarId, colorHex: '#3366FF');
-
-// Both at once
-await plugin.updateCalendar(
-  calendarId,
-  name: 'Q3 Planning',
-  colorHex: '#3366FF',
-);
-```
-
-At least one of `name` or `colorHex` must be provided.
-
-### Delete Calendar
-
-```dart
-final plugin = DeviceCalendar.instance;
-
-await plugin.deleteCalendar(calendarId);
-```
-
-Throws `DeviceCalendarException` with `DeviceCalendarError.readOnly` if the calendar can't be deleted (e.g. a system-managed account calendar).
-
-### Retrieve Events
-
-```dart
-final plugin = DeviceCalendar.instance;
-
-// Get events for the next 30 days
-final now = DateTime.now();
-final startDate = now;
-final endDate = now.add(const Duration(days: 30));
-
-// Get events from all calendars
-final allEvents = await plugin.listEvents(
-  startDate,
-  endDate,
-);
-print('Found ${allEvents.length} events');
-
-// Get events from specific calendars only
-final calendarIds = ['calendar-id-1', 'calendar-id-2'];
-final filteredEvents = await plugin.listEvents(
-  startDate,
-  endDate,
-  calendarIds: calendarIds,
-);
-
-```
-
-### Get Single Event
-
-```dart
-final plugin = DeviceCalendar.instance;
-
-// Get a specific event by instanceId
-final event = await plugin.getEvent(event.instanceId);
-if (event != null) {
-  print('Event: ${event.title}');
-}
-
-// For recurring events, get a specific occurrence
-final instance = await plugin.getEvent(event.instanceId);
-
-// For recurring events, get the master event definition
-final masterEvent = await plugin.getEvent(event.eventId);
-```
-
-### Show Event in Modal
-
-```dart
-final plugin = DeviceCalendar.instance;
-
-// Show a specific event in a modal dialog
-await plugin.showEventModal(event.instanceId);
-
-// For recurring events, show a specific occurrence
-await plugin.showEventModal(event.instanceId);
-
-// For recurring events, show the master event
-await plugin.showEventModal(event.eventId);
-
-// Open the native editor directly (skip the read-only viewer)
-await plugin.showEventModal(event.instanceId, edit: true);
-```
-
-> **Android `edit: true` caveat:** `ACTION_EDIT` is honored inconsistently
-> across calendar apps. Google Calendar ignores it for an existing event and
-> opens a blank new-event editor, while the AOSP/stock calendar opens the
-> editor as expected. There's no intent that reliably launches Google Calendar
-> straight into edit mode on an existing event, so for a dependable edit flow
-> use `showEventModal(id)` (view) and let the user tap the edit button. iOS is
-> unaffected.
-
-### Create Event via Native Editor
-
-Opens the platform's native calendar editor in create mode. Useful when you want
-the user to review/edit before saving, or as the iOS workaround for adding
-attendees (which can't be done programmatically).
-
-```dart
-final plugin = DeviceCalendar.instance;
-
-// Open blank editor
-await plugin.showCreateEventModal();
-
-// Open with pre-filled data
-await plugin.showCreateEventModal(
-  title: 'Team Meeting',
-  startDate: DateTime.now().add(Duration(hours: 1)),
-  endDate: DateTime.now().add(Duration(hours: 2)),
-  location: 'Conference Room A',
-  description: 'Weekly sync',
-  recurrenceRule: WeeklyRecurrence(
-    daysOfWeek: [DayOfWeek.tuesday],
-  ),
-);
-```
-
-All parameters are optional. The Future completes when the modal is dismissed
-(whether the user saved or cancelled).
-
-**Platform APIs:** iOS uses `EKEventEditViewController`, Android uses
-`Intent.ACTION_INSERT`.
-
-### Create Event
-
-```dart
-final plugin = DeviceCalendar.instance;
-
-// Create a basic event
+// 2. Create an event (omit calendarId to use the default calendar).
 final eventId = await plugin.createEvent(
-  calendarId: 'your-calendar-id',
   title: 'Team Meeting',
-  startDate: DateTime(2024, 3, 20, 14, 0),
-  endDate: DateTime(2024, 3, 20, 15, 0),
+  startDate: DateTime.now().add(const Duration(hours: 1)),
+  endDate: DateTime.now().add(const Duration(hours: 2)),
 );
 
-// Create an all-day event
-final allDayEventId = await plugin.createEvent(
-  calendarId: 'your-calendar-id',
-  title: 'Conference',
-  startDate: DateTime(2024, 3, 20),
-  endDate: DateTime(2024, 3, 21),
-  isAllDay: true,
-);
-
-// Create event with all optional parameters
-final detailedEventId = await plugin.createEvent(
-  calendarId: 'your-calendar-id',
-  title: 'Project Kickoff',
-  startDate: DateTime(2024, 3, 20, 10, 0),
-  endDate: DateTime(2024, 3, 20, 12, 0),
-  description: 'Quarterly project kickoff meeting',
-  location: 'Conference Room A',
-  timeZone: 'America/New_York',
-  availability: EventAvailability.busy,
-);
+// 3. Read events back.
+final now = DateTime.now();
+final events = await plugin.listEvents(now, now.add(const Duration(days: 7)));
 ```
 
-### Recurring Events
+## Permissions
 
-Create recurring events by passing a `RecurrenceRule` to `createEvent`. The rule types are sealed classes, so the compiler ensures you handle all cases.
+Every read or write needs calendar permission. Ask for it yourself:
 
 ```dart
-// Every day for 30 days
-await plugin.createEvent(
-  calendarId: calendarId,
-  title: 'Daily Standup',
-  startDate: DateTime(2024, 3, 20, 9, 0),
-  endDate: DateTime(2024, 3, 20, 9, 15),
-  recurrenceRule: DailyRecurrence(end: CountEnd(30)),
-);
-
-// Every 2 weeks on Monday and Friday
-await plugin.createEvent(
-  calendarId: calendarId,
-  title: 'Sprint Review',
-  startDate: DateTime(2024, 3, 20, 14, 0),
-  endDate: DateTime(2024, 3, 20, 15, 0),
-  recurrenceRule: WeeklyRecurrence(
-    interval: 2,
-    daysOfWeek: [DayOfWeek.monday, DayOfWeek.friday],
-  ),
-);
+final status = await plugin.requestPermissions();
+if (status != CalendarPermissionStatus.granted) return;
 ```
 
-Monthly and yearly have sealed subtypes — the default constructor is by day of month, use `.byWeekday` for weekday patterns:
+Add-only apps can ask for the gentler write-only tier (`requestPermissions(level: CalendarAccessLevel.writeOnly)`). Or let methods prompt on first use by setting `autoPermissions` once at app start. Most apps read, so `.full` is the one you usually want:
 
 ```dart
-// Monthly on the 1st and 15th
-MonthlyRecurrence(daysOfMonth: [1, 15])
-
-// Monthly on the 2nd Tuesday
-MonthlyRecurrence.byWeekday(
-  daysOfWeek: [RecurrenceDay(DayOfWeek.tuesday, position: 2)],
-)
-
-// Monthly on the last Friday
-MonthlyRecurrence.byWeekday(
-  daysOfWeek: [RecurrenceDay(DayOfWeek.friday, position: -1)],
-)
-
-// Yearly on Christmas
-YearlyRecurrence(months: [12], daysOfMonth: [25])
-
-// Yearly on the 4th Thursday of November (Thanksgiving)
-YearlyRecurrence.byWeekday(
-  months: [11],
-  daysOfWeek: [RecurrenceDay(DayOfWeek.thursday, position: 4)],
-)
-
-// Last weekday of every month (uses BYSETPOS)
-MonthlyRecurrence.byWeekday(
-  daysOfWeek: [
-    RecurrenceDay(DayOfWeek.monday),
-    RecurrenceDay(DayOfWeek.tuesday),
-    RecurrenceDay(DayOfWeek.wednesday),
-    RecurrenceDay(DayOfWeek.thursday),
-    RecurrenceDay(DayOfWeek.friday),
-  ],
-  setPositions: [-1],
-)
+DeviceCalendar.instance.autoPermissions = AutoPermissionMode.full;
 ```
 
-End conditions are either a count or a date — or omit for forever:
+See [Permissions](doc/permissions.md) for write-only, the automatic modes, and upgrading tiers in-app.
+
+## Dates & timezones
+
+Every `DateTime` the plugin hands back is in **local time**, and there are two kinds (no `timezone` package required):
+
+- **Timed events are instants.** A meeting at "3 PM EST" is a specific moment, so convert `startDate`/`endDate` to UTC freely for storage or comparison. Setting `timeZone` reinterprets the wall-clock time ("3 PM EST" becomes "3 PM PST"), not the instant.
+- **All-day events are floating dates.** A birthday on January 15 stays January 15 in any timezone, so use the date components and don't convert to UTC.
+
+## Error handling
+
+Two kinds of errors:
+
+- **`DeviceCalendarException`** - runtime conditions to handle (permission denied, not found, read-only). It carries a `DeviceCalendarError` code to switch on.
+- **Standard Dart errors** (e.g. `ArgumentError`, `StateError`) - programmer mistakes caught before any platform call, like invalid arguments. Fix them, don't catch them. A call with nothing to change (e.g. `updateEvent` with no fields) is a harmless no-op, not an error.
 
 ```dart
-DailyRecurrence(end: CountEnd(10))           // after 10 occurrences
-DailyRecurrence(end: UntilEnd(DateTime.utc(2025, 12, 31)))  // until a date
-DailyRecurrence()                            // forever
-```
-
-When reading events back, `event.recurrenceRule` gives you the typed model. For RRULE properties the typed model doesn't cover, use the `rruleString` escape hatch — it preserves the original platform string:
-
-```dart
-final event = await plugin.getEvent(eventId);
-final rule = event?.recurrenceRule;
-
-// Typed access
-if (rule is MonthlyByWeekday) {
-  print(rule.daysOfWeek);
-  print(rule.setPositions);
+try {
+  await plugin.createEvent(/* ... */);
+} on DeviceCalendarException catch (e) {
+  if (e.errorCode == DeviceCalendarError.permissionDenied) {
+    // Ask the user to grant access.
+  }
 }
-
-// Raw RRULE string — preserves platform-specific properties
-// like BYHOUR or BYSETPOS combinations the typed model doesn't cover
-print(rule?.rruleString); // e.g. "FREQ=MONTHLY;BYDAY=2TU;COUNT=12"
 ```
 
-### Update Event
+## More docs
 
-`updateEvent` updates a single thing: pass a bare event ID (`event.eventId`) to update the event — the whole series when it's recurring — or an instance ID (`event.instanceId`) to detach and edit one occurrence of a recurring series.
+- [Permissions](doc/permissions.md) - request, check, write-only, automatic
+- [Calendars & sources](doc/calendars.md) - list, create, update, delete
+- [Events](doc/events.md) - create, list, get, update, delete
+- [Recurring events](doc/recurring-events.md) - rules, series edits, occurrences
+- [Reminders](doc/reminders.md) - relative before-start alarms
+- [Native UI](doc/native-ui.md) - view, edit, and create modals
 
-```dart
-final plugin = DeviceCalendar.instance;
+## Contributing
 
-// Update event title
-await plugin.updateEvent(
-  eventId: event.eventId,
-  title: 'Updated Meeting Title',
-);
+I'm keeping pull requests closed, and not to be precious about it. Holding the whole API and the iOS/Android parity in my own head is honestly the only way I keep it consistent. Bug reports and feature requests are very welcome though, so open an issue and let's chat. :)
 
-// Update multiple fields
-await plugin.updateEvent(
-  eventId: event.eventId,
-  title: 'Team Sync',
-  startDate: DateTime(2024, 3, 21, 15, 0),
-  endDate: DateTime(2024, 3, 21, 16, 0),
-  location: Patch.set('Conference Room B'),
-  description: Patch.set('Updated description'),
-  url: Patch.set('https://example.com/meeting/456'),
-);
+## License
 
-// Clear optional fields. description, location and url take a Patch:
-// omit the argument to leave a field unchanged, Patch.set(...) to change it,
-// Patch.clear() to remove its value.
-await plugin.updateEvent(
-  eventId: event.eventId,
-  location: Patch.clear(),
-  description: Patch.clear(),
-);
-
-// Change a timed event to all-day
-await plugin.updateEvent(
-  eventId: event.eventId,
-  isAllDay: true,
-);
-
-// Change an all-day event to timed
-await plugin.updateEvent(
-  eventId: event.eventId,
-  isAllDay: false,
-  startDate: DateTime(2024, 3, 21, 10, 0),
-  endDate: DateTime(2024, 3, 21, 11, 0),
-);
-
-// Update timezone (reinterprets local time)
-// Note: "3 PM EST" becomes "3 PM PST" (different instant in time)
-await plugin.updateEvent(
-  eventId: event.eventId,
-  timeZone: 'America/Los_Angeles',
-);
-
-// Edit only this one occurrence of a recurring event. The occurrence is
-// detached from the series as an exception; startDate and endDate are
-// absolute instants, so it can move to a different day.
-await plugin.updateEvent(
-  eventId: event.instanceId,
-  title: 'Moved this week only',
-  startDate: DateTime(2024, 3, 21, 15, 0),
-  endDate: DateTime(2024, 3, 21, 16, 0),
-);
-```
-
-### Update Recurring Events
-
-To edit a recurring **series** — its recurrence rule, its time-of-day or duration, or any field across many occurrences — use `updateRecurring`. It takes an `EventSpan`:
-
-- `EventSpan.allEvents` — the change applies to the whole series.
-- `EventSpan.thisAndFollowing` — the series is split: the occurrence you pass, and every later one, carry the change.
-
-```dart
-final plugin = DeviceCalendar.instance;
-
-// Change every occurrence to start at 3 PM, keeping each occurrence's date
-await plugin.updateRecurring(
-  event.instanceId,
-  EventSpan.allEvents,
-  startTime: EventTimeOfDay(hour: 15, minute: 0),
-);
-
-// Change the duration of all occurrences to 90 minutes
-await plugin.updateRecurring(
-  event.instanceId,
-  EventSpan.allEvents,
-  duration: Duration(minutes: 90),
-);
-
-// Change the whole series to weekly
-await plugin.updateRecurring(
-  event.instanceId,
-  EventSpan.allEvents,
-  recurrenceRule: Patch.set(WeeklyRecurrence(end: CountEnd(10))),
-);
-
-// Stop the series recurring — it becomes a single, non-recurring event
-await plugin.updateRecurring(
-  event.instanceId,
-  EventSpan.allEvents,
-  recurrenceRule: Patch.clear(),
-);
-
-// Split the series: this occurrence and every later one move to a new time.
-// Returns the new series' event ID.
-final newSeriesId = await plugin.updateRecurring(
-  event.instanceId,
-  EventSpan.thisAndFollowing,
-  startTime: EventTimeOfDay(hour: 15, minute: 0),
-  duration: Duration(hours: 1),
-);
-```
-
-`startTime` replaces the time-of-day of every occurrence in scope while preserving each occurrence's date; `duration` sets how long each occurrence lasts (whole minutes; whole days for all-day events). `recurrenceRule` takes a `Patch`: omit it to leave recurrence unchanged, `Patch.set(...)` to change the rule, `Patch.clear()` to remove it. All other fields behave as in `updateEvent`. `updateRecurring` returns the event ID for the affected scope — the same ID for `allEvents`, the new series' ID for `thisAndFollowing`.
-
-**Span and the split point.** For `thisAndFollowing`, pass an instance ID (`event.instanceId`) that carries an occurrence timestamp. It is the split point: that occurrence and every later one become a new series carrying the change; earlier occurrences are untouched.
-
-**Customised occurrences.** Editing a series is best-effort with respect to occurrences a user had individually moved or deleted. Customisations before a `thisAndFollowing` split point survive; customisations at or after the split point (or anywhere, for `allEvents`) may be reset.
-
-### Delete Event
-
-`deleteEvent` mirrors `updateEvent`: a bare event ID deletes the event — the whole series when it's recurring — and an instance ID removes one occurrence of a recurring series.
-
-```dart
-final plugin = DeviceCalendar.instance;
-
-// Delete an event (the whole series, if recurring)
-await plugin.deleteEvent(eventId: event.eventId);
-
-// Delete only this one occurrence, leaving the rest of the series alone
-await plugin.deleteEvent(eventId: event.instanceId);
-```
-
-### Delete Recurring Events
-
-To delete a recurring **series** outright or truncate it, use `deleteRecurring`. It takes the same `EventSpan` as `updateRecurring`:
-
-- `EventSpan.allEvents` — the whole series is deleted (the same as `deleteEvent` with a bare event ID).
-- `EventSpan.thisAndFollowing` — the occurrence you pass, and every later one, are removed; the series is truncated to end before it.
-
-```dart
-final plugin = DeviceCalendar.instance;
-
-// Delete the whole series
-await plugin.deleteRecurring(event.instanceId, EventSpan.allEvents);
-
-// Delete this occurrence and every later one
-await plugin.deleteRecurring(event.instanceId, EventSpan.thisAndFollowing);
-```
-
-For `thisAndFollowing`, pass an instance ID (`event.instanceId`) that carries an occurrence timestamp; a bare event ID throws `ArgumentError`. `allEvents` accepts either.
-
-## 📋 Roadmap
-
-- [x] **Permissions** — request, check, and open settings
-- [x] **Calendars** — create, read, update, delete
-- [x] **Events** — create, read, update, delete
-- [x] **All-day events** — proper floating date handling across timezones
-- [x] **Native UI** — show event modal on both platforms
-- [x] **Recurring events** — create and read with sealed RecurrenceRule model (daily, weekly, monthly, yearly)
-- [x] **Update recurrence rules** — change, add or remove a recurrence rule via `updateRecurring`
-- [x] **Delete recurring events** — delete a whole series, this-and-following, or a single occurrence via `deleteRecurring`
-- [x] **Attendees** — read-only on both platforms; use `showCreateEventModal` / `showEventModal(edit: true)` to add via native UI
-- [x] **Reminders / alarms** — relative-time reminders, read/write on both platforms
-- [ ] **Platform-specific extras** — organizer and other platform-native fields exposed where supported (event URL is now supported)
-
-## 🤝 Contributing
-
-This project is closed to outside pull requests. Bug reports and feature requests are welcome - please open an issue. The maintainer handles implementation to keep the API surface and platform-parity decisions consistent.
-
-## 🧪 Testing Status
-
-This plugin includes both **unit tests** and **integration tests** to ensure reliability.
-
-## 📄 License
-
-MIT © 2025 Bullet
-See [LICENSE](LICENSE) for details.
+MIT © 2025 Bullet. See [LICENSE](LICENSE).
 
 ---
 
-**Maintained by [Bullet](https://bullet.to)** — a cross-platform task + notes + calendar app built with Flutter.
+Made by [Bullet](https://bullet.to), a task + notes + calendar app built with Flutter.

--- a/packages/device_calendar_plus/doc/calendars.md
+++ b/packages/device_calendar_plus/doc/calendars.md
@@ -1,0 +1,72 @@
+# Calendars and sources
+
+## List calendars
+
+```dart
+final calendars = await plugin.listCalendars();
+for (final calendar in calendars) {
+  print('${calendar.name} (${calendar.readOnly ? "read-only" : "writable"})');
+  if (calendar.isPrimary) print('  ⭐ primary');
+  // colorHex is the raw "#RRGGBB"; color is a parsed Flutter Color.
+  if (calendar.color != null) { /* use for theming */ }
+}
+```
+
+## List sources
+
+Sources are the accounts that own calendars (iCloud, Google, local, Exchange…).
+Use them to pick where a new calendar lives.
+
+```dart
+final sources = await plugin.listSources();
+final writable = sources.firstWhere((s) => s.supportsCalendarCreation);
+```
+
+> On Android, only sources that already have at least one calendar are
+> returned. A freshly-added account won't appear until its first calendar
+> exists.
+
+## Create a calendar
+
+```dart
+// Picks a sensible default account.
+final id = await plugin.createCalendar(name: 'My Calendar');
+
+// With a color.
+final colored = await plugin.createCalendar(name: 'Work', colorHex: '#FF5733');
+
+// Targeting a specific account.
+final scopedIos = await plugin.createCalendar(
+  name: 'Work',
+  platformOptions: CreateCalendarOptionsIos(sourceId: writable.id),
+);
+final scopedAndroid = await plugin.createCalendar(
+  name: 'Work',
+  platformOptions: CreateCalendarOptionsAndroid(
+    accountName: writable.accountName,
+    accountType: writable.accountType,
+  ),
+);
+```
+
+Returns the new calendar's ID.
+
+## Update a calendar
+
+```dart
+await plugin.updateCalendar(calendarId, name: 'Q3 Planning', colorHex: '#3366FF');
+```
+
+Pass `name`, `colorHex`, or both. Passing neither is a no-op.
+
+## Delete a calendar
+
+```dart
+await plugin.deleteCalendar(calendarId);
+```
+
+Deletes the calendar and all of its events. Throws
+`DeviceCalendarException(readOnly)` for a calendar that can't be deleted (e.g. a
+system-managed account calendar).
+
+Creating, updating, and deleting calendars all require full access.

--- a/packages/device_calendar_plus/doc/events.md
+++ b/packages/device_calendar_plus/doc/events.md
@@ -1,0 +1,106 @@
+# Events
+
+## Create
+
+```dart
+final eventId = await plugin.createEvent(
+  calendarId: calendarId, // omit to use the device's default calendar
+  title: 'Team Meeting',
+  startDate: DateTime(2024, 3, 20, 14, 0),
+  endDate: DateTime(2024, 3, 20, 15, 0),
+);
+
+// All-day event.
+await plugin.createEvent(
+  calendarId: calendarId,
+  title: 'Conference',
+  startDate: DateTime(2024, 3, 20),
+  endDate: DateTime(2024, 3, 21),
+  isAllDay: true,
+);
+
+// With optional fields.
+await plugin.createEvent(
+  calendarId: calendarId,
+  title: 'Project Kickoff',
+  startDate: DateTime(2024, 3, 20, 10, 0),
+  endDate: DateTime(2024, 3, 20, 12, 0),
+  description: 'Quarterly kickoff',
+  location: 'Conference Room A',
+  url: 'https://example.com/meeting',
+  timeZone: 'America/New_York',
+  availability: EventAvailability.busy,
+  reminders: [Duration(minutes: 15)],
+);
+```
+
+Omitting `calendarId` writes to the device's default calendar. See
+[recurring-events.md](recurring-events.md) for `recurrenceRule` and
+[reminders.md](reminders.md) for `reminders`.
+
+## List
+
+```dart
+final now = DateTime.now();
+final events = await plugin.listEvents(
+  now,
+  now.add(const Duration(days: 30)),
+  calendarIds: ['cal-1', 'cal-2'], // optional; omit for all calendars
+);
+```
+
+The range is half-open `[start, end)` — an event starting exactly at `end` is
+excluded. Recurring events are expanded into one `Event` per occurrence; see
+[recurring-events.md](recurring-events.md) for how occurrences are identified.
+
+## Get one
+
+```dart
+final event = await plugin.getEvent(id); // null if not found
+```
+
+`id` may be an event ID (the master, for a recurring series) or an instance ID
+(a specific occurrence). See [recurring-events.md](recurring-events.md).
+
+## Update
+
+Pass an event ID to update the event (the whole series when recurring), or an
+instance ID to detach and edit one occurrence.
+
+```dart
+await plugin.updateEvent(eventId: event.eventId, title: 'New title');
+
+// description, location, and url take a Patch:
+// omit = leave unchanged, Patch.set(v) = change, Patch.clear() = remove.
+await plugin.updateEvent(
+  eventId: event.eventId,
+  location: Patch.set('Room B'),
+  description: Patch.clear(),
+);
+
+// Switch between timed and all-day.
+await plugin.updateEvent(eventId: event.eventId, isAllDay: true);
+
+// Edit only this occurrence of a recurring event (it detaches as an exception).
+await plugin.updateEvent(
+  eventId: event.instanceId,
+  startDate: DateTime(2024, 3, 21, 15, 0),
+  endDate: DateTime(2024, 3, 21, 16, 0),
+);
+```
+
+Passing no fields is a no-op. To edit a recurring **series**, use
+`updateRecurring` ([recurring-events.md](recurring-events.md)).
+
+## Delete
+
+```dart
+// The event (the whole series, if recurring).
+await plugin.deleteEvent(eventId: event.eventId);
+
+// Only this occurrence.
+await plugin.deleteEvent(eventId: event.instanceId);
+```
+
+Reading, updating, and deleting require full access; creating works with
+write-only.

--- a/packages/device_calendar_plus/doc/native-ui.md
+++ b/packages/device_calendar_plus/doc/native-ui.md
@@ -1,0 +1,45 @@
+# Native UI
+
+The plugin can hand off to the OS's own calendar screens for viewing, editing,
+and creating events. Each call completes when the modal is dismissed and does
+not report back what the user changed — edits are saved directly by the OS.
+
+## View or edit an existing event
+
+```dart
+// Open the view screen (the user can still tap Edit from here).
+await plugin.showEventModal(event.instanceId);
+
+// Open directly in the editor.
+await plugin.showEventModal(event.instanceId, edit: true);
+```
+
+`edit` only controls whether the modal *starts* in the editor — the view screen
+is not read-only, it always offers an edit affordance.
+
+> **Android `edit: true` caveat:** some calendar apps honor it inconsistently —
+> notably, Google Calendar ignores it for an existing event and opens a blank
+> new-event editor instead, while the stock calendar lands in the editor as
+> expected. For a dependable edit flow, use the view modal (`edit: false`) and
+> let the user tap Edit. iOS is unaffected.
+
+## Create an event in the native editor
+
+Useful when you want the user to review before saving, or to add attendees
+(which can't be done programmatically).
+
+```dart
+// Blank editor.
+await plugin.showCreateEventModal();
+
+// Pre-filled.
+await plugin.showCreateEventModal(
+  title: 'Team Meeting',
+  startDate: DateTime.now().add(const Duration(hours: 1)),
+  endDate: DateTime.now().add(const Duration(hours: 2)),
+  location: 'Conference Room A',
+);
+```
+
+All fields are optional. `showCreateEventModal` works with write-only access;
+`showEventModal` requires full access.

--- a/packages/device_calendar_plus/doc/permissions.md
+++ b/packages/device_calendar_plus/doc/permissions.md
@@ -1,0 +1,77 @@
+# Permissions
+
+All read/write operations require calendar permission. You can request it
+yourself, or let the plugin request it on first use.
+
+## Request and check
+
+```dart
+final plugin = DeviceCalendar.instance;
+
+// Check the current status without prompting.
+final current = await plugin.hasPermissions();
+
+// Prompt the user (shows the system dialog the first time).
+final status = await plugin.requestPermissions();
+if (status != CalendarPermissionStatus.granted) return;
+```
+
+`CalendarPermissionStatus` is one of `granted`, `writeOnly`, `denied`,
+`restricted`, or `notDetermined`.
+
+When permission is denied, send the user to settings to enable it manually:
+
+```dart
+await plugin.openAppSettings();
+```
+
+## Write-only access
+
+Apps that only add events (and never read existing ones) can request a gentler
+add-only prompt:
+
+```dart
+final status = await plugin.requestPermissions(
+  level: CalendarAccessLevel.writeOnly,
+);
+if (status == CalendarPermissionStatus.writeOnly ||
+    status == CalendarPermissionStatus.granted) {
+  // Can create events.
+}
+```
+
+Write-only covers `createEvent` and `showCreateEventModal`. Everything else —
+reading, updating, deleting, listing calendars — needs full access. Write-only
+is not a ceiling: call `requestPermissions(level: CalendarAccessLevel.full)`
+later to upgrade in-app.
+
+> **iOS setup:** add `NSCalendarsWriteOnlyAccessUsageDescription` to your
+> `Info.plist` (see the README install section). On iOS 16 and below there is no
+> write-only tier, so the request falls back to full access and a grant reports
+> `granted`.
+
+## Automatic permissions
+
+To have methods request permission on first use instead of doing it yourself,
+set `autoPermissions` once at app start:
+
+```dart
+DeviceCalendar.instance.autoPermissions = AutoPermissionMode.full;
+
+// Prompts on first use, then throws DeviceCalendarException(permissionDenied)
+// if access isn't granted.
+await plugin.createEvent(/* ... */);
+```
+
+- `AutoPermissionMode.full` — request full access on the first operation that
+  needs it. Most apps read, so this is the usual choice.
+- `AutoPermissionMode.asNeeded` — each method asks for the minimum it needs:
+  add-only operations request write-only, everything else requests full. Use
+  this for add-only apps that want to defer the full prompt.
+- `null` (the default) — manual; nothing prompts on its own.
+
+Auto-mode only prompts on a fresh (`notDetermined`) status, at most once per
+access level per app run, and never silently escalates a tier you already hold.
+If you hold write-only and call a read operation you get `permissionDenied` —
+call `requestPermissions(level: CalendarAccessLevel.full)` yourself to ask for
+the upgrade (and to place any priming UI before it).

--- a/packages/device_calendar_plus/doc/recurring-events.md
+++ b/packages/device_calendar_plus/doc/recurring-events.md
@@ -1,0 +1,145 @@
+# Recurring events
+
+## Creating a recurring event
+
+Pass a `RecurrenceRule` to `createEvent`. The rule types are sealed classes, so
+the compiler ensures you handle every case.
+
+```dart
+// Daily for 30 occurrences.
+DailyRecurrence(end: CountEnd(30))
+
+// Every 2 weeks on Monday and Friday.
+WeeklyRecurrence(
+  interval: 2,
+  daysOfWeek: [DayOfWeek.monday, DayOfWeek.friday],
+)
+```
+
+Monthly and yearly default to day-of-month; use `.byWeekday` for weekday
+patterns:
+
+```dart
+MonthlyRecurrence(daysOfMonth: [1, 15])                // 1st and 15th
+MonthlyRecurrence.byWeekday(                            // 2nd Tuesday
+  daysOfWeek: [RecurrenceDay(DayOfWeek.tuesday, position: 2)],
+)
+MonthlyRecurrence.byWeekday(                            // last Friday
+  daysOfWeek: [RecurrenceDay(DayOfWeek.friday, position: -1)],
+)
+YearlyRecurrence(months: [12], daysOfMonth: [25])      // Christmas
+```
+
+End conditions are a count, a date, or omitted (forever):
+
+```dart
+DailyRecurrence(end: CountEnd(10))
+DailyRecurrence(end: UntilEnd(DateTime.utc(2025, 12, 31)))
+DailyRecurrence()
+```
+
+## Reading a rule back
+
+`event.recurrenceRule` gives the typed model. For RRULE features the typed model
+doesn't cover, `rruleString` preserves the original platform string:
+
+```dart
+final rule = event?.recurrenceRule;
+if (rule is MonthlyByWeekday) {
+  print(rule.daysOfWeek);
+}
+print(rule?.rruleString); // e.g. "FREQ=MONTHLY;BYDAY=2TU;COUNT=12"
+```
+
+## Occurrences and IDs
+
+`listEvents` expands a series into one `Event` per occurrence. Each shares the
+same `eventId` but has a distinct `instanceId` (format `eventId@timestamp`) that
+pins the occurrence. Pass `instanceId` to act on a single occurrence; pass the
+bare `eventId` to act on the whole series. The instance ID is unstable — it
+changes if the occurrence moves — so re-fetch after edits.
+
+## Editing a series
+
+`updateRecurring` edits a series — its rule, its time-of-day or duration, or any
+field across occurrences. It takes an `EventSpan`:
+
+- `EventSpan.allEvents` — the whole series follows the change.
+- `EventSpan.thisAndFollowing` — split the series: the occurrence you pass and
+  every later one carry the change; earlier ones are untouched. Requires an
+  instance ID with a timestamp.
+
+```dart
+// Move a nightshift series from 11 PM to 1 AM the next day (day + time move
+// together, measured in the event's timezone, so DST-safe).
+await plugin.updateRecurring(
+  event.instanceId,
+  EventSpan.allEvents,
+  start: DateTime(2024, 3, 19, 1, 0),
+);
+
+// Change every occurrence to 90 minutes.
+await plugin.updateRecurring(
+  event.instanceId,
+  EventSpan.allEvents,
+  duration: Duration(minutes: 90),
+);
+
+// Change the rule, or stop recurring entirely.
+await plugin.updateRecurring(
+  event.instanceId,
+  EventSpan.allEvents,
+  recurrenceRule: Patch.set(WeeklyRecurrence(end: CountEnd(10))),
+);
+await plugin.updateRecurring(
+  event.instanceId,
+  EventSpan.allEvents,
+  recurrenceRule: Patch.clear(), // becomes a single non-recurring event
+);
+
+// Split: this occurrence and later ones move; returns the new series' ID.
+final newSeriesId = await plugin.updateRecurring(
+  event.instanceId,
+  EventSpan.thisAndFollowing,
+  start: DateTime(2024, 3, 18, 15, 0),
+  duration: Duration(hours: 1),
+);
+```
+
+`updateRecurring` returns the affected scope's event ID — the same ID for
+`allEvents`, the new series' ID for `thisAndFollowing`.
+
+### Moving the day of a pinned rule
+
+`start` moves the series anchor. For rules whose day is implied by the start
+(`DailyRecurrence()`, `WeeklyRecurrence()`, `MonthlyRecurrence()`), the pattern
+just follows the anchor.
+
+For rules that pin a day explicitly (`WeeklyRecurrence(daysOfWeek: …)`,
+`MonthlyRecurrence(daysOfMonth: …)`, positional rules like "2nd Tuesday"),
+moving the day with `start` alone throws
+`DeviceCalendarException(invalidArguments)` — because moving one day of a
+multi-day rule is ambiguous (Mon of Mon/Wed/Fri → Tue could mean Tue/Wed/Fri or
+Tue/Thu/Sat). Pass the new `recurrenceRule` in the same call to say what the
+pattern should become. Time-only, duration-only, and whole-week shifts never
+throw. Watch the converse: a cross-midnight retime (11 PM → 1 AM) rolls the date
+forward, so it changes the weekday and will throw too.
+
+### Customised occurrences
+
+Editing a series is best-effort with respect to occurrences the user had
+individually moved or deleted. Customisations before a `thisAndFollowing` split
+point survive; customisations at or after the split point (or anywhere, for
+`allEvents`) may be reset.
+
+## Deleting a series
+
+`deleteRecurring` takes the same `EventSpan`:
+
+```dart
+await plugin.deleteRecurring(event.instanceId, EventSpan.allEvents);
+await plugin.deleteRecurring(event.instanceId, EventSpan.thisAndFollowing);
+```
+
+`thisAndFollowing` requires an instance ID with a timestamp; `allEvents` accepts
+either. All series edits require full access.

--- a/packages/device_calendar_plus/doc/reminders.md
+++ b/packages/device_calendar_plus/doc/reminders.md
@@ -1,0 +1,38 @@
+# Reminders
+
+Reminders are relative alarms that fire a fixed lead time **before** an event
+starts. Each is a `Duration` of lead time.
+
+```dart
+// 15 minutes and 1 hour before start.
+await plugin.createEvent(
+  calendarId: calendarId,
+  title: 'Standup',
+  startDate: start,
+  endDate: end,
+  reminders: [Duration(minutes: 15), Duration(hours: 1)],
+);
+```
+
+Reminders are minute-granular: a sub-minute `Duration` rounds to the nearest
+minute. A zero `Duration` (at start) is allowed; a negative one throws
+`ArgumentError`. Omitting `reminders` creates the event with none.
+
+Read them back from `event.reminders`.
+
+## Updating reminders
+
+`updateEvent` takes a `Patch<List<Duration>>` — `Patch.set` replaces the whole
+set, `Patch.clear` removes all reminders:
+
+```dart
+await plugin.updateEvent(
+  eventId: event.eventId,
+  reminders: Patch.set([Duration(minutes: 30)]),
+);
+
+await plugin.updateEvent(
+  eventId: event.eventId,
+  reminders: Patch.clear(),
+);
+```

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -79,52 +79,18 @@ class DeviceCalendar {
   /// [autoPermissions] is set.
   final Set<CalendarAccessLevel> _autoRequestedTiers = {};
 
-  /// Requests calendar permissions from the user.
+  /// Requests calendar permission, showing the system dialog on first use.
   ///
-  /// On first call, this will show the system permission dialog.
-  /// On subsequent calls, it returns the current permission status.
+  /// [level] chooses how much to ask for: [CalendarAccessLevel.full] (the
+  /// default, read and write) or [CalendarAccessLevel.writeOnly] (the gentler
+  /// add-only tier, for apps that only create events — a grant returns
+  /// [CalendarPermissionStatus.writeOnly]).
   ///
-  /// [level] chooses how much access to ask for:
-  /// - [CalendarAccessLevel.full] (the default) — full read and write access.
-  /// - [CalendarAccessLevel.writeOnly] — the gentler add-only prompt, for apps
-  ///   that only create events and never read existing calendar data. A
-  ///   granted write-only request returns [CalendarPermissionStatus.writeOnly].
-  ///   On iOS 16 and below write-only does not exist, so this falls back to a
-  ///   full-access request and a grant returns
-  ///   [CalendarPermissionStatus.granted].
+  /// Requesting a tier you already hold returns immediately without prompting.
+  /// Requesting [CalendarAccessLevel.full] while holding only write-only
+  /// upgrades the app in-app.
   ///
-  /// If you already hold a tier that satisfies the request, this returns
-  /// immediately without prompting (full access satisfies a write-only ask).
-  /// Requesting [CalendarAccessLevel.full] while only write-only is held
-  /// upgrades the app on both platforms — only the prompt differs:
-  /// - **Android**: `READ_CALENDAR` and `WRITE_CALENDAR` belong to the same
-  ///   `CALENDAR` permission group, so once write-only has granted
-  ///   `WRITE_CALENDAR` the OS grants the read upgrade **immediately, with no
-  ///   dialog**, and this returns [CalendarPermissionStatus.granted].
-  /// - **iOS**: re-presents the system dialog, this time asking for full
-  ///   access. If the user agrees this returns [CalendarPermissionStatus.granted];
-  ///   if they decline it returns the still-held
-  ///   [CalendarPermissionStatus.writeOnly].
-  ///
-  /// Returns a [CalendarPermissionStatus] indicating the result
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  /// final status = await plugin.requestPermissions();
-  /// if (status == CalendarPermissionStatus.granted) {
-  ///   // Access calendars
-  /// } else if (status == CalendarPermissionStatus.denied) {
-  ///   // Show "Enable in Settings" message
-  /// } else if (status == CalendarPermissionStatus.restricted) {
-  ///   // Show "Contact administrator" message
-  /// }
-  ///
-  /// // Add-only app: ask for the gentler write-only prompt.
-  /// final writeStatus = await plugin.requestPermissions(
-  ///   level: CalendarAccessLevel.writeOnly,
-  /// );
-  /// ```
+  /// See [doc/permissions.md](https://github.com/bullet-to/device_calendar_plus/blob/main/packages/device_calendar_plus/doc/permissions.md).
   Future<CalendarPermissionStatus> requestPermissions({
     CalendarAccessLevel level = CalendarAccessLevel.full,
   }) async {
@@ -135,67 +101,18 @@ class DeviceCalendar {
     );
   }
 
-  /// Checks the current calendar permission status WITHOUT requesting permissions.
+  /// Returns the current [CalendarPermissionStatus] without prompting.
   ///
-  /// Unlike [requestPermissions], this method will NOT prompt the user for
-  /// permissions if they haven't been granted yet. It only checks the current status.
-  ///
-  /// Use this method if you want to check permissions before deciding whether
-  /// to call [requestPermissions], or when you want to verify permissions without
-  /// triggering the system permission dialog.
-  ///
-  /// Returns the current [CalendarPermissionStatus].
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  /// final status = await plugin.hasPermissions();
-  /// if (status == CalendarPermissionStatus.granted) {
-  ///   // Permissions already granted
-  ///   final calendars = await plugin.listCalendars();
-  /// } else if (status == CalendarPermissionStatus.notDetermined) {
-  ///   // User hasn't been asked yet
-  ///   final newStatus = await plugin.requestPermissions();
-  /// }
-  /// ```
+  /// Unlike [requestPermissions], this never shows the system dialog — use it to
+  /// decide whether to prompt.
   Future<CalendarPermissionStatus> hasPermissions() async {
     return _handlePermissionRequest(
       () => DeviceCalendarPlusPlatform.instance.hasPermissions(),
     );
   }
 
-  /// Opens the app's settings page in the system settings.
-  ///
-  /// This is useful when permissions have been denied and you want to guide
-  /// the user to manually enable calendar permissions in the system settings.
-  ///
-  /// On iOS, this opens the app's specific settings page directly.
-  /// On Android, this opens the app info page where users can navigate to permissions.
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  /// final status = await plugin.hasPermissions();
-  /// if (status == CalendarPermissionStatus.denied) {
-  ///   // Show dialog explaining why permission is needed
-  ///   showDialog(
-  ///     context: context,
-  ///     builder: (context) => AlertDialog(
-  ///       title: Text('Calendar Permission Required'),
-  ///       content: Text('Please enable calendar access in settings.'),
-  ///       actions: [
-  ///         TextButton(
-  ///           onPressed: () {
-  ///             Navigator.pop(context);
-  ///             plugin.openAppSettings();
-  ///           },
-  ///           child: Text('Open Settings'),
-  ///         ),
-  ///       ],
-  ///     ),
-  ///   );
-  /// }
-  /// ```
+  /// Opens the app's settings page, so the user can enable calendar access
+  /// after a denial.
   Future<void> openAppSettings() async {
     try {
       await DeviceCalendarPlusPlatform.instance.openAppSettings();
@@ -296,23 +213,7 @@ class DeviceCalendar {
     }
   }
 
-  /// Lists all calendars available on the device.
-  ///
-  /// Returns a list of [Calendar] objects representing each calendar.
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  /// final calendars = await plugin.listCalendars();
-  /// for (final calendar in calendars) {
-  ///   print('${calendar.name} (${calendar.id})');
-  ///   print('  Read-only: ${calendar.readOnly}');
-  ///   print('  Primary: ${calendar.isPrimary}');
-  ///   print('  Color: ${calendar.colorHex}');
-  /// }
-  /// ```
-  ///
-  /// Requires full calendar access ([CalendarAccessLevel.full]).
+  /// Lists all calendars on the device. Requires full access.
   Future<List<Calendar>> listCalendars() async {
     await _ensurePermission(CalendarAccessLevel.full);
     try {
@@ -329,27 +230,12 @@ class DeviceCalendar {
     }
   }
 
-  /// Lists available calendar sources/accounts on the device.
+  /// Lists the accounts (iCloud, Google, local…) that calendars can be created
+  /// under. Pass a source to [createCalendar] via [CreateCalendarOptionsIos] or
+  /// [CreateCalendarOptionsAndroid] to target a specific account.
   ///
-  /// Returns the sources that calendars can be created under. Use a source's
-  /// [CalendarSource.id] with [CreateCalendarOptionsIos], or
-  /// [CalendarSource.accountName] + [CalendarSource.accountType] with
-  /// [CreateCalendarOptionsAndroid] to create calendars under a specific account.
-  ///
-  /// **Note:** On Android, only sources that already have calendars are returned.
-  /// A freshly-added account with no calendars will not appear until its first
-  /// calendar is created.
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  /// final sources = await plugin.listSources();
-  /// for (final source in sources) {
-  ///   print('${source.accountName} (${source.type})');
-  /// }
-  /// ```
-  ///
-  /// Requires full calendar access ([CalendarAccessLevel.full]).
+  /// On Android, only sources that already have a calendar are returned.
+  /// Requires full access.
   Future<List<CalendarSource>> listSources() async {
     await _ensurePermission(CalendarAccessLevel.full);
     try {
@@ -366,37 +252,11 @@ class DeviceCalendar {
     }
   }
 
-  /// Creates a new calendar on the device.
+  /// Creates a calendar and returns its ID.
   ///
-  /// [name] is the display name for the calendar (required).
-  /// [colorHex] is an optional color in #RRGGBB format (e.g., "#FF5733").
-  /// [platformOptions] is an optional platform-specific options object.
-  ///
-  /// Returns the ID of the newly created calendar.
-  ///
-  /// The calendar is created in the device's local storage by default.
-  /// Requires full calendar access ([CalendarAccessLevel.full]) — unlike
-  /// [createEvent], write-only access does not extend to creating calendars.
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  ///
-  /// // Create a calendar with just a name
-  /// final calendarId = await plugin.createCalendar(name: 'My Calendar');
-  ///
-  /// // Create a calendar with a name and color
-  /// final coloredCalendarId = await plugin.createCalendar(
-  ///   name: 'Work Calendar',
-  ///   colorHex: '#FF5733',
-  /// );
-  ///
-  /// // Android: Create a calendar with a custom account name
-  /// final androidCalendarId = await plugin.createCalendar(
-  ///   name: 'My App Calendar',
-  ///   platformOptions: CreateCalendarOptionsAndroid(accountName: 'MyApp'),
-  /// );
-  /// ```
+  /// [colorHex] is an optional `#RRGGBB` color. [platformOptions] targets a
+  /// specific account (see [listSources]); without it a sensible default
+  /// account is chosen. Requires full access.
   Future<String> createCalendar({
     required String name,
     String? colorHex,
@@ -425,33 +285,9 @@ class DeviceCalendar {
     }
   }
 
-  /// Updates an existing calendar on the device.
+  /// Updates a calendar's [name] and/or [colorHex] (`#RRGGBB`).
   ///
-  /// [calendarId] is the ID of the calendar to update.
-  /// [name] is the new display name for the calendar (optional).
-  /// [colorHex] is the new color in #RRGGBB format (optional, e.g., "#FF5733").
-  ///
-  /// Passing neither [name] nor [colorHex] is a no-op (nothing to change).
-  /// Requires full calendar access ([CalendarAccessLevel.full]) — write-only is
-  /// add-only (new events), not editing calendars.
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  ///
-  /// // Update just the name
-  /// await plugin.updateCalendar(calendarId, name: 'New Name');
-  ///
-  /// // Update just the color
-  /// await plugin.updateCalendar(calendarId, colorHex: '#FF5733');
-  ///
-  /// // Update both name and color
-  /// await plugin.updateCalendar(
-  ///   calendarId,
-  ///   name: 'New Name',
-  ///   colorHex: '#FF5733',
-  /// );
-  /// ```
+  /// Passing neither is a no-op. Requires full access.
   Future<void> updateCalendar(
     String calendarId, {
     String? name,
@@ -496,21 +332,10 @@ class DeviceCalendar {
     }
   }
 
-  /// Deletes a calendar from the device.
+  /// Deletes a calendar and all of its events. Requires full access.
   ///
-  /// [calendarId] is the ID of the calendar to delete.
-  ///
-  /// This will also delete all events within the calendar.
-  /// Requires full calendar access ([CalendarAccessLevel.full]) — write-only is
-  /// add-only (new events), not deleting calendars.
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  ///
-  /// // Delete a calendar by ID
-  /// await plugin.deleteCalendar(calendarId);
-  /// ```
+  /// Throws [DeviceCalendarException] ([DeviceCalendarError.readOnly]) for a
+  /// calendar that can't be deleted (e.g. a system-managed account calendar).
   Future<void> deleteCalendar(String calendarId) async {
     await _ensurePermission(CalendarAccessLevel.full);
     try {
@@ -525,59 +350,15 @@ class DeviceCalendar {
     }
   }
 
-  /// Lists events within the specified date range.
+  /// Lists events overlapping the half-open range `[startDate, endDate)`, sorted
+  /// by start date. An event starting exactly at [endDate] is excluded. Ranges
+  /// longer than 4 years are supported.
   ///
-  /// [startDate] and [endDate] define a half-open interval `[start, end)` —
-  /// events that overlap this range are returned, but an event starting
-  /// exactly at [endDate] is excluded.
+  /// [calendarIds] filters to specific calendars; null or empty means all.
   ///
-  /// Ranges longer than 4 years are supported. iOS's underlying query caps a
-  /// single span at ~4 years, so wide ranges are transparently split into
-  /// smaller windows and merged — every event in the range is returned once.
-  ///
-  /// [calendarIds] is an optional parameter to filter events to specific
-  /// calendars. If null or empty, events from all calendars are returned.
-  ///
-  /// Recurring events are automatically expanded into individual instances
-  /// within the date range — you get one [Event] per occurrence, not a single
-  /// master. Each instance has:
-  /// - The same [Event.eventId] (shared by the whole series)
-  /// - Different [Event.startDate] and [Event.endDate]
-  /// - A distinct [Event.instanceId] (format `eventId@timestamp`) that pins
-  ///   the occurrence
-  ///
-  /// Pass that [Event.instanceId] to [getEvent], [updateEvent], [deleteEvent],
-  /// or [showEventModal] to act on a single occurrence. (For non-recurring
-  /// events `instanceId == eventId`.) The id is plugin-derived and unstable —
-  /// it changes if the occurrence's start date moves, so re-fetch after edits.
-  ///
-  /// Returns a list of [Event] objects sorted by start date.
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  /// final now = DateTime.now();
-  /// final nextMonth = now.add(Duration(days: 30));
-  ///
-  /// // Get all events in the next month
-  /// final events = await plugin.listEvents(
-  ///   now,
-  ///   nextMonth,
-  /// );
-  ///
-  /// // Get events from specific calendars only
-  /// final workEvents = await plugin.listEvents(
-  ///   now,
-  ///   nextMonth,
-  ///   calendarIds: ['work-calendar-id', 'project-calendar-id'],
-  /// );
-  ///
-  /// for (final event in events) {
-  ///   print('${event.title} at ${event.startDate}');
-  /// }
-  /// ```
-  ///
-  /// Requires full calendar access ([CalendarAccessLevel.full]).
+  /// Recurring events are expanded into one [Event] per occurrence — each shares
+  /// the series' [Event.eventId] but carries a distinct [Event.instanceId] (see
+  /// [getEvent]). Requires full access.
   Future<List<Event>> listEvents(
     DateTime startDate,
     DateTime endDate, {
@@ -602,26 +383,12 @@ class DeviceCalendar {
     }
   }
 
-  /// Retrieves a single event by ID.
+  /// Retrieves a single event by [id], or null if not found.
   ///
-  /// The [id] can be either an event ID or an instance ID:
-  /// - **Event ID**: Returns the master event definition (for recurring events)
-  /// - **Instance ID**: Returns a specific occurrence (for recurring events)
-  ///
-  ///
-  /// Returns null if no matching event is found.
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  /// // Get specific instance of a recurring event
-  /// final instance = await plugin.getEvent(event.instanceId);
-  ///
-  /// // Get master event definition for a recurring event
-  /// final masterEvent = await plugin.getEvent(event.eventId);
-  /// ```
-  ///
-  /// Requires full calendar access ([CalendarAccessLevel.full]).
+  /// A bare event ID returns the master (the series, for a recurring event); an
+  /// instance ID (`eventId@timestamp`) returns a single occurrence. The instance
+  /// ID is unstable — it changes if the occurrence moves — so re-fetch after
+  /// edits. Requires full access.
   Future<Event?> getEvent(String id) async {
     await _ensurePermission(CalendarAccessLevel.full);
     try {
@@ -649,49 +416,18 @@ class DeviceCalendar {
     }
   }
 
-  /// Shows a calendar event in a modal dialog.
+  /// Shows an event in the OS's native calendar screen, completing when it's
+  /// dismissed. Any edits the user makes are saved by the OS; this does not
+  /// report back what changed.
   ///
-  /// The [id] can be either an event ID or an instance ID:
-  /// - **Event ID**: Shows the master event definition (for recurring events)
-  /// - **Instance ID**: Shows a specific occurrence (for recurring events)
+  /// [id] may be a bare event ID (the series master) or an instance ID (one
+  /// occurrence). [edit] only controls whether the modal *starts* in the editor
+  /// — the view screen is not read-only and always offers an Edit affordance.
   ///
-  /// When [edit] is `true`, opens the native editor directly. When `false`
-  /// (the default), opens the native view screen — but note this is **not
-  /// read-only**: on both platforms the native screen exposes an Edit affordance
-  /// that lets the user modify the event from there. `edit` only controls
-  /// whether the modal *starts* in the editor; it cannot prevent editing.
-  ///
-  /// Either way, edits made by the user are saved to the device calendar
-  /// directly by the OS. This method completes when the modal is dismissed and
-  /// does not report back whether (or what) the user changed.
-  ///
-  /// **Platform Differences:**
-  /// - **iOS**: Presents `EKEventViewController` (view, with `allowsEditing`) or
-  ///   `EKEventEditViewController` (edit) in a native modal. Both reliably bind
-  ///   to the existing event.
-  /// - **Android**: Fires `ACTION_VIEW` or `ACTION_EDIT`; the system calendar
-  ///   app renders the screen, and its view screen offers an edit button.
-  ///
-  ///   **Caveat (`edit: true` on Android):** `ACTION_EDIT` is honored
-  ///   inconsistently across calendar apps. Notably, **Google Calendar ignores
-  ///   it for an existing event and opens a blank new-event editor instead** —
-  ///   the AOSP/stock calendar lands in the editor as expected. There is no
-  ///   intent that reliably opens Google Calendar directly into edit mode on an
-  ///   existing event. For a dependable "edit this event" flow, use
-  ///   `edit: false` (`ACTION_VIEW`) and let the user tap the edit button on the
-  ///   details screen. `iOS` is unaffected.
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  /// // Open the view screen (the user can still tap Edit from here)
-  /// await plugin.showEventModal(event.instanceId);
-  ///
-  /// // Open directly in the editor
-  /// await plugin.showEventModal(event.instanceId, edit: true);
-  /// ```
-  ///
-  /// Requires full calendar access ([CalendarAccessLevel.full]).
+  /// On Android, `edit: true` is honored inconsistently (Google Calendar opens a
+  /// blank new-event editor instead); prefer the view modal and let the user tap
+  /// Edit. See [doc/native-ui.md](https://github.com/bullet-to/device_calendar_plus/blob/main/packages/device_calendar_plus/doc/native-ui.md).
+  /// Requires full access.
   Future<void> showEventModal(String id, {bool edit = false}) async {
     await _ensurePermission(CalendarAccessLevel.full);
     try {
@@ -712,71 +448,18 @@ class DeviceCalendar {
     }
   }
 
-  /// Creates a new event in a calendar.
+  /// Creates an event and returns its ID. Works with write-only access or full.
   ///
-  /// [calendarId] is the ID of the calendar to create the event in (optional).
-  ///   When omitted (`null`), the event is written to the platform's default
-  ///   calendar for new events — on iOS `defaultCalendarForNewEvents`, on
-  ///   Android the primary writable calendar (falling back to the first
-  ///   writable calendar). On Android this reads the calendar list to pick a
-  ///   default, so it needs full access — not write-only. Throws a
-  ///   [DeviceCalendarException] if no default/writable calendar is available.
-  ///   Passing a non-null but empty/whitespace ID is still an error.
-  /// [title] is the event title (required).
-  /// [startDate] is the start date/time (required).
-  /// [endDate] is the end date/time (required).
-  /// [isAllDay] indicates if this is an all-day event (default: false).
-  /// [description] is optional event notes/description.
-  /// [location] is optional event location.
-  /// [url] is an optional URL associated with the event. Round-trips through
-  ///   [Event.url]. On iOS this maps to `EKEvent.url` (visible in the native
-  ///   Calendar UI); on Android it maps to
-  ///   `CalendarContract.Events.CUSTOM_APP_URI`.
-  /// [timeZone] is optional timezone identifier (null for all-day events).
-  ///   The platform will validate the timezone string.
-  /// [availability] is the availability status (default: EventAvailability.busy).
-  /// [recurrenceRule] is an optional recurrence rule for repeating events.
-  /// [reminders] is an optional list of relative reminders, each a [Duration]
-  ///   of lead time **before** the event start at which an alarm fires (e.g.
-  ///   `Duration(minutes: 15)`). Reminders are **minute-granular** on both
-  ///   platforms: a sub-minute [Duration] rounds to the nearest minute. A
-  ///   negative [Duration] (after-start) throws [ArgumentError]; a zero
-  ///   [Duration] (at start) is allowed. Omitting it (or passing `null`) creates
-  ///   the event with no reminders.
+  /// Omit [calendarId] (or pass `null`) to write to the device's default
+  /// calendar; on Android resolving that default reads the calendar list, so it
+  /// needs full access. A non-null but empty ID is an error, as is an [endDate]
+  /// before [startDate].
   ///
-  /// Returns the system-generated event ID.
-  ///
-  /// Works with write-only access ([CalendarAccessLevel.writeOnly]), or full.
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  ///
-  /// // Create a basic event
-  /// final eventId = await plugin.createEvent(
-  ///   calendarId: 'cal-123',
-  ///   title: 'Team Meeting',
-  ///   startDate: DateTime.now(),
-  ///   endDate: DateTime.now().add(Duration(hours: 1)),
-  ///   url: 'https://example.com/meeting/123',
-  /// );
-  ///
-  /// // Create a recurring event
-  /// final recurringId = await plugin.createEvent(
-  ///   calendarId: 'cal-123',
-  ///   title: 'Daily Standup',
-  ///   startDate: DateTime(2024, 3, 15, 9, 0),
-  ///   endDate: DateTime(2024, 3, 15, 9, 15),
-  ///   recurrenceRule: DailyRecurrence(end: CountEnd(30)),
-  /// );
-  ///
-  /// // Create an event in the default calendar (no calendarId)
-  /// final defaultId = await plugin.createEvent(
-  ///   title: 'Lunch',
-  ///   startDate: DateTime.now(),
-  ///   endDate: DateTime.now().add(Duration(hours: 1)),
-  /// );
-  /// ```
+  /// [recurrenceRule] makes the event recurring (see
+  /// [doc/recurring-events.md](https://github.com/bullet-to/device_calendar_plus/blob/main/packages/device_calendar_plus/doc/recurring-events.md)).
+  /// [reminders] are lead times **before** start; each is minute-granular and
+  /// must be non-negative (see
+  /// [doc/reminders.md](https://github.com/bullet-to/device_calendar_plus/blob/main/packages/device_calendar_plus/doc/reminders.md)).
   Future<String> createEvent({
     String? calendarId,
     required String title,
@@ -850,31 +533,11 @@ class DeviceCalendar {
     }
   }
 
-  /// Deletes a single event or a single occurrence of a recurring event.
+  /// Deletes an event. A bare event ID deletes the event (the whole series, if
+  /// recurring); an instance ID removes only that occurrence.
   ///
-  /// [eventId] identifies what to delete (required):
-  /// - **Bare event ID** (e.g., `event.eventId`): deletes the non-recurring
-  ///   event, or the master of a recurring series (all occurrences).
-  /// - **Instance ID** (e.g., `event.instanceId`, format
-  ///   `eventId@timestamp`): removes only that occurrence from the series,
-  ///   as a cancelled exception; the rest of the series is untouched.
-  ///
-  /// To delete an entire recurring series or truncate it from a split point
-  /// forward, use [deleteRecurring] instead.
-  ///
-  /// Requires full calendar access ([CalendarAccessLevel.full]) — write-only is
-  /// add-only and can't delete existing events.
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  ///
-  /// // Delete a non-recurring event (or a whole recurring series)
-  /// await plugin.deleteEvent(eventId: event.eventId);
-  ///
-  /// // Delete only this one occurrence of a recurring event
-  /// await plugin.deleteEvent(eventId: event.instanceId);
-  /// ```
+  /// To truncate a series from a split point forward, use [deleteRecurring].
+  /// Requires full access.
   Future<void> deleteEvent({required String eventId}) async {
     if (eventId.trim().isEmpty) {
       throw ArgumentError.value(
@@ -905,71 +568,18 @@ class DeviceCalendar {
     }
   }
 
-  /// Updates a single event or a single occurrence of a recurring event.
+  /// Updates an event. A bare [eventId] updates the event (the whole series, if
+  /// recurring); an instance ID detaches and edits one occurrence (its
+  /// [startDate]/[endDate] are absolute, so it can move to another day).
   ///
-  /// [eventId] identifies what to update (required):
-  /// - **Bare event ID** (e.g., `event.eventId`): updates the non-recurring
-  ///   event, or the master of a recurring series (all occurrences).
-  /// - **Instance ID** (e.g., `event.instanceId`, format
-  ///   `eventId@timestamp`): detaches that single occurrence from the series
-  ///   and applies the changes to it alone. [startDate] and [endDate] are
-  ///   absolute instants, so the occurrence can move to a different day.
+  /// To change a property across a series or from a split point forward, use
+  /// [updateRecurring].
   ///
-  /// To change a property across an entire recurring series or from a split
-  /// point forward, use [updateRecurring] instead.
-  ///
-  /// All field parameters are optional - only provided fields will be updated:
-  /// - [title] - new event title
-  /// - [startDate] - new start date/time
-  /// - [endDate] - new end date/time
-  /// - [description] - event description ([Patch.set] to change, [Patch.clear]
-  ///   to remove)
-  /// - [location] - event location ([Patch.set] to change, [Patch.clear] to
-  ///   remove)
-  /// - [url] - URL associated with the event ([Patch.set] to change,
-  ///   [Patch.clear] to remove). Round-trips through [Event.url]. On iOS this
-  ///   maps to `EKEvent.url`; on Android it maps to
-  ///   `CalendarContract.Events.CUSTOM_APP_URI`.
-  /// - [isAllDay] - change between all-day and timed event
-  ///   - Changing timed → all-day: Time components are stripped to midnight
-  ///   - Changing all-day → timed: Midnight time is used
-  /// - [timeZone] - new timezone identifier
-  ///   - Note: This reinterprets the local time, not preserving the instant
-  ///   - Example: "3:00 PM EST" → "3:00 PM PST" (different instant in time)
-  /// - [availability] - new availability status
-  ///
-  /// - [reminders] - the event's reminder set ([Patch.set] to replace the whole
-  ///   set, [Patch.clear] to remove all reminders). Each [Duration] is lead
-  ///   time **before** start and is minute-granular; a negative [Duration]
-  ///   throws [ArgumentError] (zero is allowed).
-  ///
-  /// [description], [location] and [url] take a [Patch]: omit the argument (or
-  /// pass `null`) to leave the field unchanged, [Patch.set] to assign a new
-  /// value, [Patch.clear] to remove the existing value. [reminders] takes a
-  /// `Patch<List<Duration>>` with the same three states.
-  ///
-  /// Providing no fields is a no-op (nothing to change).
-  /// Requires full calendar access ([CalendarAccessLevel.full]) — write-only is
-  /// add-only and can't modify existing events.
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  ///
-  /// // Update a non-recurring event (or all occurrences of a recurring one)
-  /// await plugin.updateEvent(
-  ///   eventId: event.eventId,
-  ///   title: 'Updated Meeting Title',
-  /// );
-  ///
-  /// // Edit only this one occurrence of a recurring event
-  /// await plugin.updateEvent(
-  ///   eventId: event.instanceId,
-  ///   title: 'Moved this week only',
-  ///   startDate: DateTime(2024, 3, 21, 15, 0),
-  ///   endDate: DateTime(2024, 3, 21, 16, 0),
-  /// );
-  /// ```
+  /// Only the fields you pass change. [description], [location], [url], and
+  /// [reminders] take a [Patch] — omit to leave unchanged, [Patch.set] to
+  /// assign, [Patch.clear] to remove. Setting [timeZone] reinterprets the
+  /// wall-clock time rather than preserving the instant. Passing no fields is a
+  /// no-op. Requires full access.
   Future<void> updateEvent({
     required String eventId,
     String? title,
@@ -1061,130 +671,32 @@ class DeviceCalendar {
     }
   }
 
-  /// Updates a recurring event's series, choosing which occurrences the edit
-  /// affects.
-  ///
-  /// Use this instead of [updateEvent] when you need to change a recurring
-  /// event's [recurrenceRule], its time-of-day or duration across a series, or
-  /// when an edit should split the series at a given point.
-  ///
-  /// To edit a single occurrence, pass its instance ID to [updateEvent]
-  /// instead.
-  ///
-  /// [instanceId] identifies the occurrence to act on — pass an instance ID
-  /// (`event.instanceId`). For [EventSpan.thisAndFollowing] it must carry an
-  /// occurrence timestamp (`eventId@timestamp`); a bare event ID throws
-  /// [ArgumentError].
+  /// Edits a recurring **series** — its [recurrenceRule], its time-of-day or
+  /// [duration], or any field across occurrences. To edit one occurrence, pass
+  /// its instance ID to [updateEvent] instead.
   ///
   /// [span] chooses the scope:
   /// - [EventSpan.allEvents] — the whole series follows the change.
-  ///   Clearing [recurrenceRule] collapses the series into a single event.
-  /// - [EventSpan.thisAndFollowing] — the series is split at the
-  ///   occurrence timestamp: that occurrence and every later one carry the
-  ///   edit; earlier occurrences are untouched. Clearing [recurrenceRule] here
-  ///   turns the occurrence into a standalone non-recurring event and drops
-  ///   every later one, leaving the earlier occurrences in the original series
-  ///   (the "this and future, made non-recurring" case).
+  /// - [EventSpan.thisAndFollowing] — splits the series at the occurrence; that
+  ///   one and every later one carry the change. Requires [instanceId] to carry
+  ///   an occurrence timestamp (a bare event ID throws [ArgumentError]).
   ///
-  /// Time fields:
-  /// - [start] moves the anchored occurrence to a new start, and translates
-  ///   the whole scope by the same wall-clock delta — so it changes the
-  ///   time-of-day **and** the day together. Moving Monday 11 PM to Tuesday
-  ///   1 AM shifts every occurrence one day later and to 1 AM. The delta is
-  ///   measured against the occurrence the [instanceId] points at (or the
-  ///   series anchor, for `allEvents` with a bare event ID), in the event's
-  ///   timezone, so it is DST-safe. Duration is preserved unless [duration]
-  ///   is also passed. On all-day events only the date moves; the time-of-day
-  ///   is ignored.
-  /// - [duration] sets the event duration; it must be non-negative (zero is
-  ///   allowed for an instantaneous event) and a whole number of minutes. For
-  ///   all-day events, only whole-day durations are valid (e.g.,
-  ///   `Duration(days: 3)` for a three-day conference).
+  /// [start] moves the anchor and translates the scope by the same wall-clock
+  /// delta — changing day and time together, measured in the event's timezone
+  /// (so DST-safe). [duration] must be non-negative whole minutes (whole days
+  /// for all-day events). [recurrenceRule] takes a [Patch]: [Patch.set] to
+  /// change the rule, [Patch.clear] to stop recurring.
   ///
-  /// [recurrenceRule] takes a [Patch]: omit it to leave recurrence unchanged,
-  /// [Patch.set] to change the rule, [Patch.clear] to remove it (the event
-  /// stops recurring).
+  /// Moving the day of a rule that pins it explicitly (e.g.
+  /// `WeeklyRecurrence(daysOfWeek: …)`) without also passing a [recurrenceRule]
+  /// throws [DeviceCalendarException] ([DeviceCalendarError.invalidArguments]),
+  /// because the result is ambiguous. Implicit rules and time-only changes
+  /// follow the anchor freely. See
+  /// [doc/recurring-events.md](https://github.com/bullet-to/device_calendar_plus/blob/main/packages/device_calendar_plus/doc/recurring-events.md).
   ///
-  /// **[start] moves the series anchor; the recurrence rule is yours.**
-  ///
-  /// - Rules whose day is *implied by the start* — the defaults
-  ///   `WeeklyRecurrence()`, `MonthlyRecurrence()`, `DailyRecurrence()` — have
-  ///   no explicit day pinned, so moving the day with [start] is enough: the
-  ///   pattern follows the anchor (a Monday-anchored weekly becomes a Tuesday
-  ///   one). Nothing else to do.
-  /// - Rules that *pin a day explicitly* — `WeeklyRecurrence(daysOfWeek: …)`,
-  ///   `MonthlyRecurrence(daysOfMonth: …)`, positional rules like "2nd Tuesday"
-  ///   — cannot be moved to a different day by [start] alone. If [start] would
-  ///   change the pinned weekday (or day-of-month, or month) and you do **not**
-  ///   pass a [recurrenceRule], this throws [DeviceCalendarException] with
-  ///   [DeviceCalendarError.invalidArguments]. Pass the new rule in the same
-  ///   call to say what the pattern should become.
-  ///
-  /// *Why throw instead of guessing?* Moving one day of a multi-day rule is
-  /// genuinely ambiguous: dragging the Monday of a Mon/Wed/Fri series to
-  /// Tuesday could mean Tue/Wed/Fri (that day reassigned) or Tue/Thu/Sat (the
-  /// whole pattern shifted) — there is no single right answer, and Google
-  /// Calendar itself mishandles it. Silently picking one would surprise half
-  /// the callers; silently doing nothing reads as a broken drag and behaves
-  /// differently on iOS vs Android. So the API refuses and hands the decision
-  /// back to you, who can express it exactly via [recurrenceRule].
-  ///
-  /// Edge cases that do **not** throw (the day-spec is unchanged):
-  /// - changing only the time-of-day, or only [duration];
-  /// - a whole-week shift of a weekly rule (e.g. +7 days keeps the weekday);
-  /// - any move on an implicit rule (it has no pinned day to contradict).
-  ///
-  /// Watch for the converse: a **cross-midnight** retime of a pinned series
-  /// (11 PM → 1 AM) rolls the date forward a day, so it *does* change the
-  /// weekday and will throw — pass a [recurrenceRule] for those too.
-  ///
-  /// **Secondary effects** — what happens to occurrences the user had
-  /// individually customised — are best-effort and differ by platform.
-  /// Customisations before a `thisAndFollowing` split point survive.
-  /// Customisations after the split point (or anywhere, for `allEvents`) are
-  /// reset: a moved occurrence persists as a detached standalone event, and a
-  /// deleted occurrence may reappear if the new rule regenerates that date.
-  ///
-  /// Returns the event ID for the affected scope — the same ID for
-  /// `allEvents`, the new series' ID for `thisAndFollowing`.
-  ///
-  /// Providing no fields is a no-op (nothing to change).
-  /// Requires full calendar access ([CalendarAccessLevel.full]) — write-only is
-  /// add-only and can't modify an existing series.
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  ///
-  /// // Move a nightshift series from 11 PM to 1 AM the next day
-  /// await plugin.updateRecurring(
-  ///   event.instanceId, // an occurrence currently at 11 PM
-  ///   EventSpan.allEvents,
-  ///   start: DateTime(2024, 3, 19, 1, 0), // the day after, 1 AM
-  /// );
-  ///
-  /// // Change the duration of all occurrences to 90 minutes
-  /// await plugin.updateRecurring(
-  ///   event.instanceId,
-  ///   EventSpan.allEvents,
-  ///   duration: Duration(minutes: 90),
-  /// );
-  ///
-  /// // Split: this occurrence and later ones move to a new start
-  /// final newSeriesId = await plugin.updateRecurring(
-  ///   event.instanceId,
-  ///   EventSpan.thisAndFollowing,
-  ///   start: DateTime(2024, 3, 18, 15, 0),
-  ///   duration: Duration(hours: 1),
-  /// );
-  ///
-  /// // Change the whole series to weekly
-  /// await plugin.updateRecurring(
-  ///   event.instanceId,
-  ///   EventSpan.allEvents,
-  ///   recurrenceRule: Patch.set(WeeklyRecurrence(end: CountEnd(10))),
-  /// );
-  /// ```
+  /// Returns the affected scope's event ID (the same ID for `allEvents`, the new
+  /// series' ID for `thisAndFollowing`). Passing no fields is a no-op. Requires
+  /// full access.
   Future<String> updateRecurring(
     String instanceId,
     EventSpan span, {
@@ -1305,43 +817,15 @@ class DeviceCalendar {
     }
   }
 
-  /// Deletes a recurring event's series, choosing which occurrences are
-  /// removed.
+  /// Deletes a recurring **series** by [span]:
+  /// - [EventSpan.allEvents] — deletes the whole series (same as [deleteEvent]
+  ///   with a bare event ID).
+  /// - [EventSpan.thisAndFollowing] — removes the occurrence and every later
+  ///   one, truncating the series. Requires [instanceId] to carry an occurrence
+  ///   timestamp (a bare event ID throws [ArgumentError]).
   ///
-  /// Use this instead of [deleteEvent] when a recurring series should be
-  /// truncated from a split point forward, or deleted outright.
-  ///
-  /// To delete a single occurrence, pass its instance ID to [deleteEvent]
-  /// instead.
-  ///
-  /// [instanceId] identifies the occurrence to act on — pass an instance ID
-  /// (`event.instanceId`). For [EventSpan.thisAndFollowing] it must carry an
-  /// occurrence timestamp (`eventId@timestamp`); a bare event ID throws
-  /// [ArgumentError].
-  ///
-  /// [span] chooses the scope:
-  /// - [EventSpan.allEvents] — the whole series is deleted (the same result
-  ///   as [deleteEvent] with a bare event ID).
-  /// - [EventSpan.thisAndFollowing] — the occurrence at the timestamp and
-  ///   every later one are removed; the series is truncated to end before it.
-  ///   Earlier occurrences are untouched.
-  ///
-  /// Requires full calendar access ([CalendarAccessLevel.full]) — write-only is
-  /// add-only and can't delete an existing series.
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  ///
-  /// // Delete the whole series
-  /// await plugin.deleteRecurring(event.instanceId, EventSpan.allEvents);
-  ///
-  /// // Delete this occurrence and every later one
-  /// await plugin.deleteRecurring(
-  ///   event.instanceId,
-  ///   EventSpan.thisAndFollowing,
-  /// );
-  /// ```
+  /// To delete one occurrence, pass its instance ID to [deleteEvent]. Requires
+  /// full access.
   Future<void> deleteRecurring(String instanceId, EventSpan span) async {
     // Validate instanceId
     if (instanceId.trim().isEmpty) {
@@ -1381,39 +865,13 @@ class DeviceCalendar {
     }
   }
 
-  /// Opens the native platform calendar editor in create mode.
+  /// Opens the OS's native event editor in create mode, completing when it's
+  /// dismissed.
   ///
-  /// All parameters are optional pre-fill values. The native editor opens
-  /// with these fields populated (or blank if not provided). The user can
-  /// modify any field before saving or cancelling.
-  ///
-  /// The returned [Future] completes when the modal is dismissed (whether
-  /// the user saved or cancelled).
-  ///
-  /// If [isAllDay] is true, any provided dates are normalized to midnight.
-  /// If neither date is provided, the native editor uses its own defaults.
-  ///
-  /// **Platform APIs:**
-  /// - **iOS**: `EKEventEditViewController`
-  /// - **Android**: `Intent.ACTION_INSERT`
-  ///
-  /// Example:
-  /// ```dart
-  /// final plugin = DeviceCalendar.instance;
-  ///
-  /// // Open blank editor
-  /// await plugin.showCreateEventModal();
-  ///
-  /// // Open with pre-filled data
-  /// await plugin.showCreateEventModal(
-  ///   title: 'Team Meeting',
-  ///   startDate: DateTime.now().add(Duration(hours: 1)),
-  ///   endDate: DateTime.now().add(Duration(hours: 2)),
-  ///   location: 'Conference Room A',
-  /// );
-  /// ```
-  ///
-  /// Works with write-only access ([CalendarAccessLevel.writeOnly]), or full.
+  /// All parameters are optional pre-fill values; the user can change anything
+  /// before saving or cancelling. Useful for letting the user review, or to add
+  /// attendees (which can't be done programmatically). Works with write-only
+  /// access or full.
   Future<void> showCreateEventModal({
     String? title,
     DateTime? startDate,

--- a/packages/device_calendar_plus/lib/src/calendar.dart
+++ b/packages/device_calendar_plus/lib/src/calendar.dart
@@ -2,7 +2,7 @@ import 'dart:ui' show Color;
 
 /// Represents a user's calendar
 class Calendar {
-  /// Identifier returned by the platform (Android `Calendars._ID`, iOS `EKCalendar.calendarIdentifier`).
+  /// Identifier returned by the platform.
   final String id;
 
   /// User-facing label shown in native calendar pickers.
@@ -30,9 +30,8 @@ class Calendar {
   /// Platform-specific account type (for example `com.google`, `CalDAV`, or `local` on Android).
   final String? accountType;
 
-  /// Indicates that the calendar is the default destination for new events on that account/device.
-  ///
-  /// Android maps this to `Calendars.IS_PRIMARY`; iOS matches `eventStore.defaultCalendarForNewEvents`.
+  /// Whether the calendar is the default destination for new events on that
+  /// account/device.
   final bool isPrimary;
 
   /// Marks calendars hidden in the Android Calendar UI. iOS always reports `false`.

--- a/packages/device_calendar_plus/lib/src/calendar_access_level.dart
+++ b/packages/device_calendar_plus/lib/src/calendar_access_level.dart
@@ -4,31 +4,16 @@
 /// system prompt asks for. An add-only app can request [writeOnly] for the
 /// gentler "Add Events Only" prompt instead of full read/write.
 enum CalendarAccessLevel {
-  /// Full read and write access.
-  ///
-  /// The user is asked to allow the app to view and manage calendar events.
-  /// A granted request maps to [CalendarPermissionStatus.granted].
-  ///
-  /// - iOS 17+: `requestFullAccessToEvents`.
-  /// - iOS 16 and below: `requestAccess(to: .event)` (the only tier available).
-  /// - Android: requests both `READ_CALENDAR` and `WRITE_CALENDAR`.
+  /// Full read and write access. A granted request reports
+  /// [CalendarPermissionStatus.granted].
   full,
 
-  /// Write-only access — the app can add events but cannot read existing ones.
-  ///
-  /// This is the gentler prompt for add-only apps. A granted request maps to
+  /// Write-only access — the app can add events but not read existing ones, for
+  /// the gentler "Add Events Only" prompt. A granted request reports
   /// [CalendarPermissionStatus.writeOnly].
   ///
-  /// - iOS 17+: `requestWriteOnlyAccessToEvents` — the gentler "Add Events Only"
-  ///   prompt. Not a permanent ceiling: a later [full] request re-prompts and,
-  ///   if the user agrees, upgrades the app to full access in-app.
-  /// - iOS 16 and below: write-only does not exist, so this falls back to a
-  ///   full-access request (`requestAccess(to: .event)`) and a granted result
-  ///   reports [CalendarPermissionStatus.granted].
-  /// - Android: requests only `WRITE_CALENDAR`. `WRITE_CALENDAR` and
-  ///   `READ_CALENDAR` share the one `CALENDAR` permission group, so after a
-  ///   write-only grant a later full request escalates to read access
-  ///   **immediately, with no dialog** — where iOS shows a second prompt. Either
-  ///   way the upgrade succeeds in-app; only the prompt differs.
+  /// Not a permanent ceiling: a later [full] request upgrades the app in-app.
+  /// iOS 16 and below has no write-only tier, so the request falls back to full
+  /// access and reports [CalendarPermissionStatus.granted].
   writeOnly,
 }

--- a/packages/device_calendar_plus/lib/src/calendar_permission_status.dart
+++ b/packages/device_calendar_plus/lib/src/calendar_permission_status.dart
@@ -3,25 +3,16 @@ enum CalendarPermissionStatus {
   /// Full read and write access to calendars.
   granted,
 
-  /// Permission has been permanently denied by the user.
-  ///
-  /// On Android, this means the user selected "Don't ask again" and the
-  /// permission dialog can no longer be shown. Use [DeviceCalendar.openAppSettings]
-  /// to direct the user to the system settings page.
-  ///
-  /// On iOS, this maps to `EKAuthorizationStatus.denied`.
+  /// Permission has been permanently denied — the system dialog can no longer
+  /// be shown (on Android, the user chose "Don't ask again"). Use
+  /// [DeviceCalendar.openAppSettings] to send the user to settings.
   denied,
 
-  /// Write-only access to calendars — add events without reading existing data.
+  /// Write-only access — add events without reading existing data. Request it
+  /// with `requestPermissions(level: CalendarAccessLevel.writeOnly)`.
   ///
-  /// Request it with
-  /// `requestPermissions(level: CalendarAccessLevel.writeOnly)`.
-  ///
-  /// - On iOS 17 and later, this maps to `EKAuthorizationStatus.writeOnly`.
-  ///   iOS 16 and below has no write-only tier, so a write-only request there
-  ///   resolves to [granted] instead.
-  /// - On Android, this is returned when `WRITE_CALENDAR` is granted but
-  ///   `READ_CALENDAR` is not (e.g. after a write-only request).
+  /// iOS 16 and below has no write-only tier, so a write-only request there
+  /// resolves to [granted] instead.
   writeOnly,
 
   /// Access is restricted by device policies (iOS only).
@@ -33,17 +24,10 @@ enum CalendarPermissionStatus {
   /// This status is never returned on Android.
   restricted,
 
-  /// Permission has not been granted yet, but can still be requested.
+  /// Permission has not been granted yet, but can still be requested — calling
+  /// [DeviceCalendar.requestPermissions] in this state shows the system dialog.
   ///
-  /// Calling [DeviceCalendar.requestPermissions] while in this state will show
-  /// the system permission dialog.
-  ///
-  /// On iOS, this maps directly to the `EKAuthorizationStatus.notDetermined` state.
-  ///
-  /// On Android, this covers both "never asked" and "denied once but can still
-  /// ask again". Android's `checkSelfPermission()` returns `PERMISSION_DENIED`
-  /// in both cases, so a `SharedPreferences` flag combined with
-  /// `shouldShowRequestPermissionRationale()` is used to detect when the
-  /// permission has been permanently denied (which returns [denied] instead).
+  /// On Android this covers both "never asked" and "denied once but can still
+  /// ask again"; a permanent denial returns [denied] instead.
   notDetermined,
 }

--- a/packages/device_calendar_plus/lib/src/calendar_source.dart
+++ b/packages/device_calendar_plus/lib/src/calendar_source.dart
@@ -49,25 +49,16 @@ enum CalendarSourceType {
 class CalendarSource {
   /// Stable identifier for this source.
   ///
-  /// - **iOS**: `EKSource.sourceIdentifier` — use with [CreateCalendarOptionsIos]
-  /// - **Android**: Synthetic `"encodedAccountName:encodedAccountType"` (URI-encoded)
-  ///   — informational only, not used for creation. Use [accountName] + [accountType]
-  ///   with [CreateCalendarOptionsAndroid] instead.
+  /// On iOS, pass it to [CreateCalendarOptionsIos]. On Android it is
+  /// informational only — use [accountName] + [accountType] with
+  /// [CreateCalendarOptionsAndroid] to create a calendar.
   final String id;
 
-  /// Display name or account identifier for this source.
-  ///
-  /// - **iOS**: `EKSource.title` (e.g. "iCloud", "Gmail")
-  /// - **Android**: `ACCOUNT_NAME` (e.g. "user@gmail.com", "local")
-  ///
+  /// Display name or account identifier (e.g. "iCloud", "user@gmail.com").
   /// Matches [Calendar.accountName].
   final String accountName;
 
-  /// Raw platform type string for this source.
-  ///
-  /// - **iOS**: e.g. "caldav", "local", "exchange"
-  /// - **Android**: e.g. "com.google", "LOCAL", "com.android.exchange"
-  ///
+  /// Raw platform type string (e.g. "caldav" on iOS, "com.google" on Android).
   /// Matches [Calendar.accountType].
   final String accountType;
 

--- a/packages/device_calendar_plus/lib/src/event.dart
+++ b/packages/device_calendar_plus/lib/src/event.dart
@@ -11,35 +11,12 @@ class Event {
   /// For recurring events, all instances share the same eventId.
   final String eventId;
 
-  /// Instance identifier that uniquely identifies this specific event instance.
+  /// Identifies this specific occurrence; pass it to act on one occurrence of a
+  /// recurring series.
   ///
-  /// **UNSTABLE ID:** This is a plugin-generated identifier, not a system ID.
-  /// It is derived from the [eventId] and the event's start date.
-  ///
-  /// Use this with [DeviceCalendar.instance.getEvent] and [DeviceCalendar.instance.showEventModal]
-  /// to fetch or display this specific event occurrence.
-  ///
-  /// For non-recurring events, this equals [eventId].
-  /// For recurring events, this is a unique identifier for each occurrence.
-  ///
-  /// **Important:** This ID becomes invalid when the event's start date changes.
-  /// You are responsible for keeping instanceId up to date by re-fetching events.
-  ///
-  /// Example scenario where instanceId becomes invalid:
-  /// ```dart
-  /// // 1. You fetch some events
-  /// final events = await plugin.retrieveEvents(calendarId, ...);
-  ///
-  /// // 2. User opens native modal from one of the events and changes the start date
-  /// await plugin.showEventModal(event.instanceId);
-  /// // User changes date from Nov 5 to Nov 6 and saves
-  ///
-  /// // 3. Your stored instanceId is now invalid!
-  /// // The savedInstanceId no longer points to any event
-  ///
-  /// // 4. You must re-fetch to get the updated instanceId
-  /// final events = await plugin.retrieveEvents(calendarId, ...);
-  /// ```
+  /// Equals [eventId] for non-recurring events. This is a plugin-derived,
+  /// **unstable** ID: it becomes invalid when the occurrence's start date
+  /// changes, so re-fetch events after edits.
   final String instanceId;
 
   /// ID of the calendar this event belongs to.
@@ -98,33 +75,16 @@ class Event {
   /// supports programmatic write via this plugin.
   final List<Attendee>? attendees;
 
-  /// Relative-time reminders (alarms) for this event.
+  /// Relative-time reminders for this event, each a lead time **before** start
+  /// (e.g. `Duration(minutes: 15)`). Null when there are none.
   ///
-  /// Each [Duration] is the lead time **before** the event's start at which the
-  /// alarm fires (e.g. `Duration(minutes: 15)` fires 15 minutes before start).
-  ///
-  /// Null when the event has no reminders. Reminders are **minute-granular** on
-  /// both platforms: sub-minute durations round to the nearest minute, so a
+  /// Minute-granular: sub-minute durations round to the nearest minute, so
   /// `Duration(seconds: 90)` round-trips as `Duration(minutes: 2)`.
-  ///
-  /// **Platform mapping:**
-  /// - **iOS**: `EKAlarm(relativeOffset:)` on `EKEvent.alarms` (seconds before
-  ///   start).
-  /// - **Android**: rows in `CalendarContract.Reminders` (`MINUTES` before
-  ///   start, `METHOD_ALERT`).
   final List<Duration>? reminders;
 
-  /// Optional URL associated with this event.
-  ///
-  /// A typical use is a meeting link, a ticket page, or a deep link into the
-  /// app that created the event.
-  ///
-  /// **Platform mapping:**
-  /// - **iOS**: stored on `EKEvent.url`. Visible as the URL field in the
-  ///   native Calendar app and editable there.
-  /// - **Android**: stored on `CalendarContract.Events.CUSTOM_APP_URI`. Not
-  ///   surfaced in the default Calendar UI, but round-trips correctly through
-  ///   the plugin and is available to other apps reading the calendar.
+  /// Optional URL associated with this event — typically a meeting link, ticket
+  /// page, or deep link. Visible in the native Calendar UI on iOS; round-trips
+  /// through the plugin on Android.
   final String? url;
 
   Event({

--- a/packages/device_calendar_plus/lib/src/recurrence_rule.dart
+++ b/packages/device_calendar_plus/lib/src/recurrence_rule.dart
@@ -83,10 +83,9 @@ class UntilEnd extends RecurrenceEnd {
 
 /// Recurrence rule for calendar events (RFC 5545 RRULE subset).
 ///
-/// This models the cross-platform subset of RRULE that both iOS (EKRecurrenceRule)
-/// and Android (CalendarContract) support reliably.
-///
-/// For full RRULE access (e.g. BYHOUR on Android), use [rruleString].
+/// Models the cross-platform subset of RRULE that both iOS and Android support
+/// reliably. For RRULE features beyond that subset (e.g. BYHOUR), use
+/// [rruleString].
 sealed class RecurrenceRule {
   /// Interval between recurrences. Defaults to 1.
   ///
@@ -103,16 +102,12 @@ sealed class RecurrenceRule {
       : _rawRrule = rawRrule,
         assert(interval >= 1, 'Interval must be at least 1');
 
-  /// The raw RRULE string.
+  /// The raw RRULE string — use it for RRULE properties beyond the typed model.
   ///
-  /// When parsed from a platform event, this is the original string as returned
-  /// by the platform. On Android this is the exact CalendarContract string
-  /// (full fidelity). On iOS this is reconstructed from EKRecurrenceRule
-  /// (may lose properties like BYHOUR that EventKit doesn't model).
-  ///
-  /// When constructed in Dart, this is generated from [toRruleString].
-  ///
-  /// Use this if you need RRULE properties beyond what the typed model exposes.
+  /// When parsed from a platform event this is the original string: full
+  /// fidelity on Android; on iOS it is reconstructed and may lose properties the
+  /// platform doesn't model (e.g. BYHOUR). When constructed in Dart, it is
+  /// generated from [toRruleString].
   String get rruleString => _rawRrule ?? toRruleString();
 
   /// Serializes this rule to an RRULE string (without the "RRULE:" prefix).
@@ -185,14 +180,11 @@ class WeeklyRecurrence extends RecurrenceRule {
   /// If null, defaults to the day of the event's start date (platform behavior).
   final List<DayOfWeek>? daysOfWeek;
 
-  /// The day the week starts on (WKST).
+  /// The day the week starts on (WKST). Affects how BYDAY is calculated for
+  /// weekly recurrences. Defaults to Monday per RFC 5545 when null.
   ///
-  /// Affects how BYDAY is calculated for weekly recurrences.
-  /// Defaults to Monday per RFC 5545 when null.
-  ///
-  /// **Note:** iOS can read this from events but cannot set it when creating
-  /// events (EKRecurrenceRule does not expose it in its initializer).
-  /// The value still round-trips via [rruleString].
+  /// iOS can read this from events but cannot set it when creating them; the
+  /// value still round-trips via [rruleString].
   final DayOfWeek? wkst;
 
   const WeeklyRecurrence({
@@ -597,8 +589,6 @@ class YearlyByWeekday extends YearlyRecurrence {
 ///
 /// Without [position]: "every Tuesday" (`BYDAY=TU`).
 /// With [position]: "2nd Tuesday" (`BYDAY=2TU`) or "last Friday" (`BYDAY=-1FR`).
-///
-/// Maps to RFC 5545 BYDAY and iOS `EKRecurrenceDayOfWeek`.
 class RecurrenceDay {
   /// The day of the week.
   final DayOfWeek day;

--- a/packages/device_calendar_plus/pubspec.yaml
+++ b/packages/device_calendar_plus/pubspec.yaml
@@ -1,17 +1,17 @@
 name: device_calendar_plus
 description: A modern, maintained Flutter plugin for reading and writing device calendar events on Android and iOS.
-version: 0.7.0
+version: 0.7.1
 repository: https://github.com/bullet-to/device_calendar_plus
 issue_tracker: https://github.com/bullet-to/device_calendar_plus/issues
 
 resolution: workspace
 
 topics:
+  - device
   - calendar
   - events
   - eventkit
   - calendar-provider
-  - federated
 
 environment:
   sdk: ">=3.5.0 <4.0.0"


### PR DESCRIPTION
Cleans up the consumer-facing docs and rolls in the pending 0.7.1 bits.

**README: 791 → 109 lines.** It was basically a reference manual. Now it's an overview + a getting-started snippet, with the worked examples split into focused topic guides under `doc/` (the way eventide does it), linked from both the README and the dartdoc.

**Dartdoc trimmed hard.** `device_calendar_plus.dart` went 724 → 182 `///` lines. Pulled out every native-API leak — `EKEvent`/`EKAlarm`/`EKSource`/`EKAuthorizationStatus`, `CalendarContract` columns, native permission-method names, the Android permission-detection internals — plus the rationale essays and param lists that just echoed the signature. Kept RFC 5545 RRULE vocabulary on purpose (it's the recurrence model's own language and `rruleString` exposes it) and the `AndroidManifest.xml` permission names in setup/error docs (consumers declare those).

Also folded in the 0.7.1 prep that was sitting locally: `device` pub topic (dropped `federated` for the 5-cap), reminders ticked on the roadmap.

Docs only — no code or behavior changes, analyzer clean. Net **+761 / −1516**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)