### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/packages/device_calendar_plus/CHANGELOG.md
+++ b/packages/device_calendar_plus/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.8.0 - 2026-07-22
 
 ### Added
 - `Event.colorHex` — the event's custom color as `#RRGGBB`, with a parsed

--- a/packages/device_calendar_plus/pubspec.yaml
+++ b/packages/device_calendar_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus
 description: A modern, maintained Flutter plugin for reading and writing device calendar events on Android and iOS.
-version: 0.7.1
+version: 0.8.0
 repository: https://github.com/bullet-to/device_calendar_plus
 issue_tracker: https://github.com/bullet-to/device_calendar_plus/issues
 

--- a/packages/device_calendar_plus_android/CHANGELOG.md
+++ b/packages/device_calendar_plus_android/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 0.7.1 - 2026-07-22
 
 ### Added
 - Event maps include `colorHex` read from `Events.EVENT_COLOR` when the event

--- a/packages/device_calendar_plus_android/pubspec.yaml
+++ b/packages/device_calendar_plus_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_calendar_plus_android
 description: Android implementation of the device_calendar_plus plugin.
-version: 0.7.0
+version: 0.7.1
 repository: https://github.com/bullet-to/device_calendar_plus
 
 resolution: workspace


### PR DESCRIPTION
Release prep — bumps and dated changelogs, nothing else.

- **device_calendar_plus 0.7.1 → 0.8.0** — breaking `WeeklyRecurrence.wkst` → `weekStart` rename, plus the new read-only `Event.colorHex` (#117)
- **device_calendar_plus_android 0.7.0 → 0.7.1** — event maps carry `colorHex` from `EVENT_COLOR`
- platform interface and iOS are untouched since 0.7.0, so they sit this one out

Both shipping packages pass `dart pub publish --dry-run`. After merge: tag `v0.8.0` and publish the two packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)