### PR TITLE
Drop needless permission gates on showCreateEventModal + align the rest with the documented contract

### DIFF
--- a/packages/device_calendar_plus/doc/native-ui.md
+++ b/packages/device_calendar_plus/doc/native-ui.md
@@ -41,5 +41,12 @@ await plugin.showCreateEventModal(
 );
 ```
 
-All fields are optional. `showCreateEventModal` works with write-only access;
+All fields are optional.
+
+`showCreateEventModal` needs **no calendar permission** on Android or iOS 17+ —
+the system editor saves the event with its own access. That makes it a handy
+fallback when the user has denied access: a silent `createEvent` when granted,
+the pre-filled native form otherwise. On iOS 16 and below the editor runs
+in-process and requires full access.
+
 `showEventModal` requires full access.

--- a/packages/device_calendar_plus/doc/permissions.md
+++ b/packages/device_calendar_plus/doc/permissions.md
@@ -1,7 +1,9 @@
 # Permissions
 
 All read/write operations require calendar permission. You can request it
-yourself, or let the plugin request it on first use.
+yourself, or let the plugin request it on first use. (The one exception is
+`showCreateEventModal`, which hands off to the system editor and needs no
+permission on Android or iOS 17+.)
 
 ## Request and check
 
@@ -40,8 +42,10 @@ if (status == CalendarPermissionStatus.writeOnly ||
 }
 ```
 
-Write-only covers `createEvent` and `showCreateEventModal`. Everything else —
-reading, updating, deleting, listing calendars — needs full access. Write-only
+Write-only covers `createEvent`. Everything else — reading, updating, deleting,
+listing calendars — needs full access, except `showCreateEventModal`, which
+needs no permission at all on Android or iOS 17+ (see
+[Native UI](native-ui.md)). Write-only
 is not a ceiling: call `requestPermissions(level: CalendarAccessLevel.full)`
 later to upgrade in-app. On Android the upgrade is granted immediately with no
 second dialog (`READ_CALENDAR` and `WRITE_CALENDAR` share one permission group);

--- a/packages/device_calendar_plus/doc/permissions.md
+++ b/packages/device_calendar_plus/doc/permissions.md
@@ -45,7 +45,14 @@ if (status == CalendarPermissionStatus.writeOnly ||
 Write-only covers `createEvent`. Everything else — reading, updating, deleting,
 listing calendars — needs full access, except `showCreateEventModal`, which
 needs no permission at all on Android or iOS 17+ (see
-[Native UI](native-ui.md)). Write-only
+[Native UI](native-ui.md)).
+
+Under write-only, `createEvent` reaches different calendars per platform: iOS
+can only write into the *default* calendar (a named `calendarId` needs full
+access to look up), while Android needs an explicit `calendarId` (resolving the
+default reads the calendar list, which needs full access). An add-only app that
+sticks to write-only should omit `calendarId` on iOS and supply one on Android —
+or use `showCreateEventModal`, which needs neither. Write-only
 is not a ceiling: call `requestPermissions(level: CalendarAccessLevel.full)`
 later to upgrade in-app. On Android the upgrade is granted immediately with no
 second dialog (`READ_CALENDAR` and `WRITE_CALENDAR` share one permission group);

--- a/packages/device_calendar_plus/doc/permissions.md
+++ b/packages/device_calendar_plus/doc/permissions.md
@@ -2,8 +2,7 @@
 
 All read/write operations require calendar permission. You can request it
 yourself, or let the plugin request it on first use. (The one exception is
-`showCreateEventModal`, which hands off to the system editor and needs no
-permission on Android or iOS 17+.)
+`showCreateEventModal` — see [Native UI](native-ui.md).)
 
 ## Request and check
 

--- a/packages/device_calendar_plus/example/ios/Runner/Info.plist
+++ b/packages/device_calendar_plus/example/ios/Runner/Info.plist
@@ -28,6 +28,8 @@
 	<true/>
 	<key>NSCalendarsUsageDescription</key>
 	<string>This app needs access to your calendar to demonstrate calendar functionality.</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>This app needs full access to your calendar to demonstrate calendar functionality.</string>
 	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
 	<string>This app needs write access to your calendar to add events.</string>
 	<key>UIApplicationSceneManifest</key>

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -452,8 +452,10 @@ class DeviceCalendar {
   ///
   /// Omit [calendarId] (or pass `null`) to write to the device's default
   /// calendar; on Android resolving that default reads the calendar list, so it
-  /// needs full access. A non-null but empty ID is an error, as is an [endDate]
-  /// before [startDate].
+  /// needs full access. iOS mirrors that limitation from the other side: under
+  /// write-only access only the default calendar is reachable, so a named
+  /// [calendarId] requires full access there. A non-null but empty ID is an
+  /// error, as is an [endDate] before [startDate].
   ///
   /// [recurrenceRule] makes the event recurring (see
   /// [doc/recurring-events.md](https://github.com/bullet-to/device_calendar_plus/blob/main/packages/device_calendar_plus/doc/recurring-events.md)).

--- a/packages/device_calendar_plus/lib/device_calendar_plus.dart
+++ b/packages/device_calendar_plus/lib/device_calendar_plus.dart
@@ -870,8 +870,15 @@ class DeviceCalendar {
   ///
   /// All parameters are optional pre-fill values; the user can change anything
   /// before saving or cancelling. Useful for letting the user review, or to add
-  /// attendees (which can't be done programmatically). Works with write-only
-  /// access or full.
+  /// attendees (which can't be done programmatically).
+  ///
+  /// Needs no calendar permission on Android or iOS 17+ — the system editor
+  /// saves the event with its own access — so it also works as a fallback when
+  /// the user has denied access. Because it normally needs nothing,
+  /// [autoPermissions] never prompts for this method. On iOS 16 and below the
+  /// editor runs in-process and does require full access (request it with
+  /// [requestPermissions] first); without it this throws
+  /// [DeviceCalendarException] with [DeviceCalendarError.permissionDenied].
   Future<void> showCreateEventModal({
     String? title,
     DateTime? startDate,
@@ -894,7 +901,10 @@ class DeviceCalendar {
     final normalizedEnd =
         (isAllDay == true && endDate != null) ? _stripTime(endDate) : endDate;
 
-    await _ensurePermission(CalendarAccessLevel.writeOnly);
+    // Deliberately no _ensurePermission: the modal needs no calendar access on
+    // Android or iOS 17+, so gating (or auto-prompting) here would block the
+    // one path that still works after a denial. iOS 16 and below enforces its
+    // full-access requirement natively.
     try {
       await DeviceCalendarPlusPlatform.instance.showCreateEventModal(
         title: title,

--- a/packages/device_calendar_plus/lib/src/calendar_permission_status.dart
+++ b/packages/device_calendar_plus/lib/src/calendar_permission_status.dart
@@ -3,9 +3,15 @@ enum CalendarPermissionStatus {
   /// Full read and write access to calendars.
   granted,
 
-  /// Permission has been permanently denied — the system dialog can no longer
-  /// be shown (on Android, the user chose "Don't ask again"). Use
-  /// [DeviceCalendar.openAppSettings] to send the user to settings.
+  /// Permission was denied. Use [DeviceCalendar.openAppSettings] to send the
+  /// user to settings.
+  ///
+  /// From [DeviceCalendar.hasPermissions] this means a *permanent* denial —
+  /// the system dialog can no longer be shown (on Android, the user chose
+  /// "Don't ask again"). [DeviceCalendar.requestPermissions] additionally
+  /// reports a just-declined prompt as [denied] on both platforms; on Android
+  /// that first decline is still re-askable, so a later [DeviceCalendar.hasPermissions]
+  /// there reports [notDetermined] rather than [denied].
   denied,
 
   /// Write-only access — add events without reading existing data. Request it

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -1541,6 +1541,43 @@ void main() {
           ),
         );
       });
+
+      // Regression tests for #121: the modal needs no calendar permission on
+      // Android or iOS 17+, so the Dart layer must not gate or prompt for it.
+      test('reaches the platform when access is denied, even in auto mode',
+          () async {
+        DeviceCalendar.instance.autoPermissions = AutoPermissionMode.full;
+        mockPlatform.setPermissionStatus(CalendarPermissionStatus.denied);
+        var platformCalled = false;
+        mockPlatform.setShowCreateEventModalCallback(({
+          title,
+          startDate,
+          endDate,
+          description,
+          location,
+          isAllDay,
+          recurrenceRule,
+          availability,
+        }) {
+          platformCalled = true;
+          return Future.value();
+        });
+
+        await DeviceCalendar.instance.showCreateEventModal();
+
+        expect(platformCalled, isTrue);
+        expect(mockPlatform.requestPermissionsCallCount, 0);
+      });
+
+      test('autoPermissions never prompts for the modal, even on notDetermined',
+          () async {
+        DeviceCalendar.instance.autoPermissions = AutoPermissionMode.asNeeded;
+        mockPlatform.setPermissionStatus(CalendarPermissionStatus.notDetermined);
+
+        await DeviceCalendar.instance.showCreateEventModal();
+
+        expect(mockPlatform.requestPermissionsCallCount, 0);
+      });
     });
   });
 

--- a/packages/device_calendar_plus/test/device_calendar_plus_test.dart
+++ b/packages/device_calendar_plus/test/device_calendar_plus_test.dart
@@ -370,6 +370,8 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     _showCreateEventModalCallback = callback;
   }
 
+  int showCreateEventModalCallCount = 0;
+
   @override
   Future<void> showCreateEventModal({
     String? title,
@@ -382,6 +384,7 @@ class MockDeviceCalendarPlusPlatform extends DeviceCalendarPlusPlatform
     String? availability,
   }) async {
     if (_exceptionToThrow != null) throw _exceptionToThrow!;
+    showCreateEventModalCallCount++;
     if (_showCreateEventModalCallback != null) {
       return _showCreateEventModalCallback!(
         title: title,
@@ -1548,24 +1551,10 @@ void main() {
           () async {
         DeviceCalendar.instance.autoPermissions = AutoPermissionMode.full;
         mockPlatform.setPermissionStatus(CalendarPermissionStatus.denied);
-        var platformCalled = false;
-        mockPlatform.setShowCreateEventModalCallback(({
-          title,
-          startDate,
-          endDate,
-          description,
-          location,
-          isAllDay,
-          recurrenceRule,
-          availability,
-        }) {
-          platformCalled = true;
-          return Future.value();
-        });
 
         await DeviceCalendar.instance.showCreateEventModal();
 
-        expect(platformCalled, isTrue);
+        expect(mockPlatform.showCreateEventModalCallCount, 1);
         expect(mockPlatform.requestPermissionsCallCount, 0);
       });
 
@@ -1576,6 +1565,7 @@ void main() {
 
         await DeviceCalendar.instance.showCreateEventModal();
 
+        expect(mockPlatform.showCreateEventModalCallCount, 1);
         expect(mockPlatform.requestPermissionsCallCount, 0);
       });
     });

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
@@ -8,8 +8,46 @@ import android.provider.CalendarContract
 import androidx.core.content.ContextCompat
 
 class CalendarService(private val context: Context) {
-    
+
+    /**
+     * Gate for read endpoints. A denied read can surface as either a thrown
+     * SecurityException or a silently empty cursor, and only an explicit check
+     * distinguishes "can't read" from "genuinely no calendars" — without it a
+     * denied app sees an empty list where iOS deterministically throws.
+     */
+    private fun readAccessFailure(): CalendarException? {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR)
+            != PackageManager.PERMISSION_GRANTED) {
+            return CalendarException(
+                PlatformExceptionCodes.PERMISSION_DENIED,
+                "Calendar permission denied. Call requestPermissions() first."
+            )
+        }
+        return null
+    }
+
+    /**
+     * Gate for calendar mutations, which need the full tier on both platforms
+     * (write-only covers only createEvent, per doc/permissions.md). On Android
+     * full means READ_CALENDAR and WRITE_CALENDAR together — WRITE alone is the
+     * write-only tier, which iOS rejects for these operations.
+     */
+    private fun fullAccessFailure(): CalendarException? {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_CALENDAR)
+            != PackageManager.PERMISSION_GRANTED ||
+            ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR)
+            != PackageManager.PERMISSION_GRANTED) {
+            return CalendarException(
+                PlatformExceptionCodes.PERMISSION_DENIED,
+                "Calendar permission denied. Call requestPermissions() first."
+            )
+        }
+        return null
+    }
+
     fun listCalendars(): Result<List<Map<String, Any>>> {
+        readAccessFailure()?.let { return Result.failure(it) }
+
         val calendars = mutableListOf<Map<String, Any>>()
         
         val projection = arrayOf(
@@ -122,6 +160,8 @@ class CalendarService(private val context: Context) {
     }
 
     fun listSources(): Result<List<Map<String, Any>>> {
+        readAccessFailure()?.let { return Result.failure(it) }
+
         val sources = mutableListOf<Map<String, Any>>()
         val seen = mutableSetOf<String>()
 
@@ -176,17 +216,8 @@ class CalendarService(private val context: Context) {
     }
 
     fun createCalendar(name: String, colorHex: String?, accountNameParam: String?, accountTypeParam: String?): Result<String> {
-        // Check for write calendar permission
-        if (ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_CALENDAR)
-            != PackageManager.PERMISSION_GRANTED) {
-            return Result.failure(
-                CalendarException(
-                    PlatformExceptionCodes.PERMISSION_DENIED,
-                    "Calendar permission denied. Call requestPermissions() first."
-                )
-            )
-        }
-        
+        fullAccessFailure()?.let { return Result.failure(it) }
+
         val accountName = accountNameParam ?: "local"
         val accountType = accountTypeParam ?: CalendarContract.ACCOUNT_TYPE_LOCAL
         
@@ -250,17 +281,8 @@ class CalendarService(private val context: Context) {
     }
     
     fun updateCalendar(calendarId: String, name: String?, colorHex: String?): Result<Unit> {
-        // Check for write calendar permission
-        if (ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_CALENDAR)
-            != PackageManager.PERMISSION_GRANTED) {
-            return Result.failure(
-                CalendarException(
-                    PlatformExceptionCodes.PERMISSION_DENIED,
-                    "Calendar permission denied. Call requestPermissions() first."
-                )
-            )
-        }
-        
+        fullAccessFailure()?.let { return Result.failure(it) }
+
         try {
             // Prepare values to update
             val values = android.content.ContentValues()
@@ -313,17 +335,8 @@ class CalendarService(private val context: Context) {
     }
     
     fun deleteCalendar(calendarId: String): Result<Unit> {
-        // Check for write calendar permission
-        if (ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_CALENDAR)
-            != PackageManager.PERMISSION_GRANTED) {
-            return Result.failure(
-                CalendarException(
-                    PlatformExceptionCodes.PERMISSION_DENIED,
-                    "Calendar permission denied. Call requestPermissions() first."
-                )
-            )
-        }
-        
+        fullAccessFailure()?.let { return Result.failure(it) }
+
         try {
             val deletedRows = context.contentResolver.delete(
                 CalendarContract.Calendars.CONTENT_URI,

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/CalendarService.kt
@@ -1,52 +1,13 @@
 package to.bullet.device_calendar_plus_android
 
-import android.Manifest
 import android.content.Context
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.provider.CalendarContract
-import androidx.core.content.ContextCompat
 
 class CalendarService(private val context: Context) {
 
-    /**
-     * Gate for read endpoints. A denied read can surface as either a thrown
-     * SecurityException or a silently empty cursor, and only an explicit check
-     * distinguishes "can't read" from "genuinely no calendars" — without it a
-     * denied app sees an empty list where iOS deterministically throws.
-     */
-    private fun readAccessFailure(): CalendarException? {
-        if (ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR)
-            != PackageManager.PERMISSION_GRANTED) {
-            return CalendarException(
-                PlatformExceptionCodes.PERMISSION_DENIED,
-                "Calendar permission denied. Call requestPermissions() first."
-            )
-        }
-        return null
-    }
-
-    /**
-     * Gate for calendar mutations, which need the full tier on both platforms
-     * (write-only covers only createEvent, per doc/permissions.md). On Android
-     * full means READ_CALENDAR and WRITE_CALENDAR together — WRITE alone is the
-     * write-only tier, which iOS rejects for these operations.
-     */
-    private fun fullAccessFailure(): CalendarException? {
-        if (ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_CALENDAR)
-            != PackageManager.PERMISSION_GRANTED ||
-            ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR)
-            != PackageManager.PERMISSION_GRANTED) {
-            return CalendarException(
-                PlatformExceptionCodes.PERMISSION_DENIED,
-                "Calendar permission denied. Call requestPermissions() first."
-            )
-        }
-        return null
-    }
-
     fun listCalendars(): Result<List<Map<String, Any>>> {
-        readAccessFailure()?.let { return Result.failure(it) }
+        readAccessFailure(context)?.let { return Result.failure(it) }
 
         val calendars = mutableListOf<Map<String, Any>>()
         
@@ -139,19 +100,8 @@ class CalendarService(private val context: Context) {
      * Reuses [listCalendars] so the writability definition stays in one place.
      */
     fun resolveDefaultWritableCalendarId(): Result<String?> {
-        // Picking a default reads the calendar list, so it needs READ_CALENDAR.
-        // Guard it explicitly: a denied read can surface as either a thrown
-        // SecurityException or a silently empty cursor, and only the explicit
-        // check distinguishes "can't read" from "genuinely no calendars".
-        if (ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR)
-            != PackageManager.PERMISSION_GRANTED) {
-            return Result.failure(
-                CalendarException(
-                    PlatformExceptionCodes.PERMISSION_DENIED,
-                    "Reading calendars to resolve a default requires READ_CALENDAR"
-                )
-            )
-        }
+        // Picking a default reads the calendar list; listCalendars gates the
+        // read itself, and its failure propagates through the map.
         return listCalendars().map { calendars ->
             val writable = calendars.filter { it["readOnly"] == false }
             (writable.firstOrNull { it["isPrimary"] == true } ?: writable.firstOrNull())
@@ -160,7 +110,7 @@ class CalendarService(private val context: Context) {
     }
 
     fun listSources(): Result<List<Map<String, Any>>> {
-        readAccessFailure()?.let { return Result.failure(it) }
+        readAccessFailure(context)?.let { return Result.failure(it) }
 
         val sources = mutableListOf<Map<String, Any>>()
         val seen = mutableSetOf<String>()
@@ -216,7 +166,7 @@ class CalendarService(private val context: Context) {
     }
 
     fun createCalendar(name: String, colorHex: String?, accountNameParam: String?, accountTypeParam: String?): Result<String> {
-        fullAccessFailure()?.let { return Result.failure(it) }
+        fullAccessFailure(context)?.let { return Result.failure(it) }
 
         val accountName = accountNameParam ?: "local"
         val accountType = accountTypeParam ?: CalendarContract.ACCOUNT_TYPE_LOCAL
@@ -281,7 +231,7 @@ class CalendarService(private val context: Context) {
     }
     
     fun updateCalendar(calendarId: String, name: String?, colorHex: String?): Result<Unit> {
-        fullAccessFailure()?.let { return Result.failure(it) }
+        fullAccessFailure(context)?.let { return Result.failure(it) }
 
         try {
             // Prepare values to update
@@ -335,7 +285,7 @@ class CalendarService(private val context: Context) {
     }
     
     fun deleteCalendar(calendarId: String): Result<Unit> {
-        fullAccessFailure()?.let { return Result.failure(it) }
+        fullAccessFailure(context)?.let { return Result.failure(it) }
 
         try {
             val deletedRows = context.contentResolver.delete(

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/DeviceCalendarPlusAndroidPlugin.kt
@@ -147,8 +147,10 @@ class DeviceCalendarPlusAndroidPlugin :
     private fun handleOpenAppSettings(result: Result) {
         val currentActivity = activity
         if (currentActivity == null) {
+            // Same condition as requestPermissions' no-Activity failure, so use
+            // the same code — callers shouldn't handle two errors for one state.
             result.error(
-                PlatformExceptionCodes.UNKNOWN_ERROR,
+                PlatformExceptionCodes.OPERATION_FAILED,
                 "Activity not available",
                 null
             )

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -631,7 +631,9 @@ class EventsService(
             if (location != null) intent.putExtra(CalendarContract.Events.EVENT_LOCATION, location)
             if (startDate != null) intent.putExtra(CalendarContract.EXTRA_EVENT_BEGIN_TIME, startDate)
             if (endDate != null) intent.putExtra(CalendarContract.EXTRA_EVENT_END_TIME, endDate)
-            if (isAllDay != null) intent.putExtra(CalendarContract.Events.ALL_DAY, if (isAllDay) 1 else 0)
+            // EXTRA_EVENT_ALL_DAY is a *boolean* extra — calendar apps read it
+            // with getBooleanExtra, which ignores an Integer value entirely.
+            if (isAllDay != null) intent.putExtra(CalendarContract.EXTRA_EVENT_ALL_DAY, isAllDay)
             if (recurrenceRule != null) intent.putExtra(CalendarContract.Events.RRULE, recurrenceRule)
             if (availability != null) {
                 val availabilityValue = when (availability) {
@@ -833,9 +835,14 @@ class EventsService(
      * recurring).
      */
     fun deleteEvent(eventId: String, timestamp: Long? = null): Result<Unit> {
-        // Check for write calendar permission
+        // Deleting needs the full tier (write-only covers only createEvent),
+        // which on Android means READ_CALENDAR and WRITE_CALENDAR together.
+        // Check both explicitly so a write-only grant fails here the way iOS
+        // does, instead of by whichever internal read happens to throw first.
         if (android.content.pm.PackageManager.PERMISSION_GRANTED !=
-            context.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR)) {
+            context.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR) ||
+            android.content.pm.PackageManager.PERMISSION_GRANTED !=
+            context.checkSelfPermission(android.Manifest.permission.READ_CALENDAR)) {
             return Result.failure(
                 CalendarException(
                     PlatformExceptionCodes.PERMISSION_DENIED,
@@ -907,9 +914,14 @@ class EventsService(
         endDate: java.util.Date?,
         patch: EventFieldPatch
     ): Result<Unit> {
-        // Check for write calendar permission
+        // Updating needs the full tier (write-only covers only createEvent),
+        // which on Android means READ_CALENDAR and WRITE_CALENDAR together.
+        // Check both explicitly so a write-only grant fails here the way iOS
+        // does, instead of by whichever internal read happens to throw first.
         if (android.content.pm.PackageManager.PERMISSION_GRANTED !=
-            context.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR)) {
+            context.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR) ||
+            android.content.pm.PackageManager.PERMISSION_GRANTED !=
+            context.checkSelfPermission(android.Manifest.permission.READ_CALENDAR)) {
             return Result.failure(
                 CalendarException(
                     PlatformExceptionCodes.PERMISSION_DENIED,
@@ -1171,8 +1183,12 @@ class EventsService(
         recurrenceRule: String?,
         patch: EventFieldPatch
     ): Result<String> {
+        // Full tier required (write-only covers only createEvent): on Android
+        // that means READ_CALENDAR and WRITE_CALENDAR together, matching iOS.
         if (android.content.pm.PackageManager.PERMISSION_GRANTED !=
-            context.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR)) {
+            context.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR) ||
+            android.content.pm.PackageManager.PERMISSION_GRANTED !=
+            context.checkSelfPermission(android.Manifest.permission.READ_CALENDAR)) {
             return Result.failure(
                 CalendarException(
                     PlatformExceptionCodes.PERMISSION_DENIED,
@@ -1501,8 +1517,12 @@ class EventsService(
         timestamp: Long?,
         span: String
     ): Result<Unit> {
+        // Full tier required (write-only covers only createEvent): on Android
+        // that means READ_CALENDAR and WRITE_CALENDAR together, matching iOS.
         if (android.content.pm.PackageManager.PERMISSION_GRANTED !=
-            context.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR)) {
+            context.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR) ||
+            android.content.pm.PackageManager.PERMISSION_GRANTED !=
+            context.checkSelfPermission(android.Manifest.permission.READ_CALENDAR)) {
             return Result.failure(
                 CalendarException(
                     PlatformExceptionCodes.PERMISSION_DENIED,

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -21,6 +21,8 @@ class EventsService(
         calendarIds: List<String>?,
         eventId: String? = null
     ): Result<List<Map<String, Any>>> {
+        readAccessFailure(context)?.let { return Result.failure(it) }
+
         val events = mutableListOf<Map<String, Any>>()
 
         val startMillis = startDate.time
@@ -444,6 +446,8 @@ class EventsService(
     }
     
     fun getEvent(eventId: String, timestamp: Long?): Result<Map<String, Any>?> {
+        readAccessFailure(context)?.let { return Result.failure(it) }
+
         if (timestamp != null) {
             // Recurring event with timestamp
             val occurrenceMillis = timestamp
@@ -653,14 +657,11 @@ class EventsService(
                     "Calendar app not found"
                 )
             )
-        } catch (e: SecurityException) {
-            Result.failure(
-                CalendarException(
-                    PlatformExceptionCodes.PERMISSION_DENIED,
-                    "Permission denied: ${e.message}"
-                )
-            )
         } catch (e: Exception) {
+            // No SecurityException special-case: ACTION_INSERT needs no calendar
+            // permission, so one here isn't a calendar-permission problem and
+            // mapping it to PERMISSION_DENIED would send callers down a
+            // requestPermissions loop that can't help.
             Result.failure(
                 CalendarException(
                     PlatformExceptionCodes.UNKNOWN_ERROR,
@@ -835,21 +836,7 @@ class EventsService(
      * recurring).
      */
     fun deleteEvent(eventId: String, timestamp: Long? = null): Result<Unit> {
-        // Deleting needs the full tier (write-only covers only createEvent),
-        // which on Android means READ_CALENDAR and WRITE_CALENDAR together.
-        // Check both explicitly so a write-only grant fails here the way iOS
-        // does, instead of by whichever internal read happens to throw first.
-        if (android.content.pm.PackageManager.PERMISSION_GRANTED !=
-            context.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR) ||
-            android.content.pm.PackageManager.PERMISSION_GRANTED !=
-            context.checkSelfPermission(android.Manifest.permission.READ_CALENDAR)) {
-            return Result.failure(
-                CalendarException(
-                    PlatformExceptionCodes.PERMISSION_DENIED,
-                    "Calendar permission denied. Call requestPermissions() first."
-                )
-            )
-        }
+        fullAccessFailure(context)?.let { return Result.failure(it) }
 
         return try {
             if (timestamp != null) {
@@ -914,21 +901,7 @@ class EventsService(
         endDate: java.util.Date?,
         patch: EventFieldPatch
     ): Result<Unit> {
-        // Updating needs the full tier (write-only covers only createEvent),
-        // which on Android means READ_CALENDAR and WRITE_CALENDAR together.
-        // Check both explicitly so a write-only grant fails here the way iOS
-        // does, instead of by whichever internal read happens to throw first.
-        if (android.content.pm.PackageManager.PERMISSION_GRANTED !=
-            context.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR) ||
-            android.content.pm.PackageManager.PERMISSION_GRANTED !=
-            context.checkSelfPermission(android.Manifest.permission.READ_CALENDAR)) {
-            return Result.failure(
-                CalendarException(
-                    PlatformExceptionCodes.PERMISSION_DENIED,
-                    "Calendar permission denied. Call requestPermissions() first."
-                )
-            )
-        }
+        fullAccessFailure(context)?.let { return Result.failure(it) }
 
         return try {
             if (timestamp != null) {
@@ -1183,19 +1156,7 @@ class EventsService(
         recurrenceRule: String?,
         patch: EventFieldPatch
     ): Result<String> {
-        // Full tier required (write-only covers only createEvent): on Android
-        // that means READ_CALENDAR and WRITE_CALENDAR together, matching iOS.
-        if (android.content.pm.PackageManager.PERMISSION_GRANTED !=
-            context.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR) ||
-            android.content.pm.PackageManager.PERMISSION_GRANTED !=
-            context.checkSelfPermission(android.Manifest.permission.READ_CALENDAR)) {
-            return Result.failure(
-                CalendarException(
-                    PlatformExceptionCodes.PERMISSION_DENIED,
-                    "Calendar permission denied. Call requestPermissions() first."
-                )
-            )
-        }
+        fullAccessFailure(context)?.let { return Result.failure(it) }
 
         return try {
             if (span != "allEvents" && span != "thisAndFollowing") {
@@ -1517,19 +1478,7 @@ class EventsService(
         timestamp: Long?,
         span: String
     ): Result<Unit> {
-        // Full tier required (write-only covers only createEvent): on Android
-        // that means READ_CALENDAR and WRITE_CALENDAR together, matching iOS.
-        if (android.content.pm.PackageManager.PERMISSION_GRANTED !=
-            context.checkSelfPermission(android.Manifest.permission.WRITE_CALENDAR) ||
-            android.content.pm.PackageManager.PERMISSION_GRANTED !=
-            context.checkSelfPermission(android.Manifest.permission.READ_CALENDAR)) {
-            return Result.failure(
-                CalendarException(
-                    PlatformExceptionCodes.PERMISSION_DENIED,
-                    "Calendar permission denied. Call requestPermissions() first."
-                )
-            )
-        }
+        fullAccessFailure(context)?.let { return Result.failure(it) }
 
         return try {
             when (span) {

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/EventsService.kt
@@ -621,16 +621,9 @@ class EventsService(
         requestCode: Int,
     ): Result<Unit> {
         return try {
-            if (android.content.pm.PackageManager.PERMISSION_GRANTED !=
-                context.checkSelfPermission(android.Manifest.permission.READ_CALENDAR)) {
-                return Result.failure(
-                    CalendarException(
-                        PlatformExceptionCodes.PERMISSION_DENIED,
-                        "Calendar permission denied. Call requestPermissions() first."
-                    )
-                )
-            }
-
+            // No permission gate: ACTION_INSERT hands the event to the calendar
+            // app, which saves it with its own access — the docs are explicit
+            // that the caller needs neither READ_ nor WRITE_CALENDAR.
             val intent = Intent(Intent.ACTION_INSERT).setData(CalendarContract.Events.CONTENT_URI)
 
             if (title != null) intent.putExtra(CalendarContract.Events.TITLE, title)

--- a/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/PermissionGates.kt
+++ b/packages/device_calendar_plus_android/android/src/main/kotlin/to/bullet/device_calendar_plus_android/PermissionGates.kt
@@ -1,0 +1,48 @@
+package to.bullet.device_calendar_plus_android
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+
+// Shared permission gates for the service classes. Android has no single
+// "calendar permission": READ_CALENDAR alone is enough to read, WRITE_CALENDAR
+// alone is the write-only tier, and the full tier means holding both — the
+// same mapping PermissionService reports to Dart.
+
+/**
+ * Gate for read endpoints. A denied read can surface as either a thrown
+ * SecurityException or a silently empty cursor, and only an explicit check
+ * distinguishes "can't read" from "genuinely nothing there" — without it a
+ * denied app sees an empty result where iOS deterministically throws.
+ */
+internal fun readAccessFailure(context: Context): CalendarException? {
+    if (ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR)
+        != PackageManager.PERMISSION_GRANTED) {
+        return CalendarException(
+            PlatformExceptionCodes.PERMISSION_DENIED,
+            "Calendar permission denied. Call requestPermissions() first."
+        )
+    }
+    return null
+}
+
+/**
+ * Gate for operations that need the full tier — write-only covers only
+ * createEvent, per doc/permissions.md. The message names the tier because a
+ * plain "call requestPermissions()" is a no-op for a write-only holder: their
+ * request already succeeded, at the wrong level.
+ */
+internal fun fullAccessFailure(context: Context): CalendarException? {
+    if (ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_CALENDAR)
+        != PackageManager.PERMISSION_GRANTED ||
+        ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR)
+        != PackageManager.PERMISSION_GRANTED) {
+        return CalendarException(
+            PlatformExceptionCodes.PERMISSION_DENIED,
+            "Calendar permission denied. Full access is required — call " +
+                "requestPermissions(level: CalendarAccessLevel.full) first."
+        )
+    }
+    return null
+}

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -420,17 +420,19 @@ class EventsService {
   /// events (no default available is an error).
   private func resolveCalendar(calendarId: String?) -> Result<EKCalendar, CalendarError> {
     if let calendarId = calendarId {
+      // Under write-only access the store can't look calendars up at all
+      // (only defaultCalendarForNewEvents is reachable), so a named ID is a
+      // permission problem before it's a lookup problem — checking up front
+      // states that contract directly instead of inferring it from a nil
+      // lookup, and spares the caller a phantom "not found".
+      guard permissionService.hasPermission(for: .full) else {
+        return .failure(CalendarError(
+          code: PlatformExceptionCodes.permissionDenied,
+          message: "Targeting a calendar by ID requires full calendar access. "
+            + "With write-only access, omit calendarId to use the default calendar."
+        ))
+      }
       guard let calendar = eventStore.calendar(withIdentifier: calendarId) else {
-        // Under write-only access the store can't look calendars up at all
-        // (only defaultCalendarForNewEvents is reachable), so the honest error
-        // is the missing permission, not a phantom "not found".
-        guard permissionService.hasPermission(for: .full) else {
-          return .failure(CalendarError(
-            code: PlatformExceptionCodes.permissionDenied,
-            message: "Targeting a calendar by ID requires full calendar access. "
-              + "With write-only access, omit calendarId to use the default calendar."
-          ))
-        }
         return .failure(CalendarError(
           code: PlatformExceptionCodes.notFound,
           message: "Calendar with ID \(calendarId) not found"

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -566,12 +566,19 @@ class EventsService {
     availability: String?,
     completion: @escaping (Result<EKEvent?, CalendarError>) -> Void
   ) {
-    guard permissionService.hasPermission(for: .full) else {
-      completion(.failure(CalendarError(
-        code: PlatformExceptionCodes.permissionDenied,
-        message: "Calendar permission denied. Call requestPermissions() first."
-      )))
-      return
+    // On iOS 17+ no calendar access is needed: EKEventEditViewController runs
+    // out of process and reaches the user's calendars itself. Below 17 the
+    // editor runs in-process and presents unusable without an authorized
+    // store, so the gate stays there (pre-17 access has no write-only tier —
+    // authorized means full).
+    if #unavailable(iOS 17.0) {
+      guard permissionService.hasPermission(for: .full) else {
+        completion(.failure(CalendarError(
+          code: PlatformExceptionCodes.permissionDenied,
+          message: "Calendar permission denied. Call requestPermissions() first."
+        )))
+        return
+      }
     }
 
     // If all params are nil, return nil so the editor opens blank

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/EventsService.swift
@@ -421,6 +421,16 @@ class EventsService {
   private func resolveCalendar(calendarId: String?) -> Result<EKCalendar, CalendarError> {
     if let calendarId = calendarId {
       guard let calendar = eventStore.calendar(withIdentifier: calendarId) else {
+        // Under write-only access the store can't look calendars up at all
+        // (only defaultCalendarForNewEvents is reachable), so the honest error
+        // is the missing permission, not a phantom "not found".
+        guard permissionService.hasPermission(for: .full) else {
+          return .failure(CalendarError(
+            code: PlatformExceptionCodes.permissionDenied,
+            message: "Targeting a calendar by ID requires full calendar access. "
+              + "With write-only access, omit calendarId to use the default calendar."
+          ))
+        }
         return .failure(CalendarError(
           code: PlatformExceptionCodes.notFound,
           message: "Calendar with ID \(calendarId) not found"

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/PermissionService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/PermissionService.swift
@@ -77,6 +77,15 @@ class PermissionService {
     return PermissionError(code: PlatformExceptionCodes.permissionsNotDeclared, message: errorMessage)
   }
 
+  private func missingFullAccessDescriptionError() -> PermissionError {
+    var errorMessage = "Full-access calendar usage description not declared in Info.plist.\n\n"
+    errorMessage += "Add the following to ios/Runner/Info.plist:\n"
+    errorMessage += "<key>NSCalendarsFullAccessUsageDescription</key>\n"
+    errorMessage += "<string>Full access to view and edit your calendar events.</string>"
+
+    return PermissionError(code: PlatformExceptionCodes.permissionsNotDeclared, message: errorMessage)
+  }
+
   private func missingUsageDescriptionError() -> PermissionError {
     var errorMessage = "Calendar usage description not declared in Info.plist.\n\n"
     errorMessage += "Add the following to ios/Runner/Info.plist:\n"
@@ -90,14 +99,20 @@ class PermissionService {
 
   /// Verifies the Info.plist declares the usage description the request needs.
   ///
-  /// A write-only request on iOS 17+ goes through `requestWriteOnlyAccessToEvents`,
-  /// which **requires** `NSCalendarsWriteOnlyAccessUsageDescription` — without it
-  /// the OS raises an exception, so we surface a clear error instead of crashing.
-  /// Every other path uses `NSCalendarsUsageDescription`.
+  /// On iOS 17+ each request variant **requires** its own key: full access
+  /// (`requestFullAccessToEvents`) needs `NSCalendarsFullAccessUsageDescription`
+  /// and write-only needs `NSCalendarsWriteOnlyAccessUsageDescription` — the
+  /// legacy `NSCalendarsUsageDescription` no longer satisfies either, and
+  /// without the matching key the OS raises an exception, so we surface a
+  /// clear error instead of crashing. iOS 16 and below uses only the legacy key.
   private func checkUsageDescriptionDeclared(writeOnly: Bool) -> PermissionError? {
-    if writeOnly, #available(iOS 17.0, *) {
-      return isDescriptionDeclared("NSCalendarsWriteOnlyAccessUsageDescription")
-        ? nil : missingWriteOnlyDescriptionError()
+    if #available(iOS 17.0, *) {
+      if writeOnly {
+        return isDescriptionDeclared("NSCalendarsWriteOnlyAccessUsageDescription")
+          ? nil : missingWriteOnlyDescriptionError()
+      }
+      return isDescriptionDeclared("NSCalendarsFullAccessUsageDescription")
+        ? nil : missingFullAccessDescriptionError()
     }
 
     return isDescriptionDeclared("NSCalendarsUsageDescription")
@@ -142,9 +157,11 @@ class PermissionService {
   
   func hasPermissions() -> Result<String, PermissionError> {
     // A status check triggers no prompt, so any declared calendar usage
-    // description — full or write-only — satisfies the configuration guard. An
-    // add-only app that declares only the write-only key can still check status.
+    // description — legacy, full-access, or write-only — satisfies the
+    // configuration guard. An add-only app that declares only the write-only
+    // key can still check status.
     guard isDescriptionDeclared("NSCalendarsUsageDescription")
+      || isDescriptionDeclared("NSCalendarsFullAccessUsageDescription")
       || isDescriptionDeclared("NSCalendarsWriteOnlyAccessUsageDescription") else {
       return .failure(missingUsageDescriptionError())
     }

--- a/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/PermissionService.swift
+++ b/packages/device_calendar_plus_ios/ios/device_calendar_plus_ios/Sources/device_calendar_plus_ios/PermissionService.swift
@@ -63,38 +63,59 @@ class PermissionService {
     }
   }
   
+  // Info.plist usage-description keys. The declaration checks and the error
+  // messages must name the same keys, so both go through these constants and
+  // the shared descriptionExample map.
+  private static let legacyUsageKey = "NSCalendarsUsageDescription"
+  private static let fullAccessUsageKey = "NSCalendarsFullAccessUsageDescription"
+  private static let writeOnlyUsageKey = "NSCalendarsWriteOnlyAccessUsageDescription"
+
+  private static let descriptionExamples: [String: String] = [
+    legacyUsageKey: "Access your calendar to view and manage events.",
+    fullAccessUsageKey: "Full access to view and edit your calendar events.",
+    writeOnlyUsageKey: "Add events without reading existing events.",
+  ]
+
   private func isDescriptionDeclared(_ key: String) -> Bool {
     let value = Bundle.main.object(forInfoDictionaryKey: key) as? String
     return !(value?.isEmpty ?? true)
   }
 
-  private func missingWriteOnlyDescriptionError() -> PermissionError {
-    var errorMessage = "Write-only calendar usage description not declared in Info.plist.\n\n"
-    errorMessage += "Add the following to ios/Runner/Info.plist:\n"
-    errorMessage += "<key>NSCalendarsWriteOnlyAccessUsageDescription</key>\n"
-    errorMessage += "<string>Add events without reading existing events.</string>"
+  private func missingDescriptionError(_ title: String, keys: [String]) -> PermissionError {
+    var errorMessage = "\(title) not declared in Info.plist.\n\n"
+    errorMessage += "Add the following to ios/Runner/Info.plist:"
+    for key in keys {
+      errorMessage += "\n<key>\(key)</key>"
+      errorMessage += "\n<string>\(PermissionService.descriptionExamples[key] ?? "")</string>"
+    }
 
     return PermissionError(code: PlatformExceptionCodes.permissionsNotDeclared, message: errorMessage)
+  }
+
+  private func missingWriteOnlyDescriptionError() -> PermissionError {
+    missingDescriptionError(
+      "Write-only calendar usage description",
+      keys: [PermissionService.writeOnlyUsageKey])
   }
 
   private func missingFullAccessDescriptionError() -> PermissionError {
-    var errorMessage = "Full-access calendar usage description not declared in Info.plist.\n\n"
-    errorMessage += "Add the following to ios/Runner/Info.plist:\n"
-    errorMessage += "<key>NSCalendarsFullAccessUsageDescription</key>\n"
-    errorMessage += "<string>Full access to view and edit your calendar events.</string>"
-
-    return PermissionError(code: PlatformExceptionCodes.permissionsNotDeclared, message: errorMessage)
+    missingDescriptionError(
+      "Full-access calendar usage description",
+      keys: [PermissionService.fullAccessUsageKey])
   }
 
+  /// The no-keys-at-all error. Lists every key so following the advice once
+  /// satisfies both the status guard and any later request on any OS version —
+  /// naming only the legacy key would fix `hasPermissions` and then fail again
+  /// on an iOS 17+ request, which demands the tier-specific keys.
   private func missingUsageDescriptionError() -> PermissionError {
-    var errorMessage = "Calendar usage description not declared in Info.plist.\n\n"
-    errorMessage += "Add the following to ios/Runner/Info.plist:\n"
-    errorMessage += "<key>NSCalendarsUsageDescription</key>\n"
-    errorMessage += "<string>Access your calendar to view and manage events.</string>\n"
-    errorMessage += "<key>NSCalendarsWriteOnlyAccessUsageDescription</key>\n"
-    errorMessage += "<string>Add events without reading existing events.</string>"
-
-    return PermissionError(code: PlatformExceptionCodes.permissionsNotDeclared, message: errorMessage)
+    missingDescriptionError(
+      "Calendar usage description",
+      keys: [
+        PermissionService.fullAccessUsageKey,
+        PermissionService.writeOnlyUsageKey,
+        PermissionService.legacyUsageKey,
+      ])
   }
 
   /// Verifies the Info.plist declares the usage description the request needs.
@@ -108,15 +129,16 @@ class PermissionService {
   private func checkUsageDescriptionDeclared(writeOnly: Bool) -> PermissionError? {
     if #available(iOS 17.0, *) {
       if writeOnly {
-        return isDescriptionDeclared("NSCalendarsWriteOnlyAccessUsageDescription")
+        return isDescriptionDeclared(PermissionService.writeOnlyUsageKey)
           ? nil : missingWriteOnlyDescriptionError()
       }
-      return isDescriptionDeclared("NSCalendarsFullAccessUsageDescription")
+      return isDescriptionDeclared(PermissionService.fullAccessUsageKey)
         ? nil : missingFullAccessDescriptionError()
     }
 
-    return isDescriptionDeclared("NSCalendarsUsageDescription")
-      ? nil : missingUsageDescriptionError()
+    return isDescriptionDeclared(PermissionService.legacyUsageKey)
+      ? nil : missingDescriptionError(
+        "Calendar usage description", keys: [PermissionService.legacyUsageKey])
   }
   
   private func getCurrentPermissionStatus() -> String {
@@ -160,9 +182,9 @@ class PermissionService {
     // description — legacy, full-access, or write-only — satisfies the
     // configuration guard. An add-only app that declares only the write-only
     // key can still check status.
-    guard isDescriptionDeclared("NSCalendarsUsageDescription")
-      || isDescriptionDeclared("NSCalendarsFullAccessUsageDescription")
-      || isDescriptionDeclared("NSCalendarsWriteOnlyAccessUsageDescription") else {
+    guard isDescriptionDeclared(PermissionService.legacyUsageKey)
+      || isDescriptionDeclared(PermissionService.fullAccessUsageKey)
+      || isDescriptionDeclared(PermissionService.writeOnlyUsageKey) else {
       return .failure(missingUsageDescriptionError())
     }
 
@@ -177,11 +199,6 @@ class PermissionService {
     writeOnly: Bool,
     completion: @escaping (Result<String, PermissionError>) -> Void
   ) {
-    if let error = checkUsageDescriptionDeclared(writeOnly: writeOnly) {
-      completion(.failure(error))
-      return
-    }
-
     let currentStatus = getCurrentPermissionStatus()
 
     // Already hold a tier that satisfies the request? No prompt needed. Full
@@ -198,6 +215,15 @@ class PermissionService {
 
     if alreadySatisfied || terminal {
       completion(.success(currentStatus))
+      return
+    }
+
+    // The usage-description key is only needed once we actually fire an OS
+    // request, so the check sits after the early returns — an app that ships
+    // without the (iOS 17+) tier key must still get its already-granted or
+    // terminal status back rather than a configuration error.
+    if let error = checkUsageDescriptionDeclared(writeOnly: writeOnly) {
+      completion(.failure(error))
       return
     }
 


### PR DESCRIPTION
Fixes #121 — and the report was spot on. `ACTION_INSERT` needs no permission on Android, and `EKEventEditViewController` is out-of-process on iOS 17+, so gating the create modal just killed the one recovery path an add-only app has after a denial.

## What's here

**The #121 fix (3 layers):**
- iOS: gate only below iOS 17 (`#unavailable`), where the in-process editor genuinely needs an authorized store
- Android: `READ_CALENDAR` check on the create-modal path gone
- Dart: `_ensurePermission` gone from `showCreateEventModal` — no gate, no auto-prompt
- Docs + two regression unit tests

**Same-class fixes from a full endpoint audit** (every endpoint, all 3 layers — gates that didn't match doc/permissions.md):
- Android read endpoints (`listCalendars`, `listSources`, `listEvents`, `getEvent`) now gate `READ_CALENDAR` explicitly — a denied read used to surface as a silent `[]`/null where iOS throws
- Android full-tier ops (calendar mutations, event update/delete, recurring update/delete) now require READ **and** WRITE — WRITE alone is the write-only tier, which could previously mutate calendars on Android while iOS rejected it. The error message now names the tier, since "call requestPermissions() first" is a no-op for a write-only holder
- iOS plist guard: full-access requests on 17+ now check `NSCalendarsFullAccessUsageDescription` (what the OS actually demands, and what our README says) instead of the legacy key — and the check only runs when a prompt will actually fire, so already-granted/terminal states still get their status back
- iOS `createEvent` with a named `calendarId` under write-only: honest `permissionDenied` (with a hint) instead of a phantom `notFound`
- Android `showCreateEventModal` all-day prefill: `EXTRA_EVENT_ALL_DAY` is a boolean extra; we were writing an Int, which `getBooleanExtra` ignores
- Android gates consolidated into a shared `PermissionGates.kt` (they were heading for 7 hand-rolled copies)

**Audit findings outside this PR's theme** → filed as #122–#127 (read-path bugs, modal plumbing robustness, recurring split edges, event-write divergences, calendar CRUD gaps, permission status edge cases).

## Deliberate calls (pushed back on review findings)

- **iOS ≤16 + autoPermissions + modal**: auto mode no longer prompts for the modal anywhere. On iOS ≤16 that means a notDetermined app gets `permissionDenied` instead of a prompt. Restoring it would mean spurious prompts on iOS 17+/Android (the whole point of #121) or OS-version sniffing in Dart — not worth it for a shrinking tail. It's documented on the method.
- **`openAppSettings` no-Activity error** changed `unknownError` → `operationFailed` to match `requestPermissions` for the identical state — technically observable, deliberately so.
- No CHANGELOG here — that happens at release time.

## Testing

- 202 Dart unit tests green, analyzer clean, Kotlin compiles, Swift parses
- Integration suites on Android emulator + iOS simulator: running now, results to follow in a comment (no physical devices attached at time of writing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)