### PR TITLE
refactor!: rename WeeklyRecurrence.wkst → weekStart (+ parity docs)

### DIFF
--- a/packages/device_calendar_plus/CHANGELOG.md
+++ b/packages/device_calendar_plus/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+### Changed
+- **Breaking:** `WeeklyRecurrence`'s `wkst` field and constructor parameter are
+  renamed to `weekStart`, matching the spelled-out naming of the other
+  recurrence fields (`daysOfWeek`, `daysOfMonth`, `setPositions`, …). The
+  emitted RRULE is unchanged (still uses the `WKST=` token). Update
+  `WeeklyRecurrence(wkst: …)` call sites and `.wkst` reads to `weekStart`.
+
 ## 0.7.1 - 2026-06-17
 
 ### Changed

--- a/packages/device_calendar_plus/doc/events.md
+++ b/packages/device_calendar_plus/doc/events.md
@@ -89,8 +89,11 @@ await plugin.updateEvent(
 );
 ```
 
-Passing no fields is a no-op. To edit a recurring **series**, use
-`updateRecurring` ([recurring-events.md](recurring-events.md)).
+Switching `isAllDay` reinterprets the times: timed → all-day strips the start
+and end to midnight; all-day → timed starts them at midnight. Setting `timeZone`
+reinterprets the wall-clock time rather than preserving the instant. Passing no
+fields is a no-op. To edit a recurring **series**, use `updateRecurring`
+([recurring-events.md](recurring-events.md)).
 
 ## Delete
 

--- a/packages/device_calendar_plus/doc/permissions.md
+++ b/packages/device_calendar_plus/doc/permissions.md
@@ -43,7 +43,10 @@ if (status == CalendarPermissionStatus.writeOnly ||
 Write-only covers `createEvent` and `showCreateEventModal`. Everything else —
 reading, updating, deleting, listing calendars — needs full access. Write-only
 is not a ceiling: call `requestPermissions(level: CalendarAccessLevel.full)`
-later to upgrade in-app.
+later to upgrade in-app. On Android the upgrade is granted immediately with no
+second dialog (`READ_CALENDAR` and `WRITE_CALENDAR` share one permission group);
+on iOS it re-prompts, and if the user declines the call returns the still-held
+`writeOnly` rather than `denied`.
 
 > **iOS setup:** add `NSCalendarsWriteOnlyAccessUsageDescription` to your
 > `Info.plist` (see the README install section). On iOS 16 and below there is no

--- a/packages/device_calendar_plus/doc/recurring-events.md
+++ b/packages/device_calendar_plus/doc/recurring-events.md
@@ -51,6 +51,12 @@ if (rule is MonthlyByWeekday) {
 print(rule?.rruleString); // e.g. "FREQ=MONTHLY;BYDAY=2TU;COUNT=12"
 ```
 
+`rruleString` is exact on Android; on iOS it's reconstructed from EventKit and
+may drop properties EventKit doesn't model (e.g. `BYHOUR`). Note `weekStart`
+(WKST) round-trips when reading, but iOS can't *set* it when creating an event —
+EventKit ignores it there, so a weekly rule that depends on a non-default week
+start may differ across platforms.
+
 ## Occurrences and IDs
 
 `listEvents` expands a series into one `Event` per occurrence. Each shares the

--- a/packages/device_calendar_plus/lib/src/recurrence_rule.dart
+++ b/packages/device_calendar_plus/lib/src/recurrence_rule.dart
@@ -185,11 +185,11 @@ class WeeklyRecurrence extends RecurrenceRule {
   ///
   /// iOS can read this from events but cannot set it when creating them; the
   /// value still round-trips via [rruleString].
-  final DayOfWeek? wkst;
+  final DayOfWeek? weekStart;
 
   const WeeklyRecurrence({
     this.daysOfWeek,
-    this.wkst,
+    this.weekStart,
     super.interval,
     super.end,
     super.rawRrule,
@@ -203,7 +203,7 @@ class WeeklyRecurrence extends RecurrenceRule {
       buf.write(';BYDAY=${daysOfWeek!.map((d) => d.toRruleDay()).join(',')}');
     }
     buf.write(_endParts());
-    if (wkst != null) buf.write(';WKST=${wkst!.toRruleDay()}');
+    if (weekStart != null) buf.write(';WKST=${weekStart!.toRruleDay()}');
     return buf.toString();
   }
 
@@ -213,20 +213,20 @@ class WeeklyRecurrence extends RecurrenceRule {
     return other is WeeklyRecurrence &&
         other.interval == interval &&
         other.end == end &&
-        other.wkst == wkst &&
+        other.weekStart == weekStart &&
         _listEquals(other.daysOfWeek, daysOfWeek);
   }
 
   @override
   int get hashCode => Object.hash(
         super.hashCode,
-        wkst,
+        weekStart,
         daysOfWeek != null ? Object.hashAll(daysOfWeek!) : null,
       );
 
   @override
   String toString() =>
-      'WeeklyRecurrence(interval: $interval, daysOfWeek: $daysOfWeek, wkst: $wkst, end: $end)';
+      'WeeklyRecurrence(interval: $interval, daysOfWeek: $daysOfWeek, weekStart: $weekStart, end: $end)';
 }
 
 /// Event repeats every N months.
@@ -707,7 +707,7 @@ class _RruleParser {
         'WEEKLY' => WeeklyRecurrence(
             interval: interval,
             daysOfWeek: _parseDaysOfWeek(params['BYDAY']),
-            wkst: params['WKST'] != null
+            weekStart: params['WKST'] != null
                 ? DayOfWeek.fromRruleDay(params['WKST']!)
                 : null,
             end: end,

--- a/packages/device_calendar_plus/test/recurrence_rule_test.dart
+++ b/packages/device_calendar_plus/test/recurrence_rule_test.dart
@@ -701,15 +701,15 @@ void main() {
   });
 
   group('WKST', () {
-    test('weekly with wkst serializes correctly', () {
+    test('weekly with weekStart serializes correctly', () {
       const rule = WeeklyRecurrence(
         daysOfWeek: [DayOfWeek.monday],
-        wkst: DayOfWeek.sunday,
+        weekStart: DayOfWeek.sunday,
       );
       expect(rule.toRruleString(), 'FREQ=WEEKLY;BYDAY=MO;WKST=SU');
     });
 
-    test('weekly without wkst omits it', () {
+    test('weekly without weekStart omits it', () {
       const rule = WeeklyRecurrence(daysOfWeek: [DayOfWeek.monday]);
       expect(rule.toRruleString(), isNot(contains('WKST')));
     });
@@ -718,29 +718,29 @@ void main() {
       final rule =
           RecurrenceRule.fromRruleString('FREQ=WEEKLY;BYDAY=MO;WKST=SU');
       expect(rule, isA<WeeklyRecurrence>());
-      expect((rule as WeeklyRecurrence).wkst, DayOfWeek.sunday);
+      expect((rule as WeeklyRecurrence).weekStart, DayOfWeek.sunday);
     });
 
     test('WKST roundtrip', () {
       const original = WeeklyRecurrence(
         daysOfWeek: [DayOfWeek.monday, DayOfWeek.friday],
-        wkst: DayOfWeek.sunday,
+        weekStart: DayOfWeek.sunday,
         end: CountEnd(10),
       );
       final parsed = RecurrenceRule.fromRruleString(original.toRruleString());
       expect(parsed, isA<WeeklyRecurrence>());
       final weekly = parsed as WeeklyRecurrence;
-      expect(weekly.wkst, DayOfWeek.sunday);
+      expect(weekly.weekStart, DayOfWeek.sunday);
       expect(weekly.daysOfWeek, original.daysOfWeek);
     });
 
     test('WKST equality', () {
       const a = WeeklyRecurrence(
-          daysOfWeek: [DayOfWeek.monday], wkst: DayOfWeek.sunday);
+          daysOfWeek: [DayOfWeek.monday], weekStart: DayOfWeek.sunday);
       const b = WeeklyRecurrence(
-          daysOfWeek: [DayOfWeek.monday], wkst: DayOfWeek.sunday);
+          daysOfWeek: [DayOfWeek.monday], weekStart: DayOfWeek.sunday);
       const c = WeeklyRecurrence(
-          daysOfWeek: [DayOfWeek.monday], wkst: DayOfWeek.monday);
+          daysOfWeek: [DayOfWeek.monday], weekStart: DayOfWeek.monday);
       expect(a, equals(b));
       expect(a, isNot(equals(c)));
     });


### PR DESCRIPTION
Renames the one abbreviated recurrence field to match the rest of the model, plus the platform-parity doc notes it depends on.

**Breaking (queued for 0.8.0, not released yet).** `WeeklyRecurrence`'s `wkst` field and constructor parameter become `weekStart` - every other recurrence field is a spelled-out word (`daysOfWeek`, `daysOfMonth`, `setPositions`, `months`), so `wkst` was the odd one out. The emitted RRULE is unchanged (still `WKST=`), and the rename stays app-facing - it doesn't cross the platform channel. Call sites move from `WeeklyRecurrence(wkst: …)` / `.wkst` to `weekStart`.

Also includes the topic-guide parity notes:
- **Permissions** - per-platform write-only → full upgrade behaviour
- **Events** - `isAllDay`/`timeZone` reinterpret times on update
- **Recurring** - `rruleString` fidelity, and the `weekStart` read-vs-set caveat on iOS

CHANGELOG entry is under `## Unreleased`; no version bump or publish here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)