### PR TITLE
feat: expose per-event color as read-only Event.colorHex

### DIFF
--- a/.claude/rules/api-design.md
+++ b/.claude/rules/api-design.md
@@ -2,9 +2,15 @@
 
 ## Cross-platform consistency
 
-Only expose features that work identically on both iOS and Android. If a
-capability is read-only on one platform, it's read-only in the plugin. If it
-doesn't exist on one platform, don't add it.
+For **writes and mutations**, only expose features that work identically on
+both iOS and Android. If a capability is read-only on one platform, it's
+read-only in the plugin. No write support unless both platforms have it.
+
+**Read-only data** is exempt: a value that only one platform provides MAY be
+exposed as a nullable platform-specific field (e.g. `Event.colorHex`, which
+Android reads from `EVENT_COLOR` and iOS always reports as `null`). Document
+the per-platform behaviour on the field, and don't add write support unless
+both platforms have it.
 
 When a behaviour *can* be made consistent but the platforms naturally differ,
 conform Android to iOS. iOS is the priority platform — it has most of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,9 +30,9 @@ These conventions apply across the entire plugin. Any new feature that deals wit
 
 Both platform implementations must return data in the **same map shape**. The platform interface defines this contract — if a field exists in the Dart model's `fromMap()`, both platforms must populate it.
 
-- Don't add a field to the Dart model unless both platforms return it.
+- Don't add a field to the Dart model unless both platforms return it. **Read-only data is exempt:** a value that only one platform provides may be exposed as a nullable platform-specific field (e.g. `Event.colorHex`, which Android reads from `EVENT_COLOR` and iOS always reports as `null`). Document the per-platform behaviour on the field, and don't add write support unless both platforms have it.
 - Don't change the map shape for one platform without updating the other.
-- If a field is platform-specific, handle it through typed platform option classes (see `CreateCalendarOptionsAndroid` for an example).
+- If a platform-specific field needs write configuration, handle it through typed platform option classes (see `CreateCalendarOptionsAndroid` for an example).
 
 ## Architecture
 
@@ -43,7 +43,7 @@ This is a federated plugin. Changes to the API surface typically touch all four 
 3. **`device_calendar_plus_ios`** — Implement for iOS (Swift, EventKit).
 4. **`device_calendar_plus`** — Expose through the public Dart API with validation and documentation.
 
-If you're adding a new field to an existing model, you need to handle both the **write path** (Dart → native) and the **read path** (native → Dart). Both must be tested.
+If you're adding a new field to an existing model, you need to handle both the **write path** (Dart → native) and the **read path** (native → Dart). Both must be tested. (Read-only fields only have a read path — test that.)
 
 ## Testing
 

--- a/packages/device_calendar_plus/CHANGELOG.md
+++ b/packages/device_calendar_plus/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+### Added
+- `Event.colorHex` — the event's custom color as `#RRGGBB`, with a parsed
+  `Event.color` getter (read-only, mirrors `Calendar.colorHex`). Android reads
+  the event's custom color (`EVENT_COLOR`), `null` when the event uses its
+  calendar's color; iOS always reports `null` (EventKit has no per-event
+  color). No write support (#117).
+
 ### Changed
 - **Breaking:** `WeeklyRecurrence`'s `wkst` field and constructor parameter are
   renamed to `weekStart`, matching the spelled-out naming of the other

--- a/packages/device_calendar_plus/doc/events.md
+++ b/packages/device_calendar_plus/doc/events.md
@@ -62,6 +62,18 @@ final event = await plugin.getEvent(id); // null if not found
 `id` may be an event ID (the master, for a recurring series) or an instance ID
 (a specific occurrence). See [recurring-events.md](recurring-events.md).
 
+## Event color (read-only)
+
+`Event.colorHex` is the event's custom color as `#RRGGBB` (with a parsed
+`Event.color` getter). It is read-only and platform-specific:
+
+- **Android** reads the event's custom color (`EVENT_COLOR`), e.g. one set in
+  Google Calendar. It's `null` when the event just uses its calendar's color.
+- **iOS** always reports `null` — EventKit has no per-event color.
+
+There is no write support; `createEvent`/`updateEvent` don't accept a color.
+For the calendar's own color, see [calendars.md](calendars.md).
+
 ## Update
 
 Pass an event ID to update the event (the whole series when recurring), or an

--- a/packages/device_calendar_plus/example/android/app/src/main/kotlin/to/bullet/example/MainActivity.kt
+++ b/packages/device_calendar_plus/example/android/app/src/main/kotlin/to/bullet/example/MainActivity.kt
@@ -1,5 +1,55 @@
 package to.bullet.example
 
+import android.content.ContentUris
+import android.content.ContentValues
+import android.provider.CalendarContract
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        // Test-only channel used by the integration tests to seed calendar
+        // provider state the plugin deliberately can't write itself.
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "to.bullet.device_calendar_plus_example/test"
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                // EVENT_COLOR is sync-adapter-owned, so stamp it the way a
+                // sync adapter would: a CALLER_IS_SYNCADAPTER update scoped to
+                // the plugin's local test account. This simulates an external
+                // app (e.g. Google Calendar) assigning a custom event color.
+                "setEventColor" -> {
+                    try {
+                        val eventId = call.argument<String>("eventId")!!.toLong()
+                        val color = call.argument<Number>("color")!!.toInt()
+                        val uri = ContentUris
+                            .withAppendedId(CalendarContract.Events.CONTENT_URI, eventId)
+                            .buildUpon()
+                            .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
+                            // Plugin-created local calendars use account name
+                            // "local" with ACCOUNT_TYPE_LOCAL (see the plugin's
+                            // CalendarService.createCalendar).
+                            .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME, "local")
+                            .appendQueryParameter(
+                                CalendarContract.Calendars.ACCOUNT_TYPE,
+                                CalendarContract.ACCOUNT_TYPE_LOCAL
+                            )
+                            .build()
+                        val values = ContentValues().apply {
+                            put(CalendarContract.Events.EVENT_COLOR, color)
+                        }
+                        val updated = contentResolver.update(uri, values, null, null)
+                        result.success(updated)
+                    } catch (e: Exception) {
+                        result.error("TEST_SEED_FAILED", e.message, null)
+                    }
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+}

--- a/packages/device_calendar_plus/example/android/app/src/main/kotlin/to/bullet/example/MainActivity.kt
+++ b/packages/device_calendar_plus/example/android/app/src/main/kotlin/to/bullet/example/MainActivity.kt
@@ -1,55 +1,11 @@
 package to.bullet.example
 
-import android.content.ContentUris
-import android.content.ContentValues
-import android.provider.CalendarContract
 import io.flutter.embedding.android.FlutterActivity
 import io.flutter.embedding.engine.FlutterEngine
-import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity() {
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
-
-        // Test-only channel used by the integration tests to seed calendar
-        // provider state the plugin deliberately can't write itself.
-        MethodChannel(
-            flutterEngine.dartExecutor.binaryMessenger,
-            "to.bullet.device_calendar_plus_example/test"
-        ).setMethodCallHandler { call, result ->
-            when (call.method) {
-                // EVENT_COLOR is sync-adapter-owned, so stamp it the way a
-                // sync adapter would: a CALLER_IS_SYNCADAPTER update scoped to
-                // the plugin's local test account. This simulates an external
-                // app (e.g. Google Calendar) assigning a custom event color.
-                "setEventColor" -> {
-                    try {
-                        val eventId = call.argument<String>("eventId")!!.toLong()
-                        val color = call.argument<Number>("color")!!.toInt()
-                        val uri = ContentUris
-                            .withAppendedId(CalendarContract.Events.CONTENT_URI, eventId)
-                            .buildUpon()
-                            .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
-                            // Plugin-created local calendars use account name
-                            // "local" with ACCOUNT_TYPE_LOCAL (see the plugin's
-                            // CalendarService.createCalendar).
-                            .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME, "local")
-                            .appendQueryParameter(
-                                CalendarContract.Calendars.ACCOUNT_TYPE,
-                                CalendarContract.ACCOUNT_TYPE_LOCAL
-                            )
-                            .build()
-                        val values = ContentValues().apply {
-                            put(CalendarContract.Events.EVENT_COLOR, color)
-                        }
-                        val updated = contentResolver.update(uri, values, null, null)
-                        result.success(updated)
-                    } catch (e: Exception) {
-                        result.error("TEST_SEED_FAILED", e.message, null)
-                    }
-                }
-                else -> result.notImplemented()
-            }
-        }
+        TestSeedChannel.register(flutterEngine, contentResolver)
     }
 }

--- a/packages/device_calendar_plus/example/android/app/src/main/kotlin/to/bullet/example/TestSeedChannel.kt
+++ b/packages/device_calendar_plus/example/android/app/src/main/kotlin/to/bullet/example/TestSeedChannel.kt
@@ -1,0 +1,55 @@
+package to.bullet.example
+
+import android.content.ContentResolver
+import android.content.ContentUris
+import android.content.ContentValues
+import android.provider.CalendarContract
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+
+/**
+ * Test-only channel used by the integration tests to seed calendar
+ * provider state the plugin deliberately can't write itself.
+ */
+object TestSeedChannel {
+    fun register(flutterEngine: FlutterEngine, contentResolver: ContentResolver) {
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "to.bullet.device_calendar_plus_example/test"
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                // EVENT_COLOR is sync-adapter-owned, so stamp it the way a
+                // sync adapter would: a CALLER_IS_SYNCADAPTER update scoped to
+                // the plugin's local test account. This simulates an external
+                // app (e.g. Google Calendar) assigning a custom event color.
+                "setEventColor" -> {
+                    try {
+                        val eventId = call.argument<String>("eventId")!!.toLong()
+                        val color = call.argument<Number>("color")!!.toInt()
+                        val uri = ContentUris
+                            .withAppendedId(CalendarContract.Events.CONTENT_URI, eventId)
+                            .buildUpon()
+                            .appendQueryParameter(CalendarContract.CALLER_IS_SYNCADAPTER, "true")
+                            // Plugin-created local calendars use account name
+                            // "local" with ACCOUNT_TYPE_LOCAL (see the plugin's
+                            // CalendarService.createCalendar).
+                            .appendQueryParameter(CalendarContract.Calendars.ACCOUNT_NAME, "local")
+                            .appendQueryParameter(
+                                CalendarContract.Calendars.ACCOUNT_TYPE,
+                                CalendarContract.ACCOUNT_TYPE_LOCAL
+                            )
+                            .build()
+                        val values = ContentValues().apply {
+                            put(CalendarContract.Events.EVENT_COLOR, color)
+                        }
+                        val updated = contentResolver.update(uri, values, null, null)
+                        result.success(updated)
+                    } catch (e: Exception) {
+                        result.error("TEST_SEED_FAILED", e.message, null)
+                    }
+                }
+                else -> result.notImplemented()
+            }
+        }
+    }
+}

--- a/packages/device_calendar_plus/example/integration_test/device_calendar_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/device_calendar_test.dart
@@ -499,22 +499,38 @@ void main() {
       // getEvent should also return the url
       final fetched = await plugin.getEvent(eventId);
       expect(fetched?.url, eventUrl);
+    });
 
+    test('getEvent leaves colorHex null when the event has no custom color',
+        () async {
       // Plugin-created events have no custom per-event color: Android only
       // sets EVENT_COLOR when something external (e.g. Google Calendar)
       // assigns one, and iOS has no per-event color at all — so colorHex is
       // null on both platforms.
+      final timestamp = DateTime.now().millisecondsSinceEpoch;
+      final calendarId = await plugin.createCalendar(
+        name: 'Event Color Null Test $timestamp',
+      );
+      createdCalendarIds.add(calendarId);
+
+      final now = DateTime.now();
+      final eventId = await plugin.createEvent(
+        calendarId: calendarId,
+        title: 'Event Without Custom Color',
+        startDate: DateTime(now.year, now.month, now.day, 13, 0),
+        endDate: DateTime(now.year, now.month, now.day, 14, 0),
+      );
+      expect(eventId, isNotEmpty);
+
+      final fetched = await plugin.getEvent(eventId);
+      expect(fetched, isNotNull);
       expect(fetched?.colorHex, isNull);
+      expect(fetched?.color, isNull);
     });
 
-    test('getEvent returns colorHex when EVENT_COLOR is set (Android)',
-        () async {
+    test('Read colorHex when EVENT_COLOR is set (Android)', () async {
       // Android-only: iOS has no per-event color, so there is nothing to
-      // seed there (the null contract is asserted above).
-      if (!Platform.isAndroid) {
-        return;
-      }
-
+      // seed there (the null contract is asserted in the test above).
       final timestamp = DateTime.now().millisecondsSinceEpoch;
       final calendarId = await plugin.createCalendar(
         name: 'Event Color Test $timestamp',
@@ -522,11 +538,13 @@ void main() {
       createdCalendarIds.add(calendarId);
 
       final now = DateTime.now();
+      final startDate = DateTime(now.year, now.month, now.day, 13, 0);
+      final endDate = DateTime(now.year, now.month, now.day, 14, 0);
       final eventId = await plugin.createEvent(
         calendarId: calendarId,
         title: 'Event With Custom Color',
-        startDate: DateTime(now.year, now.month, now.day, 13, 0),
-        endDate: DateTime(now.year, now.month, now.day, 14, 0),
+        startDate: startDate,
+        endDate: endDate,
       );
       expect(eventId, isNotEmpty);
 
@@ -542,10 +560,23 @@ void main() {
       });
       expect(updated, 1);
 
+      // getEvent reads via the Events projection.
       final fetched = await plugin.getEvent(eventId);
       expect(fetched?.colorHex, '#FF0000');
       expect(fetched?.color, const Color(0xFFFF0000));
-    });
+
+      // listEvents reads via the separate Instances projection, so assert
+      // through it too — dropping EVENT_COLOR from either read path should
+      // fail this test.
+      final events = await plugin.listEvents(
+        startDate.subtract(Duration(hours: 1)),
+        endDate.add(Duration(hours: 1)),
+        calendarIds: [calendarId],
+      );
+      final instance = events.firstWhere((e) => e.eventId == eventId);
+      expect(instance.colorHex, '#FF0000');
+      expect(instance.color, const Color(0xFFFF0000));
+    }, skip: !Platform.isAndroid);
 
     test('Create Event without URL leaves url null', () async {
       // Sanity check: omitting url must not accidentally populate the field.

--- a/packages/device_calendar_plus/example/integration_test/device_calendar_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/device_calendar_test.dart
@@ -514,11 +514,13 @@ void main() {
       createdCalendarIds.add(calendarId);
 
       final now = DateTime.now();
+      final startDate = DateTime(now.year, now.month, now.day, 13, 0);
+      final endDate = DateTime(now.year, now.month, now.day, 14, 0);
       final eventId = await plugin.createEvent(
         calendarId: calendarId,
         title: 'Event Without Custom Color',
-        startDate: DateTime(now.year, now.month, now.day, 13, 0),
-        endDate: DateTime(now.year, now.month, now.day, 14, 0),
+        startDate: startDate,
+        endDate: endDate,
       );
       expect(eventId, isNotEmpty);
 
@@ -526,6 +528,19 @@ void main() {
       expect(fetched, isNotNull);
       expect(fetched?.colorHex, isNull);
       expect(fetched?.color, isNull);
+
+      // listEvents reads via the separate Instances projection (Android), so
+      // assert the null contract through it too — an unset EVENT_COLOR that
+      // reads as 0 instead of NULL there would surface a spurious '#000000'
+      // via listEvents while getEvent stays null.
+      final events = await plugin.listEvents(
+        startDate.subtract(Duration(hours: 1)),
+        endDate.add(Duration(hours: 1)),
+        calendarIds: [calendarId],
+      );
+      final instance = events.firstWhere((e) => e.eventId == eventId);
+      expect(instance.colorHex, isNull);
+      expect(instance.color, isNull);
     });
 
     test('Read colorHex when EVENT_COLOR is set (Android)', () async {

--- a/packages/device_calendar_plus/example/integration_test/device_calendar_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/device_calendar_test.dart
@@ -1,6 +1,8 @@
 import 'dart:io' show Platform;
+import 'dart:ui' show Color;
 
 import 'package:device_calendar_plus/device_calendar_plus.dart';
+import 'package:flutter/services.dart' show MethodChannel;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -497,6 +499,52 @@ void main() {
       // getEvent should also return the url
       final fetched = await plugin.getEvent(eventId);
       expect(fetched?.url, eventUrl);
+
+      // Plugin-created events have no custom per-event color: Android only
+      // sets EVENT_COLOR when something external (e.g. Google Calendar)
+      // assigns one, and iOS has no per-event color at all — so colorHex is
+      // null on both platforms.
+      expect(fetched?.colorHex, isNull);
+    });
+
+    test('getEvent returns colorHex when EVENT_COLOR is set (Android)',
+        () async {
+      // Android-only: iOS has no per-event color, so there is nothing to
+      // seed there (the null contract is asserted above).
+      if (!Platform.isAndroid) {
+        return;
+      }
+
+      final timestamp = DateTime.now().millisecondsSinceEpoch;
+      final calendarId = await plugin.createCalendar(
+        name: 'Event Color Test $timestamp',
+      );
+      createdCalendarIds.add(calendarId);
+
+      final now = DateTime.now();
+      final eventId = await plugin.createEvent(
+        calendarId: calendarId,
+        title: 'Event With Custom Color',
+        startDate: DateTime(now.year, now.month, now.day, 13, 0),
+        endDate: DateTime(now.year, now.month, now.day, 14, 0),
+      );
+      expect(eventId, isNotEmpty);
+
+      // EVENT_COLOR is sync-adapter-owned, so the plugin can't write it. The
+      // example app exposes a test-only channel that stamps it directly via
+      // ContentResolver using a sync-adapter URI on the local test calendar,
+      // simulating a color set externally (e.g. in Google Calendar).
+      final updated = await const MethodChannel(
+        'to.bullet.device_calendar_plus_example/test',
+      ).invokeMethod<int>('setEventColor', {
+        'eventId': eventId,
+        'color': 0xFFFF0000,
+      });
+      expect(updated, 1);
+
+      final fetched = await plugin.getEvent(eventId);
+      expect(fetched?.colorHex, '#FF0000');
+      expect(fetched?.color, const Color(0xFFFF0000));
     });
 
     test('Create Event without URL leaves url null', () async {

--- a/packages/device_calendar_plus/example/integration_test/device_calendar_test.dart
+++ b/packages/device_calendar_plus/example/integration_test/device_calendar_test.dart
@@ -501,8 +501,9 @@ void main() {
       expect(fetched?.url, eventUrl);
     });
 
-    test('getEvent leaves colorHex null when the event has no custom color',
-        () async {
+    test(
+        'colorHex is null via getEvent and listEvents when the event has no '
+        'custom color', () async {
       // Plugin-created events have no custom per-event color: Android only
       // sets EVENT_COLOR when something external (e.g. Google Calendar)
       // assigns one, and iOS has no per-event color at all — so colorHex is

--- a/packages/device_calendar_plus/lib/src/calendar.dart
+++ b/packages/device_calendar_plus/lib/src/calendar.dart
@@ -1,5 +1,7 @@
 import 'dart:ui' show Color;
 
+import 'color_hex.dart';
+
 /// Represents a user's calendar
 class Calendar {
   /// Identifier returned by the platform.
@@ -12,14 +14,7 @@ class Calendar {
   final String? colorHex;
 
   /// Parsed [colorHex] as a Flutter [Color], or `null` if absent or unparseable.
-  Color? get color {
-    final hex = colorHex;
-    if (hex == null) return null;
-    final cleaned = hex.startsWith('#') ? hex.substring(1) : hex;
-    final value = int.tryParse(cleaned, radix: 16);
-    if (value == null) return null;
-    return Color(cleaned.length == 6 ? value | 0xFF000000 : value);
-  }
+  Color? get color => colorFromHex(colorHex);
 
   /// Whether edits are disallowed (subscribed/shared calendars, server-managed feeds, etc.).
   final bool readOnly;

--- a/packages/device_calendar_plus/lib/src/color_hex.dart
+++ b/packages/device_calendar_plus/lib/src/color_hex.dart
@@ -1,0 +1,16 @@
+import 'dart:ui' show Color;
+
+/// Parses a hex color string into a [Color].
+///
+/// Accepts `#RRGGBB` or `#AARRGGBB` (the `#` prefix is optional). 6-digit
+/// values are treated as fully opaque; 8-digit values keep their own alpha.
+/// Returns `null` when [hex] is `null` or unparseable.
+///
+/// Package-internal: shared by `Calendar.color` and `Event.color`.
+Color? colorFromHex(String? hex) {
+  if (hex == null) return null;
+  final cleaned = hex.startsWith('#') ? hex.substring(1) : hex;
+  final value = int.tryParse(cleaned, radix: 16);
+  if (value == null) return null;
+  return Color(cleaned.length == 6 ? value | 0xFF000000 : value);
+}

--- a/packages/device_calendar_plus/lib/src/event.dart
+++ b/packages/device_calendar_plus/lib/src/event.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show Color;
+
 import 'package:flutter/foundation.dart';
 
 import 'attendee.dart';
@@ -87,6 +89,25 @@ class Event {
   /// through the plugin on Android.
   final String? url;
 
+  /// Custom per-event color as a hex string in `#RRGGBB` format (read-only).
+  ///
+  /// Android only: read from the event's custom color when one is set (for
+  /// example by Google Calendar), `null` when the event uses its calendar's
+  /// color. iOS always reports `null` — EventKit has no per-event color.
+  ///
+  /// The plugin does not support writing this field.
+  final String? colorHex;
+
+  /// Parsed [colorHex] as a Flutter [Color], or `null` if absent or unparseable.
+  Color? get color {
+    final hex = colorHex;
+    if (hex == null) return null;
+    final cleaned = hex.startsWith('#') ? hex.substring(1) : hex;
+    final value = int.tryParse(cleaned, radix: 16);
+    if (value == null) return null;
+    return Color(cleaned.length == 6 ? value | 0xFF000000 : value);
+  }
+
   Event({
     required this.eventId,
     required this.instanceId,
@@ -105,6 +126,7 @@ class Event {
     this.attendees,
     this.reminders,
     this.url,
+    this.colorHex,
   });
 
   /// Creates an Event from a map returned by the platform.
@@ -136,6 +158,7 @@ class Event {
           ?.map((m) => Duration(minutes: (m as num).toInt()))
           .toList(),
       url: map['url'] as String?,
+      colorHex: map['colorHex'] as String?,
     );
   }
 
@@ -158,6 +181,7 @@ class Event {
     if (location != null) map['location'] = location;
     if (timeZone != null) map['timeZone'] = timeZone;
     if (url != null) map['url'] = url;
+    if (colorHex != null) map['colorHex'] = colorHex;
     if (recurrenceRule != null) {
       map['recurrenceRule'] = recurrenceRule!.rruleString;
     }
@@ -199,7 +223,8 @@ class Event {
         other.recurrenceRule == recurrenceRule &&
         listEquals(other.attendees, attendees) &&
         listEquals(other.reminders, reminders) &&
-        other.url == url;
+        other.url == url &&
+        other.colorHex == colorHex;
   }
 
   @override
@@ -222,6 +247,7 @@ class Event {
       attendees != null ? Object.hashAll(attendees!) : null,
       reminders != null ? Object.hashAll(reminders!) : null,
       url,
+      colorHex,
     );
   }
 }

--- a/packages/device_calendar_plus/lib/src/event.dart
+++ b/packages/device_calendar_plus/lib/src/event.dart
@@ -3,6 +3,7 @@ import 'dart:ui' show Color;
 import 'package:flutter/foundation.dart';
 
 import 'attendee.dart';
+import 'color_hex.dart';
 import 'event_availability.dart';
 import 'event_status.dart';
 import 'recurrence_rule.dart';
@@ -99,14 +100,7 @@ class Event {
   final String? colorHex;
 
   /// Parsed [colorHex] as a Flutter [Color], or `null` if absent or unparseable.
-  Color? get color {
-    final hex = colorHex;
-    if (hex == null) return null;
-    final cleaned = hex.startsWith('#') ? hex.substring(1) : hex;
-    final value = int.tryParse(cleaned, radix: 16);
-    if (value == null) return null;
-    return Color(cleaned.length == 6 ? value | 0xFF000000 : value);
-  }
+  Color? get color => colorFromHex(colorHex);
 
   Event({
     required this.eventId,

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -1625,5 +1625,24 @@ void main() {
         expect(event.toMap().containsKey('reminders'), isFalse);
       });
     });
+
+    group('color', () {
+      test('parses colorHex into a Color', () {
+        final event = Event.fromMap(baseMap()..['colorHex'] = '#FF0000');
+        expect(event.colorHex, '#FF0000');
+        expect(event.color, const Color(0xFFFF0000));
+      });
+
+      test('is null when the platform reports no colorHex', () {
+        final event = Event.fromMap(baseMap());
+        expect(event.colorHex, isNull);
+        expect(event.color, isNull);
+      });
+
+      test('is null for an unparseable colorHex', () {
+        final event = Event.fromMap(baseMap()..['colorHex'] = 'notacolor');
+        expect(event.color, isNull);
+      });
+    });
   });
 }

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -1,5 +1,3 @@
-import 'dart:ui' show Color;
-
 import 'package:device_calendar_plus/device_calendar_plus.dart';
 import 'package:device_calendar_plus_platform_interface/device_calendar_plus_platform_interface.dart';
 import 'package:flutter/services.dart';
@@ -1628,14 +1626,9 @@ void main() {
       });
     });
 
-    group('colorHex', () {
-      // Hex parsing itself is covered once, in the Calendar.color group
-      // (Event.color delegates to the same shared helper).
-      test('fromMap carries colorHex through to the model', () {
-        final event = Event.fromMap(baseMap()..['colorHex'] = '#FF0000');
-        expect(event.colorHex, '#FF0000');
-        expect(Event.fromMap(baseMap()).colorHex, isNull);
-      });
-    });
+    // colorHex is a branchless fromMap passthrough (testing.md: don't
+    // unit-test trivial model properties). The read path is covered by the
+    // colorHex integration tests, and hex parsing by the Calendar.color
+    // group above (Event.color delegates to the same shared helper).
   });
 }

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -1546,6 +1546,8 @@ void main() {
     });
   });
 
+  // Single parsing suite for the shared colorFromHex helper, which also backs
+  // Event.color (a trivial delegating getter, so it isn't re-tested there).
   group('Calendar.color', () {
     Calendar cal({String? colorHex}) => Calendar(
           id: '1',
@@ -1626,22 +1628,13 @@ void main() {
       });
     });
 
-    group('color', () {
-      test('parses colorHex into a Color', () {
+    group('colorHex', () {
+      // Hex parsing itself is covered once, in the Calendar.color group
+      // (Event.color delegates to the same shared helper).
+      test('fromMap carries colorHex through to the model', () {
         final event = Event.fromMap(baseMap()..['colorHex'] = '#FF0000');
         expect(event.colorHex, '#FF0000');
-        expect(event.color, const Color(0xFFFF0000));
-      });
-
-      test('is null when the platform reports no colorHex', () {
-        final event = Event.fromMap(baseMap());
-        expect(event.colorHex, isNull);
-        expect(event.color, isNull);
-      });
-
-      test('is null for an unparseable colorHex', () {
-        final event = Event.fromMap(baseMap()..['colorHex'] = 'notacolor');
-        expect(event.color, isNull);
+        expect(Event.fromMap(baseMap()).colorHex, isNull);
       });
     });
   });

--- a/packages/device_calendar_plus_android/CHANGELOG.md
+++ b/packages/device_calendar_plus_android/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Added
+- Event maps include `colorHex` read from `Events.EVENT_COLOR` when the event
+  has a custom color; absent otherwise (#117).
+
 ## 0.7.0 - 2026-06-17
 
 ### Added

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -53,7 +53,8 @@ class EventsService(
             CalendarContract.Instances.STATUS,
             CalendarContract.Instances.EVENT_TIMEZONE,
             CalendarContract.Instances.RRULE,
-            CalendarContract.Instances.CUSTOM_APP_URI
+            CalendarContract.Instances.CUSTOM_APP_URI,
+            CalendarContract.Instances.EVENT_COLOR
         )
 
         val selections = mutableListOf<String>()
@@ -109,7 +110,8 @@ class EventsService(
                         CalendarContract.Instances.STATUS,
                         CalendarContract.Instances.EVENT_TIMEZONE,
                         CalendarContract.Instances.RRULE,
-                        urlColumn = CalendarContract.Instances.CUSTOM_APP_URI
+                        urlColumn = CalendarContract.Instances.CUSTOM_APP_URI,
+                        eventColorColumn = CalendarContract.Instances.EVENT_COLOR
                     )
                     events.add(eventMap)
                 }
@@ -205,7 +207,8 @@ class EventsService(
         recurrenceRuleColumn: String,
         createdColumn: String? = null,
         lastModifiedColumn: String? = null,
-        urlColumn: String? = null
+        urlColumn: String? = null,
+        eventColorColumn: String? = null
     ): Map<String, Any> {
         val eventIdIndex = cursor.getColumnIndex(eventIdColumn)
         val calendarIdIndex = cursor.getColumnIndex(calendarIdColumn)
@@ -222,6 +225,7 @@ class EventsService(
         val createdIndex = if (createdColumn != null) cursor.getColumnIndex(createdColumn) else -1
         val lastModifiedIndex = if (lastModifiedColumn != null) cursor.getColumnIndex(lastModifiedColumn) else -1
         val urlIndex = if (urlColumn != null) cursor.getColumnIndex(urlColumn) else -1
+        val eventColorIndex = if (eventColorColumn != null) cursor.getColumnIndex(eventColorColumn) else -1
         
         val eventId = cursor.getString(eventIdIndex)
         val calendarId = cursor.getString(calendarIdIndex)
@@ -238,6 +242,7 @@ class EventsService(
         val createdDate = if (createdIndex >= 0 && !cursor.isNull(createdIndex)) cursor.getLong(createdIndex) else null
         val lastModifiedDate = if (lastModifiedIndex >= 0 && !cursor.isNull(lastModifiedIndex)) cursor.getLong(lastModifiedIndex) else null
         val url = if (urlIndex >= 0 && !cursor.isNull(urlIndex)) cursor.getString(urlIndex) else null
+        val eventColor = if (eventColorIndex >= 0 && !cursor.isNull(eventColorIndex)) cursor.getInt(eventColorIndex) else null
         
         // Generate instanceId using RAW timestamps before any modifications
         val instanceId: String = if (recurrenceRule != null) {
@@ -296,6 +301,12 @@ class EventsService(
         // Add URL if available (Android: CUSTOM_APP_URI)
         if (url != null) {
             eventMap["url"] = url
+        }
+
+        // Custom per-event color (EVENT_COLOR), read-only. Null when the event
+        // uses the calendar's color.
+        if (eventColor != null) {
+            eventMap["colorHex"] = ColorHelper.colorToHex(eventColor)
         }
 
         // Query attendees
@@ -469,7 +480,8 @@ class EventsService(
                 CalendarContract.Events.STATUS,
                 CalendarContract.Events.EVENT_TIMEZONE,
                 CalendarContract.Events.RRULE,
-                CalendarContract.Events.CUSTOM_APP_URI
+                CalendarContract.Events.CUSTOM_APP_URI,
+                CalendarContract.Events.EVENT_COLOR
             )
             
             val selection = "${CalendarContract.Events._ID} = ?"
@@ -498,7 +510,8 @@ class EventsService(
                             CalendarContract.Events.STATUS,
                             CalendarContract.Events.EVENT_TIMEZONE,
                             CalendarContract.Events.RRULE,
-                            urlColumn = CalendarContract.Events.CUSTOM_APP_URI
+                            urlColumn = CalendarContract.Events.CUSTOM_APP_URI,
+                            eventColorColumn = CalendarContract.Events.EVENT_COLOR
                         )
                         return Result.success(eventMap)
                     } else {

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -110,8 +110,7 @@ class EventsService(
                         CalendarContract.Instances.STATUS,
                         CalendarContract.Instances.EVENT_TIMEZONE,
                         CalendarContract.Instances.RRULE,
-                        urlColumn = CalendarContract.Instances.CUSTOM_APP_URI,
-                        eventColorColumn = CalendarContract.Instances.EVENT_COLOR
+                        urlColumn = CalendarContract.Instances.CUSTOM_APP_URI
                     )
                     events.add(eventMap)
                 }
@@ -207,8 +206,7 @@ class EventsService(
         recurrenceRuleColumn: String,
         createdColumn: String? = null,
         lastModifiedColumn: String? = null,
-        urlColumn: String? = null,
-        eventColorColumn: String? = null
+        urlColumn: String? = null
     ): Map<String, Any> {
         val eventIdIndex = cursor.getColumnIndex(eventIdColumn)
         val calendarIdIndex = cursor.getColumnIndex(calendarIdColumn)
@@ -225,7 +223,10 @@ class EventsService(
         val createdIndex = if (createdColumn != null) cursor.getColumnIndex(createdColumn) else -1
         val lastModifiedIndex = if (lastModifiedColumn != null) cursor.getColumnIndex(lastModifiedColumn) else -1
         val urlIndex = if (urlColumn != null) cursor.getColumnIndex(urlColumn) else -1
-        val eventColorIndex = if (eventColorColumn != null) cursor.getColumnIndex(eventColorColumn) else -1
+        // Instances implements EventsColumns, so EVENT_COLOR is the same
+        // column name through both content URIs — no per-call-site parameter
+        // needed. The index >= 0 guard below covers projections without it.
+        val eventColorIndex = cursor.getColumnIndex(CalendarContract.Events.EVENT_COLOR)
         
         val eventId = cursor.getString(eventIdIndex)
         val calendarId = cursor.getString(calendarIdIndex)
@@ -510,8 +511,7 @@ class EventsService(
                             CalendarContract.Events.STATUS,
                             CalendarContract.Events.EVENT_TIMEZONE,
                             CalendarContract.Events.RRULE,
-                            urlColumn = CalendarContract.Events.CUSTOM_APP_URI,
-                            eventColorColumn = CalendarContract.Events.EVENT_COLOR
+                            urlColumn = CalendarContract.Events.CUSTOM_APP_URI
                         )
                         return Result.success(eventMap)
                     } else {


### PR DESCRIPTION
Closes #117.

## What

Adds `Event.colorHex` — the event's custom color as a `#RRGGBB` string, with a parsed `Event.color` getter — mirroring the existing `Calendar.colorHex` pattern.

- **Android** reads `CalendarContract.Events.EVENT_COLOR` (both the Instances query and `getEvent`) and converts the ARGB int to hex via the same `ColorHelper.colorToHex` used for calendar colors. `null` when the event has no custom color.
- **iOS** always reports `null` — EventKit has no per-event color. (No iOS code change needed; the key is simply absent from the event map.)
- **Read-only**: create/update paths are untouched; no way to write the color.

Also, as required by the spec: `.claude/rules/api-design.md`'s "Cross-platform consistency" section is now scoped to writes/mutations — read-only data MAY be exposed as a nullable platform-specific field when only one platform provides it, with the per-platform behaviour documented on the field and no write support unless both platforms have it.

Docs: events topic guide gets an "Event color (read-only)" section with the platform note; changelog entries in the app-facing and Android packages.

## Verification

Auto-verified (no UI change):
- `flutter analyze`: clean (same 6 pre-existing infos as main, verified against a stashed baseline)
- Unit tests: all pass (`device_calendar_plus` 200, platform interface 18, android 8). No new unit tests for `Event.colorHex`/`Event.color` — those are trivial model passthroughs, which `testing.md` says not to unit-test. Hex parsing stays covered once, via the `Calendar.color` group over the shared `colorFromHex` helper.
- Android Kotlin compiles: example `flutter build apk --debug` succeeds

The read path is owned by two new integration tests: the null contract (event with no custom color → `colorHex` is `null`) on both platforms, and on Android a seeded `EVENT_COLOR` — stamped via a sync-adapter update through the example app's test channel — asserted through both `getEvent` and `listEvents`, so the two projections can't silently drift apart.

Device runs (2026-07-22, at the current head):
- **Android**: `./run_integration_tests.sh emulator-5554` (API 34 emulator) — 86 passed / 5 skipped at each of the three timezone cycles (America/Los_Angeles, UTC, Australia/Sydney). This exercises the seeded-color test for real: the sync-adapter `EVENT_COLOR` update returned 1 and `#FF0000` read back through both the `getEvent` and `listEvents` projections.
- **iOS**: `./run_integration_tests.sh` on an iPhone 17 Pro simulator (iOS 26.3) — 86 passed / 5 skipped, covering the null-`colorHex` contract on iOS (the Android-only seeded test is among the skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
